### PR TITLE
fix(merlin): Bump merlin to use gdi 0.2.1, kserve 0.8.8

### DIFF
--- a/charts/merlin/Chart.lock
+++ b/charts/merlin/Chart.lock
@@ -7,15 +7,15 @@ dependencies:
   version: 7.0.0
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.1
+  version: 0.2.1
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.0
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.1
+  version: 0.2.1
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.1
-digest: sha256:a77844658c3f62fdb544ac62b4965e6bf1a2c02add3f91a57aecc9aab231ccf5
-generated: "2022-10-19T11:38:16.411365+05:30"
+  version: 0.2.1
+digest: sha256:72eaa2d0884dafe9aae0a74f9196e188bb3ca722470af8be920d346406e6333d
+generated: "2022-10-21T13:55:17.159413+05:30"

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes-friendly ML model management, deployment, and serving.
 name: merlin
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.24.0
 
 maintainers:
@@ -20,7 +20,7 @@ dependencies:
     alias: mlflow-postgresql
     condition: mlflow-postgresql.enabled
   - name: generic-dep-installer
-    version: 0.1.1
+    version: 0.2.1
     repository: "https://caraml-dev.github.io/helm-charts"
     alias: vault
     condition: vault.enabled
@@ -29,12 +29,12 @@ dependencies:
     version: 0.2.0
     condition: mlp.enabled
   - name: generic-dep-installer
-    version: 0.1.1
+    version: 0.2.1
     repository: "https://caraml-dev.github.io/helm-charts"
     alias: kserve
     condition: kserve.enabled
   - name: generic-dep-installer
-    version: 0.1.1
+    version: 0.2.1
     repository: "https://caraml-dev.github.io/helm-charts"
     alias: minio
     condition: minio.enabled

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,6 +1,6 @@
 # merlin
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -14,9 +14,9 @@ Kubernetes-friendly ML model management, deployment, and serving.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://caraml-dev.github.io/helm-charts | vault(generic-dep-installer) | 0.1.1 |
-| https://caraml-dev.github.io/helm-charts | kserve(generic-dep-installer) | 0.1.1 |
-| https://caraml-dev.github.io/helm-charts | minio(generic-dep-installer) | 0.1.1 |
+| https://caraml-dev.github.io/helm-charts | vault(generic-dep-installer) | 0.2.1 |
+| https://caraml-dev.github.io/helm-charts | kserve(generic-dep-installer) | 0.2.1 |
+| https://caraml-dev.github.io/helm-charts | minio(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | mlp | 0.2.0 |
 | https://charts.helm.sh/stable | merlin-postgresql(postgresql) | 7.0.0 |
 | https://charts.helm.sh/stable | mlflow-postgresql(postgresql) | 7.0.0 |
@@ -99,7 +99,7 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | kserve.helmChart.namespace | string | `"kserve"` |  |
 | kserve.helmChart.release | string | `"kserve"` |  |
 | kserve.helmChart.repository | string | `"https://caraml-dev.github.io/helm-charts"` |  |
-| kserve.helmChart.version | string | `"0.8.5"` |  |
+| kserve.helmChart.version | string | `"0.8.8"` |  |
 | kserve.hook.weight | string | `"-2"` |  |
 | loggerDestinationURL | string | `"http://yourDestinationLogger"` |  |
 | merlin-postgresql.enabled | bool | `true` |  |

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -173,7 +173,7 @@ MLflow Postgres related
     {{- else if .Values.mlflowExternalPostgresql.enabled -}}
         {{- .Values.mlflowExternalPostgresql.database -}}
     {{- else -}}
-        {{- .Values.global.merlin.postgresqlDatabase -}}
+        {{- .Values.global.merlin.mlflow.postgresqlDatabase -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -498,7 +498,7 @@ kserve:
   helmChart:
     chart: kserve
     repository: "https://caraml-dev.github.io/helm-charts"
-    version: 0.8.5
+    version: 0.8.8
     release: kserve
     namespace: kserve
     createNamespace: true


### PR DESCRIPTION
# Motivation
Should be merged after #43 is merged

# Modification

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
