### PR TITLE
chore(merlin): Update chart version for gen-dep-installer and kserve

### DIFF
--- a/charts/merlin/Chart.lock
+++ b/charts/merlin/Chart.lock
@@ -7,15 +7,15 @@ dependencies:
   version: 7.0.0
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.0
+  version: 0.1.1
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.0
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.0
+  version: 0.1.1
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.0
-digest: sha256:a5f7470fc091eee40c160d9a75a14a133a44ac8a680f98795432bff4cd701b37
-generated: "2022-10-17T11:43:31.360634+05:30"
+  version: 0.1.1
+digest: sha256:a77844658c3f62fdb544ac62b4965e6bf1a2c02add3f91a57aecc9aab231ccf5
+generated: "2022-10-19T11:38:16.411365+05:30"

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes-friendly ML model management, deployment, and serving.
 name: merlin
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.22.0
 
 maintainers:
@@ -20,7 +20,7 @@ dependencies:
     alias: mlflow-postgresql
     condition: mlflow-postgresql.enabled
   - name: generic-dep-installer
-    version: 0.1.0
+    version: 0.1.1
     repository: "https://caraml-dev.github.io/helm-charts"
     alias: vault
     condition: vault.enabled
@@ -29,12 +29,12 @@ dependencies:
     version: 0.2.0
     condition: mlp.enabled
   - name: generic-dep-installer
-    version: 0.1.0
+    version: 0.1.1
     repository: "https://caraml-dev.github.io/helm-charts"
     alias: kserve
     condition: kserve.enabled
   - name: generic-dep-installer
-    version: 0.1.0
+    version: 0.1.1
     repository: "https://caraml-dev.github.io/helm-charts"
     alias: minio
     condition: minio.enabled

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,6 +1,6 @@
 # merlin
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: 0.22.0](https://img.shields.io/badge/AppVersion-0.22.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![AppVersion: 0.22.0](https://img.shields.io/badge/AppVersion-0.22.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -14,9 +14,9 @@ Kubernetes-friendly ML model management, deployment, and serving.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://caraml-dev.github.io/helm-charts | vault(generic-dep-installer) | 0.1.0 |
-| https://caraml-dev.github.io/helm-charts | kserve(generic-dep-installer) | 0.1.0 |
-| https://caraml-dev.github.io/helm-charts | minio(generic-dep-installer) | 0.1.0 |
+| https://caraml-dev.github.io/helm-charts | vault(generic-dep-installer) | 0.1.1 |
+| https://caraml-dev.github.io/helm-charts | kserve(generic-dep-installer) | 0.1.1 |
+| https://caraml-dev.github.io/helm-charts | minio(generic-dep-installer) | 0.1.1 |
 | https://caraml-dev.github.io/helm-charts | mlp | 0.2.0 |
 | https://charts.helm.sh/stable | merlin-postgresql(postgresql) | 7.0.0 |
 | https://charts.helm.sh/stable | mlflow-postgresql(postgresql) | 7.0.0 |
@@ -97,7 +97,7 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | kserve.helmChart.namespace | string | `"kserve"` |  |
 | kserve.helmChart.release | string | `"kserve"` |  |
 | kserve.helmChart.repository | string | `"https://caraml-dev.github.io/helm-charts"` |  |
-| kserve.helmChart.version | string | `"0.8.2"` |  |
+| kserve.helmChart.version | string | `"0.8.5"` |  |
 | kserve.hook.weight | string | `"-2"` |  |
 | loggerDestinationURL | string | `"http://yourDestinationLogger"` |  |
 | merlin-postgresql.enabled | bool | `true` |  |

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -492,7 +492,7 @@ kserve:
   helmChart:
     chart: kserve
     repository: "https://caraml-dev.github.io/helm-charts"
-    version: 0.8.2
+    version: 0.8.5
     release: kserve
     namespace: kserve
     createNamespace: true


### PR DESCRIPTION
# Motivation
Update chart version for gen-dep-installer and kserve to get latest generic-dep-installer changes.

# Modification
Update chart version for gen-dep-installer and kserve to get latest generic-dep-installer changes.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
