### PR TITLE
ci: update owners for caraml-store chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # Default owners for repo
 * @caraml-dev/platform
+
+charts/caraml-store @caraml-dev/feast-dev


### PR DESCRIPTION
# Motivation
The feast dev team must be involved into the caraml-store chart reviews
