### PR TITLE
fix(knative-serving-istio): Fix istioIngressGateway dep for knative-serving-istio

### DIFF
--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: knative-serving-istio
 description: Installs Knative-serving for Istio
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "v1.0.0"
 maintainers:
   - name: caraml-dev

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square)
 ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Installs Knative-serving for Istio
@@ -101,11 +101,11 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | istioIngressGateway.chartValues.autoscaling.enabled | bool | `false` |  |
 | istioIngressGateway.chartValues.env.ISTIO_METAJSON_STATS | string | `"{\\\"sidecar.istio.io/statsInclusionSuffixes\\\": \\\"upstream_rq_1xx,upstream_rq_2xx,upstream_rq_3xx,upstream_rq_4xx,upstream_rq_5xx,upstream_rq_time,upstream_cx_tx_bytes_total,upstream_cx_rx_bytes_total,upstream_cx_total,downstream_rq_1xx,downstream_rq_2xx,downstream_rq_3xx,downstream_rq_4xx,downstream_rq_5xx,downstream_rq_time,downstream_cx_tx_bytes_total,downstream_cx_rx_bytes_total,downstream_cx_total\\\"}\n"` |  |
 | istioIngressGateway.chartValues.env.ISTIO_META_ROUTER_MODE | string | `"standard"` |  |
-| istioIngressGateway.chartValues.global.enabled | bool | `true` | Controls deployment of istio-ingressgateway. Set to false if there is an existing istio deployment |
 | istioIngressGateway.chartValues.name | string | `"istio-ingressgateway"` | Specify name here so each gateway installation has its own unique name |
 | istioIngressGateway.chartValues.resources | object | `{}` |  |
 | istioIngressGateway.chartValues.serviceAccount.create | bool | `true` |  |
 | istioIngressGateway.chartValues.serviceAccount.name | string | `"istio-ingressgateway"` |  |
+| istioIngressGateway.global.enabled | bool | `true` | Controls deployment of istio-ingressgateway. Set to false if there is an existing istio deployment |
 | istioIngressGateway.helmChart.chart | string | `"gateway"` |  |
 | istioIngressGateway.helmChart.createNamespace | bool | `false` |  |
 | istioIngressGateway.helmChart.namespace | string | `"istio-system"` |  |

--- a/charts/knative-serving-istio/values.yaml
+++ b/charts/knative-serving-istio/values.yaml
@@ -406,6 +406,9 @@ istiod:
 # istioIngressGateway - installed using helm-dep-installer chart
 ############################################################
 istioIngressGateway:
+  global:
+    # -- Controls deployment of istio-ingressgateway. Set to false if there is an existing istio deployment
+    enabled: true
   helmChart:
     repository: "https://istio-release.storage.googleapis.com/charts"
     chart: gateway
@@ -416,9 +419,6 @@ istioIngressGateway:
   hook:
     weight: 1
   chartValues:
-    global:
-      # -- Controls deployment of istio-ingressgateway. Set to false if there is an existing istio deployment
-      enabled: true
     # -- Specify name here so each gateway installation has its own unique name
     name: istio-ingressgateway
     autoscaling:

--- a/charts/kserve/Chart.yaml
+++ b/charts/kserve/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kserve
 description: A Helm chart for installing Kserve
 type: application
-version: 0.8.3
+version: 0.8.4
 appVersion: 0.8.0
 maintainers:
   - name: caraml-dev

--- a/charts/kserve/README.md
+++ b/charts/kserve/README.md
@@ -256,7 +256,7 @@ The following table lists the configurable parameters of the Kserve chart and th
 | knativeServingIstio.helmChart.namespace | string | `"knative-serving"` |  |
 | knativeServingIstio.helmChart.release | string | `"knative-serving"` |  |
 | knativeServingIstio.helmChart.repository | string | `"https://caraml-dev.github.io/helm-charts"` |  |
-| knativeServingIstio.helmChart.version | string | `"1.0.2"` |  |
+| knativeServingIstio.helmChart.version | string | `"1.0.3"` |  |
 | labels | object | `{"common":{}}` | For release specific common labels |
 | logger.defaultUrl | string | `"http://default-broker"` |  |
 | logger.image.registry | string | `""` |  |

--- a/charts/kserve/README.md
+++ b/charts/kserve/README.md
@@ -1,7 +1,7 @@
 # kserve
 
 ---
-![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square)
+![Version: 0.8.4](https://img.shields.io/badge/Version-0.8.4-informational?style=flat-square)
 ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for installing Kserve

--- a/charts/kserve/values.yaml
+++ b/charts/kserve/values.yaml
@@ -435,7 +435,7 @@ knativeServingIstio:
   enabled: true
   helmChart:
     chart: knative-serving-istio
-    version: 1.0.2
+    version: 1.0.3
     repository: "https://caraml-dev.github.io/helm-charts"
     release: knative-serving
     namespace: knative-serving


### PR DESCRIPTION
# Motivation
This PR enables the istioIngressGateway dependency that was previously disabled due to wrong field set in values.yaml

# Modification

# Checklist
- [x] Chart version bumped
- [x] README.md updated
