### PR TITLE
Patch common chart

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,10 +15,10 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.0"
+appVersion: "0.2.1"

--- a/charts/common/templates/_helper.tpl
+++ b/charts/common/templates/_helper.tpl
@@ -36,7 +36,7 @@ Takes 3 arguments:
 Pass in is global map object
 */}}
 {{- define "common.get-oauth-client" }}
-{{- $store := index . 0 }}
+{{- $store := . }}
 {{- if ne $store.oauthclient "" }}
 {{- printf "%s" $store.oauthclient }}
 {{- else }}

--- a/charts/common/templates/_helper.tpl
+++ b/charts/common/templates/_helper.tpl
@@ -33,15 +33,13 @@ Takes 3 arguments:
 {{- end }}
 
 {{/*
-1st arg is global map object, 2nd arg is value in values.yaml
+Pass in is global map object
 */}}
 {{- define "common.get-oauth-client" }}
 {{- $store := index . 0 }}
-{{- $val := index . 1 }}
-{{- if $store }}
-{{- $temp := printf "%s" $store.oauthclient }}
-{{- include "common.set-value" (list $temp $val)}}
+{{- if ne $store.oauthclient "" }}
+{{- printf "%s" $store.oauthclient }}
 {{- else }}
-{{- printf "%s" $val}}
+{{- printf "" }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# Motivation
Patch common chart to return value from globals on for `common.get-oauth-client` template, let user decide which value to prefer ( from `.Values.global` obj or `values.yaml`)

# Modification

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
