### PR TITLE
ci: fix release pipeline, add missing arg in workflow step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,10 +33,9 @@ jobs:
           for dir in $(ls -d charts/*/); do
             num_of_deps=$(( $(helm dependency list $dir 2> /dev/null | tail +2 | wc -l ) -1 ))
             if [ $num_of_deps -gt 0 ]; then
-              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | xargs -n 2 helm repo add
+              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | xargs -n 2 helm repo add --force-update
             fi
           done
-
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0


### PR DESCRIPTION
# Motivation
Release pipeline is broken because of a missing flag

# Modification
* add missing flag in the `Add dependency charts` step. 

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
