### PR TITLE
fix(merlin): Update merlin chart to use new common chart

### DIFF
--- a/charts/merlin/Chart.lock
+++ b/charts/merlin/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.1
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.0
+  version: 0.2.2
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
@@ -19,6 +19,6 @@ dependencies:
   version: 0.2.1
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.1
-digest: sha256:c954b8e5db44986bcfd8f594e401199b0627f59e255ebc9e0e23b56c3780ab5b
-generated: "2022-10-21T17:43:04.50436+08:00"
+  version: 0.2.2
+digest: sha256:cc7dd4d23fa9dd6e693e51274b5a813b1eb613ceb38c43e51a9ed6e21be538cb
+generated: "2022-11-01T11:59:49.55486+08:00"

--- a/charts/merlin/Chart.lock
+++ b/charts/merlin/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.1
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.2
+  version: 0.3.1
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
@@ -19,6 +19,6 @@ dependencies:
   version: 0.2.1
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.2
-digest: sha256:cc7dd4d23fa9dd6e693e51274b5a813b1eb613ceb38c43e51a9ed6e21be538cb
-generated: "2022-11-01T11:59:49.55486+08:00"
+  version: 0.2.4
+digest: sha256:5e127604ae5c29fe998f05c66aaef72d4b8b01100a16fc192e55543d4f408da4
+generated: "2022-11-03T15:29:29.867027+08:00"

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes-friendly ML model management, deployment, and serving.
 name: merlin
-version: 0.9.3
+version: 0.9.4
 appVersion: 0.24.0
 
 maintainers:
@@ -26,7 +26,7 @@ dependencies:
     condition: vault.enabled
   - name: mlp
     repository: "https://caraml-dev.github.io/helm-charts"
-    version: 0.2.0
+    version: 0.2.2
     condition: mlp.enabled
   - name: generic-dep-installer
     version: 0.2.1
@@ -39,5 +39,5 @@ dependencies:
     alias: minio
     condition: minio.enabled
   - name: common
-    version: 0.2.1
+    version: 0.2.2
     repository: "https://caraml-dev.github.io/helm-charts"

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     condition: vault.enabled
   - name: mlp
     repository: "https://caraml-dev.github.io/helm-charts"
-    version: 0.2.2
+    version: ~0.2.3
     condition: mlp.enabled
   - name: generic-dep-installer
     version: 0.2.1

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     condition: vault.enabled
   - name: mlp
     repository: "https://caraml-dev.github.io/helm-charts"
-    version: ~0.2.3
+    version: 0.3.1
     condition: mlp.enabled
   - name: generic-dep-installer
     version: 0.2.1
@@ -39,5 +39,5 @@ dependencies:
     alias: minio
     condition: minio.enabled
   - name: common
-    version: 0.2.2
+    version: 0.2.4
     repository: "https://caraml-dev.github.io/helm-charts"

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -18,7 +18,7 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | https://caraml-dev.github.io/helm-charts | vault(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | kserve(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | minio(generic-dep-installer) | 0.2.1 |
-| https://caraml-dev.github.io/helm-charts | mlp | 0.2.2 |
+| https://caraml-dev.github.io/helm-charts | mlp | ~0.2.3 |
 | https://charts.helm.sh/stable | mlflow-postgresql(postgresql) | 7.0.0 |
 | https://charts.helm.sh/stable | merlin-postgresql(postgresql) | 7.0.0 |
 

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,6 +1,6 @@
 # merlin
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -14,11 +14,11 @@ Kubernetes-friendly ML model management, deployment, and serving.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://caraml-dev.github.io/helm-charts | common | 0.2.1 |
+| https://caraml-dev.github.io/helm-charts | common | 0.2.2 |
 | https://caraml-dev.github.io/helm-charts | vault(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | kserve(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | minio(generic-dep-installer) | 0.2.1 |
-| https://caraml-dev.github.io/helm-charts | mlp | 0.2.0 |
+| https://caraml-dev.github.io/helm-charts | mlp | 0.2.2 |
 | https://charts.helm.sh/stable | mlflow-postgresql(postgresql) | 7.0.0 |
 | https://charts.helm.sh/stable | merlin-postgresql(postgresql) | 7.0.0 |
 

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -14,11 +14,11 @@ Kubernetes-friendly ML model management, deployment, and serving.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://caraml-dev.github.io/helm-charts | common | 0.2.2 |
+| https://caraml-dev.github.io/helm-charts | common | 0.2.4 |
 | https://caraml-dev.github.io/helm-charts | vault(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | kserve(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | minio(generic-dep-installer) | 0.2.1 |
-| https://caraml-dev.github.io/helm-charts | mlp | ~0.2.3 |
+| https://caraml-dev.github.io/helm-charts | mlp | 0.3.1 |
 | https://charts.helm.sh/stable | mlflow-postgresql(postgresql) | 7.0.0 |
 | https://charts.helm.sh/stable | merlin-postgresql(postgresql) | 7.0.0 |
 

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -226,3 +226,14 @@ MLflow Postgres related
   {{- printf "%s" $host }}
   {{- end }}
 {{- end }}
+
+
+{{- define "merlin.get-feast-api-host"}}
+{{- $protocol := (default "http" (get . "protocol")) }}
+{{- $hostname := include "common.get-external-hostname" . }}
+{{- if $hostname }}
+{{- printf "%s://%s" $protocol $hostname}}
+{{- else }}
+{{- printf ""}}
+{{- end }}
+{{- end }}

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -3,7 +3,7 @@
 {{- $globMlpApi := include "common.get-component-value" (list .Values.global "mlp" (list "vsPrefix" "apiPrefix"))}}
 {{- $globMlpApiHost := include "merlin.get-workload-host" (list .Values.global .Release.Namespace "mlp")}}
 {{- $globOauthClientID := include "common.get-oauth-client" .Values.global }}
-{{- $globFeastApiHost := (printf "%s://%s" (default "http" (get .Values.global "protocol")) (include "common.get-external-hostname" .Values.global)) }}
+{{- $globFeastApiHost := include "merlin.get-feast-api-host" .Values.global }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/merlin/values-global.yaml
+++ b/charts/merlin/values-global.yaml
@@ -1,6 +1,6 @@
 global:
   ingressIP: ""
-  oauthclient: "test-client-123"
+  oAuthClient: "test-client-123"
   # -- istioIngressIP takes precedence over domain. Used for local deployment
   istioLookUp:
     namespace: istio-system

--- a/charts/merlin/values-global.yaml
+++ b/charts/merlin/values-global.yaml
@@ -1,6 +1,6 @@
 global:
   ingressIP: ""
-  oAuthClient: "test-client-123"
+  oauthClientID: "global-client-123"
   # -- istioIngressIP takes precedence over domain. Used for local deployment
   istioLookUp:
     namespace: istio-system

--- a/charts/routes/Chart.yaml
+++ b/charts/routes/Chart.yaml
@@ -58,4 +58,4 @@ dependencies:
   - name: common
     repository: "https://caraml-dev.github.io/helm-charts"
     condition: common.enabled
-    version: 0.2.4
+    version: 0.2.1

--- a/charts/routes/Chart.yaml
+++ b/charts/routes/Chart.yaml
@@ -58,4 +58,4 @@ dependencies:
   - name: common
     repository: "https://caraml-dev.github.io/helm-charts"
     condition: common.enabled
-    version: 0.2.1
+    version: 0.2.4


### PR DESCRIPTION
# Motivation
It adds a namedtemplate to fix the `"http://%s!(nil).nip.io` error when rendering feast api host. Returns "" when global.feast is empty.

# Modification
* upgrade common chart to 0.2.4
* upgrade mlp chart to 0.3.1
* `global.oauthclient` change to `global.oauthClientID`

# Checklist
- [x] Chart version bumped
- [x] README.md updated
