### PR TITLE
ci: fix release pipeline, exclude file based repo URLs in Add dependancy step

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -43,7 +43,7 @@ jobs:
           for dir in $(ls -d charts/*/); do
             num_of_deps=$(( $(helm dependency list $dir 2> /dev/null | tail +2 | wc -l ) -1 ))
             if [ $num_of_deps -gt 0 ]; then
-              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | xargs -n 2 helm repo add --force-update
+              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | grep -v "file://" | xargs -n 2 helm repo add --force-update
             fi
           done
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,10 +37,10 @@ jobs:
             fi
           done
 
-      # - name: Run chart-releaser
-      #   uses: helm/chart-releaser-action@v1.4.0
-      #   with:
-      #     charts_dir: charts
-      #     config: .github/config/cr.yaml
-      #   env:
-      #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        with:
+          charts_dir: charts
+          config: .github/config/cr.yaml
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,14 +33,14 @@ jobs:
           for dir in $(ls -d charts/*/); do
             num_of_deps=$(( $(helm dependency list $dir 2> /dev/null | tail +2 | wc -l ) -1 ))
             if [ $num_of_deps -gt 0 ]; then
-              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | xargs -n 2 helm repo add --force-update
+              helm dependency list $dir 2> /dev/null | tail +2 | head -n $num_of_deps | awk '{ print " " $1 " " $3 }' | grep -v "file://" | xargs -n 2 helm repo add --force-update
             fi
           done
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
-        with:
-          charts_dir: charts
-          config: .github/config/cr.yaml
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      # - name: Run chart-releaser
+      #   uses: helm/chart-releaser-action@v1.4.0
+      #   with:
+      #     charts_dir: charts
+      #     config: .github/config/cr.yaml
+      #   env:
+      #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Motivation
Release workflow failing because of the `file://` protocol in repo URLs.

# Modification

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
