### PR TITLE
chore(knative): Update deps in knative-serving-istio charts

### DIFF
--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: knative-serving-istio
 description: Installs Knative-serving for Istio
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "v1.0.0"
 maintainers:
   - name: caraml-dev

--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -9,14 +9,12 @@ maintainers:
     email: caraml-dev@caraml.dev
 dependencies:
   - name: knative-serving-core
-    # TODO: Replace with caraml-dev url once chart is released
-    repository: "file://../knative-serving-core"
+    repository: "https://caraml-dev.github.io/helm-charts"
     version: 1.1.0
     alias: knativeServingCore
     condition: knativeServingCore.enabled
   - name: generic-dep-installer
-    # TODO: Replace with caraml-dev url once chart is released
-    repository: "file://../helm-dep-installer"
+    repository: "https://caraml-dev.github.io/helm-charts"
     version: 0.1.0
     alias: istiod
     condition: istiod.enabled
@@ -26,14 +24,12 @@ dependencies:
     alias: base
     condition: base.enabled
   - name: generic-dep-installer
-    # TODO: Replace with caraml-dev url once chart is released
-    repository: "file://../helm-dep-installer"
+    repository: "https://caraml-dev.github.io/helm-charts"
     version: 0.1.0
     alias: istioIngressGateway
     condition: istioIngressGateway.global.enabled
   - name: generic-dep-installer
-    # TODO: Replace with caraml-dev url once chart is released
-    repository: "file://../helm-dep-installer"
+    repository: "https://caraml-dev.github.io/helm-charts"
     version: 0.1.0
     alias: clusterLocalGateway
     condition: clusterLocalGateway.global.enabled

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
 ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Installs Knative-serving for Istio


### PR DESCRIPTION
# Motivation
* Helm chart currently not installable when repository is not cloned, this PR fixes this issue.

# Modification
* Point dependencies to repo url instead file uri

# Checklist
- [x] Chart version bumped
- [x] README.md updated
