### PR TITLE
fix(gdi): Uninstall step in generic-dep-installer to use helm command.

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -40,11 +40,12 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add caraml https://caraml-dev.github.io/helm-charts/
-          helm repo add istio https://istio-release.storage.googleapis.com/charts
-          helm repo add stable https://charts.helm.sh/stable
-          helm repo add cert-manager https://charts.jetstack.io
-          helm repo add hashicorp https://helm.releases.hashicorp.com
+          for dir in $(ls -d charts/*/); do
+            num_of_deps=$(( $(helm dependency list $dir 2> /dev/null | tail +2 | wc -l ) -1 ))
+            if [ $num_of_deps -gt 0 ]; then
+              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | xargs -n 2 helm repo add
+            fi
+          done
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/config/ct.yaml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -43,7 +43,7 @@ jobs:
           for dir in $(ls -d charts/*/); do
             num_of_deps=$(( $(helm dependency list $dir 2> /dev/null | tail +2 | wc -l ) -1 ))
             if [ $num_of_deps -gt 0 ]; then
-              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | xargs -n 2 helm repo add
+              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | xargs -n 2 helm repo add --force-update
             fi
           done
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,11 +30,13 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add caraml https://caraml-dev.github.io/helm-charts/
-          helm repo add istio https://istio-release.storage.googleapis.com/charts
-          helm repo add stable https://charts.helm.sh/stable
-          helm repo add hashicorp https://helm.releases.hashicorp.com
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          for dir in $(ls -d charts/*/); do
+            num_of_deps=$(( $(helm dependency list $dir 2> /dev/null | tail +2 | wc -l ) -1 ))
+            if [ $num_of_deps -gt 0 ]; then
+              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | xargs -n 2 helm repo add
+            fi
+          done
+
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0

--- a/charts/helm-dep-installer/Chart.yaml
+++ b/charts/helm-dep-installer/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Container image used by job requires helm and kubectl binary to be present, and thus should be set accordingly based on the version of K8s being used.
   See https://helm.sh/docs/topics/version_skew/ for more info on which helm version to use.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.1.0"
 maintainers:
   - name: caraml-dev

--- a/charts/helm-dep-installer/README.md
+++ b/charts/helm-dep-installer/README.md
@@ -1,6 +1,6 @@
 # generic-dep-installer
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This helm chart is used to control the order of installation of helm chart dependencies through the use of pre-install hooks and hook weights.
 It creates a K8s Job that performs that applies a rendered helm chart to a cluster, while exposing the `.Values.hook.weight` to users to configure which dependency should be installed first.

--- a/charts/helm-dep-installer/files/run.sh
+++ b/charts/helm-dep-installer/files/run.sh
@@ -51,8 +51,9 @@ main() {
     # kubectl apply -f /tmp/manifests.yaml
     # kubectl wait pods --all -n $NAMESPACE --for=condition=Ready --timeout=180s
   elif [[ $ACTION == "delete" ]]; then
-    kubectl delete -f /tmp/manifests.yaml --ignore-not-found
-    kubectl wait -f /tmp/manifests.yaml --for=delete --timeout=180s
+    helm uninstall $RELEASE_NAME --namespace $NAMESPACE --debug --wait --timeout=180s
+    # kubectl delete -f /tmp/manifests.yaml --ignore-not-found
+    # kubectl wait -f /tmp/manifests.yaml --for=delete --timeout=180s
     kubectl delete ns $NAMESPACE --ignore-not-found
   fi
 }


### PR DESCRIPTION
# Motivation
Uninstaller via generic-dep-installer chart was using kubectl command instead of the helm command. Hence the sub-dependencies are not being uninstalled. 

# Modification
* Use `helm uninstall` in GDI uninstall step.
* Dynamically add helm repo in GitHub pipelines. 


# Checklist
- [x] Chart version bumped
- [x] README.md updated
