### PR TITLE
ci: Add workflow to create Chart bump PR on every release

### DIFF
--- a/.github/workflows/chart-bumper.yaml
+++ b/.github/workflows/chart-bumper.yaml
@@ -1,0 +1,63 @@
+name: Upgrade helm charts minor versions
+
+on:
+  workflow_run:
+    workflows: ["Release Charts"]
+    types: [completed]
+
+jobs:
+  upgrade-helm-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: install pyaml
+        run: |
+          pip3 install pyaml==21.10.1
+
+      - name: install updateCli
+        run: |
+          curl -sL -o /tmp/updatecli_amd64.deb https://github.com/updatecli/updatecli/releases/download/v0.36.0/updatecli_amd64.deb
+          sudo apt install /tmp/updatecli_amd64.deb
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+        with:
+          version: v3.5.1
+
+      - name: Run chart bumper script & update docs
+        run: |
+          python scripts/chart_bumper.py
+          rm -f manifest.yaml
+          bash scripts/helm-docs.sh
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        if: steps.list-changed.outputs.changed == 'true'
+        with:
+          commit-message: "feat: upgrade helm charts"
+          title: "chore: upgrade helm charts minor versions"
+          body: |
+            Automatic upgrade of helm chart minor versions using https://github.com/updatecli/updatecli
+          branch: upgrade-helm-charts-minors
+          base: main

--- a/.github/workflows/chart-bumper.yaml
+++ b/.github/workflows/chart-bumper.yaml
@@ -41,6 +41,7 @@ jobs:
         run: |
           python scripts/chart_bumper.py
           rm -f manifest.yaml
+          rm -f manifest_gdi_dependant.yaml
           bash scripts/helm-docs.sh
 
       - name: Run chart-testing (list-changed)

--- a/scripts/chart_bumper.py
+++ b/scripts/chart_bumper.py
@@ -1,0 +1,138 @@
+
+"""
+Simple python script that is used in github actions to
+automatically bump chart dependencies using the updatecli CLI tool.
+"""
+
+from pathlib import Path
+import subprocess
+import yaml
+import os
+import traceback
+
+# Add charts here where it is known that higher versions are not
+# yet stable or that you would like to disable automatic upgrades for
+EXCLUDED_CHARTS = str(os.environ.get("EXCLUDED_CHARTS", "")).split(',')
+
+# Inject a BUMP_MAJOR env variable if you would like the script to automatically
+# bump major chart versions too. Make sure you inspect the upgrade instructions before merging!
+BUMP_MAJOR = os.environ.get("BUMP_MAJOR") == "true"
+# Inject a BUMP_MINOR env variable if you would like the script to automatically
+# bump minor chart versions too. Make sure you inspect the upgrade instructions before merging!
+BUMP_MINOR = os.environ.get("BUMP_MINOR") == "true"
+
+
+def update_gdi_dependency(chart_path : str, dependency: dict):
+    with open(chart_path + "/values.yaml") as f:
+        text = f.read()
+    chart_values: dict = yaml.safe_load(text)
+
+    # bump major or minor depending on set env variable
+    chart_version = chart_values[dependency["alias"]]["helmChart"]["version"]
+    version_major = f"{chart_version.split('.')[0]}" if not BUMP_MAJOR else "*"
+    version_minor = f"{chart_version.split('.')[1]}" if not BUMP_MAJOR else "*"
+    version = f"{version_major}.{version_minor}.*"
+    manifest = f"""
+sources:
+    lastMinorRelease:
+        kind: helmChart
+        spec:
+            url: "{chart_values[dependency["alias"]]["helmChart"]["repository"]}"
+            name: "{chart_values[dependency["alias"]]["helmChart"]["chart"]}"
+            version: "{version}"
+conditions: {{}}
+targets:
+    chart:
+        name: Bump Chart version
+        kind: helmChart
+        spec:
+            Name: "{chart_path}"
+            file: "Chart.yaml"
+            versionIncrement: "patch"
+    chartValues:
+        name: Bump Chart dependencies
+        kind: helmChart
+        spec:
+            Name: "{chart_path}"
+            file: "values.yaml"
+            key: "{chart_values[dependency["alias"]]}.helmChart.version"
+            versionIncrement: "patch"
+"""
+
+    with open("manifest_gdi_dependant.yaml", "w") as f:
+        f.write(manifest)
+    subprocess.check_output(
+            "updatecli apply --config manifest_gdi_dependant.yaml".split(" "))
+
+    os.remove("manifest_gdi_dependant.yaml")
+
+
+def update_chart(chart_path: str):
+    """
+    Given a path to a helm chart. Bump the version of the dependencies of this chart
+    if any newer versions exist.
+    """
+    print(f"Updating chart version for: {chart_path}")
+
+    with open(chart_path + "/Chart.yaml") as f:
+        text = f.read()
+
+    chart: dict = yaml.safe_load(text)
+
+    if not "dependencies" in chart:
+        return
+
+    for index, dependency in enumerate(chart["dependencies"]):
+
+        if dependency["name"] in EXCLUDED_CHARTS:
+            print(f"Skipping {dependency['name']} because it is excluded..")
+            continue
+
+        # bump major or minor depending on set env variable
+        version_major = f"{dependency['version'].split('.')[0]}" if not BUMP_MAJOR else "*"
+        version_minor = f"{dependency['version'].split('.')[1]}" if not BUMP_MAJOR else "*"
+        version = f"{version_major}.{version_minor}.*"
+        manifest = f"""
+sources:
+   lastMinorRelease:
+       kind: helmChart
+       spec:
+           url: "{dependency["repository"]}"
+           name: "{dependency["name"]}"
+           version: "{version}"
+conditions: {{}}
+targets:
+   chart:
+       name: Bump Chart dependencies
+       kind: helmChart
+       spec:
+           Name: "{chart_path}"
+           file: "Chart.yaml"
+           key: "dependencies[{index}].version"
+           versionIncrement: "patch"
+"""
+
+        with open("manifest.yaml", "w") as f:
+            f.write(manifest)
+
+        subprocess.check_output(
+            "updatecli apply --config manifest.yaml".split(" "))
+
+        if dependency["name"] == "generic-dep-installer":
+            update_gdi_dependency(chart_path, dependency)
+
+    print(f"Updating helm dependencies for chart: {chart_path}")
+    subprocess.check_output(
+        f"helm dep update {chart_path}".split(" "))
+
+if __name__ == "__main__":
+
+    # loop through all the charts and use updatecli
+    # to bump the chart versions if a newer version exists
+    paths = Path("charts")
+    for path in paths.iterdir():
+        try:
+            update_chart(str(path.absolute()))
+        except Exception as e:
+            print(f"Failed processing chart bumper for {path}")
+            print(traceback.format_exc())

--- a/scripts/chart_bumper.py
+++ b/scripts/chart_bumper.py
@@ -42,13 +42,6 @@ sources:
             version: "{version}"
 conditions: {{}}
 targets:
-    chart:
-        name: Bump Chart version
-        kind: helmChart
-        spec:
-            Name: "{chart_path}"
-            file: "Chart.yaml"
-            versionIncrement: "patch"
     chartValues:
         name: Bump Chart dependencies
         kind: helmChart

--- a/scripts/chart_bumper.py
+++ b/scripts/chart_bumper.py
@@ -22,7 +22,7 @@ BUMP_MAJOR = os.environ.get("BUMP_MAJOR") == "true"
 BUMP_MINOR = os.environ.get("BUMP_MINOR") == "true"
 
 
-def update_gdi_dependency(chart_path : str, dependency: dict):
+def update_gdi_dependency(chart_path: str, dependency: dict):
     with open(chart_path + "/values.yaml") as f:
         text = f.read()
     chart_values: dict = yaml.safe_load(text)
@@ -62,9 +62,7 @@ targets:
     with open("manifest_gdi_dependant.yaml", "w") as f:
         f.write(manifest)
     subprocess.check_output(
-            "updatecli apply --config manifest_gdi_dependant.yaml".split(" "))
-
-    os.remove("manifest_gdi_dependant.yaml")
+        "updatecli apply --config manifest_gdi_dependant.yaml".split(" "))
 
 
 def update_chart(chart_path: str):
@@ -124,6 +122,7 @@ targets:
     print(f"Updating helm dependencies for chart: {chart_path}")
     subprocess.check_output(
         f"helm dep update {chart_path}".split(" "))
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
# Motivation
Every time there is a new version of the helm chart released, the updated version needs to be propagated up to all the charts where it is a dependency. This creates a lot of manual effort to create PRs. This new workflow aims to automatically create a PR for updating the version of the released chart in whichever charts are applicable. This caters to both dependencies listed in the Chart.yaml file and the ones added via generic-dep-installer.

The idea for creating this came from this [blog](https://blog.promaton.com/how-to-set-up-automated-helm-chart-upgrades-e292192a9aad). It uses the tool: [update-cli](https://www.updatecli.io/).

# Modification
* Add new ci workflow.

# Known caveat
The script goes through all charts and checks if there is a newer version of the listed dependencies. For each new version of a dependent chart found, it creates an update-cli manifest and executes the command. For each execution, the chart gets a patch version upgrade. This can result in skipped patch versions if there are multiple dependency updates.


# Checklist
- [ ] Chart version bumped - NA
- [ ] README.md updated - NA
