### PR TITLE
fix(caraml-store): Fix template mistakes

### DIFF
--- a/charts/caraml-store/Chart.yaml
+++ b/charts/caraml-store/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: "CaraML store registry: Feature registry for CaraML store."
 name: caraml-store
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.3
 home: https://github.com/caraml-dev/caraml-store
 keywords:

--- a/charts/caraml-store/README.md
+++ b/charts/caraml-store/README.md
@@ -1,6 +1,6 @@
 # caraml-store
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
 
 CaraML store registry: Feature registry for CaraML store.
 

--- a/charts/caraml-store/templates/registry/configmap.yaml
+++ b/charts/caraml-store/templates/registry/configmap.yaml
@@ -19,9 +19,10 @@ data:
       port: {{ .Values.registry.actuator.port }}
     kubernetes:
       inCluster: true
-    jobService:
-      common:
-        sparkImage: "ghcr.io/caraml-dev/caraml-store-spark:{{ .Values.registry.image.tag | default .Chart.AppVersion }}"
+    caraml:
+      jobService:
+        common:
+          sparkImage: "ghcr.io/caraml-dev/caraml-store-spark:{{ .Values.registry.image.tag | default .Chart.AppVersion }}"
 {{- end }}
 
 {{- if index .Values.registry "application-override.yaml" "enabled" }}

--- a/charts/caraml-store/templates/registry/secret.yaml
+++ b/charts/caraml-store/templates/registry/secret.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ template "caraml-store.registry.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    component: registry
 {{ include "caraml-store.registry.labels" . | indent 4 }}
 type: Opaque
 stringData:

--- a/charts/caraml-store/templates/registry/servicemonitor.yaml
+++ b/charts/caraml-store/templates/registry/servicemonitor.yaml
@@ -7,7 +7,8 @@ metadata:
 {{ include "caraml-store.registry.labels" . | indent 4 }}
 spec:
   selector:
-{{- include "caraml-store.registry.selectorLabels" . | nindent 4 }}
+    matchLabels:
+{{- include "caraml-store.registry.selectorLabels" . | nindent 6 }}
   endpoints:
     - path: /actuator/prometheus
     - targetPort: {{ .Values.registry.actuator.port }}

--- a/charts/caraml-store/templates/serving/deployment.yaml
+++ b/charts/caraml-store/templates/serving/deployment.yaml
@@ -77,16 +77,16 @@ spec:
             - "@/app/jib-classpath-file"
             - dev.caraml.serving.CaraMLServing
             - --spring.config.location=
-          {{- if index .Values.registry "application.yaml" "enabled" -}}
+          {{- if index .Values.serving "application.yaml" "enabled" -}}
               classpath:/application.yaml
           {{- end }}
-          {{- if index .Values.registry "application-generated.yaml" "enabled" -}}
+          {{- if index .Values.serving "application-generated.yaml" "enabled" -}}
               ,file:/etc/caraml-store/application-generated.yaml
           {{- end }}
-          {{- if index .Values.registry "application-secret.yaml" "enabled" -}}
+          {{- if index .Values.serving "application-secret.yaml" "enabled" -}}
               ,file:/etc/secrets/caraml-store/application-secret.yaml
           {{- end }}
-          {{- if index .Values.registry "application-override.yaml" "enabled" -}}
+          {{- if index .Values.serving "application-override.yaml" "enabled" -}}
               ,file:/etc/caraml-store/application-override.yaml
           {{- end }}
 

--- a/charts/caraml-store/templates/serving/secret.yaml
+++ b/charts/caraml-store/templates/serving/secret.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ template "caraml-store.serving.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    component: serving
 {{ include "caraml-store.serving.labels" . | indent 4 }}
 type: Opaque
 stringData:

--- a/charts/caraml-store/templates/serving/secret.yaml
+++ b/charts/caraml-store/templates/serving/secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "caraml-store.serving.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    component: registry
+    component: serving
 {{ include "caraml-store.serving.labels" . | indent 4 }}
 type: Opaque
 stringData:

--- a/charts/caraml-store/templates/serving/servicemonitor.yaml
+++ b/charts/caraml-store/templates/serving/servicemonitor.yaml
@@ -7,7 +7,8 @@ metadata:
 {{ include "caraml-store.serving.labels" . | indent 4 }}
 spec:
   selector:
-{{- include "caraml-store.serving.selectorLabels" . | nindent 4 }}
+    matchLabels:
+{{- include "caraml-store.registry.selectorLabels" . | nindent 6 }}
   endpoints:
     - path: /actuator/prometheus
     - targetPort: {{ .Values.serving.actuator.port }}


### PR DESCRIPTION
# Motivation
The deployment commands and secret for the serving component is currently wrongly configured to use the values for registry rather than serving.

# Modification

# Checklist
- [ x] Chart version bumped
- [ x] README.md updated
