### PR TITLE
chore(kserve): upgrade gdi chart version to 0.2.0

### DIFF
--- a/charts/kserve/Chart.yaml
+++ b/charts/kserve/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: kserve
 description: A Helm chart for installing Kserve
 type: application
-version: 0.8.5
+version: 0.8.6
 appVersion: 0.8.0
 maintainers:
   - name: caraml-dev
     email: caraml-dev@caraml.dev
 dependencies:
   - name: generic-dep-installer
-    version: 0.1.1
+    version: 0.2.0
     repository: "https://caraml-dev.github.io/helm-charts"
     alias: knativeServingIstio
     condition: knativeServingIstio.enabled

--- a/charts/kserve/README.md
+++ b/charts/kserve/README.md
@@ -1,7 +1,7 @@
 # kserve
 
 ---
-![Version: 0.8.5](https://img.shields.io/badge/Version-0.8.5-informational?style=flat-square)
+![Version: 0.8.6](https://img.shields.io/badge/Version-0.8.6-informational?style=flat-square)
 ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for installing Kserve
@@ -256,7 +256,7 @@ The following table lists the configurable parameters of the Kserve chart and th
 | knativeServingIstio.helmChart.namespace | string | `"knative-serving"` |  |
 | knativeServingIstio.helmChart.release | string | `"knative-serving"` |  |
 | knativeServingIstio.helmChart.repository | string | `"https://caraml-dev.github.io/helm-charts"` |  |
-| knativeServingIstio.helmChart.version | string | `"1.0.4"` |  |
+| knativeServingIstio.helmChart.version | string | `"1.0.5"` |  |
 | labels | object | `{"common":{}}` | For release specific common labels |
 | logger.defaultUrl | string | `"http://default-broker"` |  |
 | logger.image.registry | string | `""` |  |

--- a/charts/kserve/values.yaml
+++ b/charts/kserve/values.yaml
@@ -435,7 +435,7 @@ knativeServingIstio:
   enabled: true
   helmChart:
     chart: knative-serving-istio
-    version: 1.0.4
+    version: 1.0.5
     repository: "https://caraml-dev.github.io/helm-charts"
     release: knative-serving
     namespace: knative-serving


### PR DESCRIPTION
# Motivation
New chart version in GDI chart fixing uninstall-related bugs.

# Modification
upgrade GDI chart version to 0.2.0

# Checklist
- [x] Chart version bumped
- [x] README.md updated
