### PR TITLE
chore(kserve): Modify kserve to use release cert-manager-base

### DIFF
--- a/charts/kserve/Chart.yaml
+++ b/charts/kserve/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kserve
 description: A Helm chart for installing Kserve
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: 0.8.0
 maintainers:
   - name: caraml-dev

--- a/charts/kserve/Chart.yaml
+++ b/charts/kserve/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     condition: knativeServingIstio.enabled
   - name: cert-manager-base
     version: 1.8.1
-    repository: "file://../cert-manager-base"
+    repository: "https://caraml-dev.github.io/helm-charts"
     alias: certManagerBase
     condition: certManagerBase.enabled
   - name: cert-manager

--- a/charts/kserve/README.md
+++ b/charts/kserve/README.md
@@ -1,7 +1,7 @@
 # kserve
 
 ---
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square)
+![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square)
 ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for installing Kserve


### PR DESCRIPTION
# Motivation
This PR modifies kserve deps to reference the released version of cert-manager-base Helm chart instead of the file path to the helm chart.

# Modification

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
