### PR TITLE
ci: Add dependabot config to auto create PRs for GitHub actions version upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
# Motivation
Updating Github actions on a regular basis to get the latest versions manually is a repetitive task that can be automated by GitHub-provided dependabot. 

# Modification
Add dependabot config to GitHub config.

# Checklist
- [ ] Chart version bumped - NA
- [ ] README.md updated - NA
