### PR TITLE
chore(knative-serving): upgrade gdi chart version to 0.2.0

### DIFF
--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: knative-serving-istio
 description: Installs Knative-serving for Istio
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "v1.0.0"
 maintainers:
   - name: caraml-dev
@@ -15,7 +15,7 @@ dependencies:
     condition: knativeServingCore.enabled
   - name: generic-dep-installer
     repository: "https://caraml-dev.github.io/helm-charts"
-    version: 0.1.1
+    version: 0.2.0
     alias: istiod
     condition: istiod.enabled
   - name: base
@@ -25,11 +25,11 @@ dependencies:
     condition: base.enabled
   - name: generic-dep-installer
     repository: "https://caraml-dev.github.io/helm-charts"
-    version: 0.1.1
+    version: 0.2.0
     alias: istioIngressGateway
     condition: istioIngressGateway.global.enabled
   - name: generic-dep-installer
     repository: "https://caraml-dev.github.io/helm-charts"
-    version: 0.1.1
+    version: 0.2.0
     alias: clusterLocalGateway
     condition: clusterLocalGateway.global.enabled

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square)
 ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Installs Knative-serving for Istio


### PR DESCRIPTION
# Motivation
New chart version in GDI chart fixing uninstall-related bugs.

# Modification
upgrade GDI chart version to 0.2.0

# Checklist
- [x] Chart version bumped
- [x] README.md updated
