### PR TITLE
feat: Update knative-serving-core to 1.3.2

### DIFF
--- a/charts/knative-serving-core/Chart.yaml
+++ b/charts/knative-serving-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: knative-serving-core
 description: Installs Knative Serving core and CRDs.
 type: application
-version: 1.1.2
-appVersion: "v1.0.1"
+version: 1.3.2
+appVersion: "v1.3.2"
 maintainers:
   - name: caraml-dev
     email: caraml-dev@caraml.dev

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -1,8 +1,8 @@
 # knative-serving-core
 
 ---
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square)
-![AppVersion: v1.0.1](https://img.shields.io/badge/AppVersion-v1.0.1-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square)
+![AppVersion: v1.3.2](https://img.shields.io/badge/AppVersion-v1.3.2-informational?style=flat-square)
 
 Installs Knative Serving core and CRDs.
 
@@ -60,38 +60,38 @@ The following table lists the configurable parameters of the Knative Serving Cor
 | activator.autoscaling.minReplicas | int | `1` | Minimum number of replicas for activator. |
 | activator.autoscaling.targetCPUUtilizationPercentage | int | `50` | Target CPU utlisation before it scales up/down. |
 | activator.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/activator"` | Repository of the activator image |
-| activator.image.sha | string | `"ca607f73e5daef7f3db0358e145220f8423e93c20ee7ea9f5595f13bd508289a"` | SHA256 of the activator image, either provide tag or SHA (SHA will be given priority) |
+| activator.image.sha | string | `"01270196a1eba7e5fd5fe34b877c82a7e8c93861de535a82342717d28f81d671"` | SHA256 of the activator image, either provide tag or SHA (SHA will be given priority) |
 | activator.image.tag | string | `""` | Tag of the activator image, either provide tag or SHA (SHA will be given priority) |
 | activator.replicaCount | int | `1` | Number of replicas for the activator deployment. |
 | activator.resources | object | `{"limits":{"cpu":"1000m","memory":"600Mi"},"requests":{"cpu":"300m","memory":"100Mi"}}` | Resources requests and limits for activator. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | autoscaler.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler"` | Repository of the autoscaler image |
-| autoscaler.image.sha | string | `"31aed8b5b241147585cb0e48366451a96354fc6036d6a5667997237c1d302d98"` | SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
+| autoscaler.image.sha | string | `"c5a03a236bfe2abdc7d40203d787668c8accaaf39062a86e68b4d403077835e2"` | SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
 | autoscaler.image.tag | string | `""` | Tag of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
 | autoscaler.replicaCount | int | `1` | Number of replicas for the autoscaler deployment. |
 | autoscaler.resources | object | `{"limits":{"cpu":"1000m","memory":"1000Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}` | Resources requests and limits for autoscaler. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | autoscalerHpa.enabled | bool | `true` |  |
 | autoscalerHpa.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa"` | Repository of the autoscaler image |
-| autoscalerHpa.image.sha | string | `"c7020d14b51862fae8e92da7b0442aa7843eb81c32699d158a3b24c19d5af8d4"` | SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
+| autoscalerHpa.image.sha | string | `"256373054915e035d3f5df214ca80eea7a235526c93348933f42acf0437bb1a2"` | SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
 | autoscalerHpa.image.tag | string | `""` | Tag of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
 | autoscalerHpa.replicaCount | int | `1` | Number of replicas for the autoscaler deployment. |
 | autoscalerHpa.resources | object | `{"limits":{"cpu":"1000m","memory":"256Mi"},"requests":{"cpu":"500m","memory":"128Mi"}}` | Resources requests and limits for autoscaler. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
-| config | object | `{"autoscaler":{},"buckets":"1","defaults":{},"deployment":{"queueSidecarImage":"gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:80dfb4568e08e43093f93b2cae9401f815efcb67ad8442d1f7f4c8a41e071fbe"},"domain":{},"features":{},"gc":{},"leaderElection":{"lease-duration":"15s","renew-deadline":"10s","retry-period":"2s"},"logging":{"logging.request-log-template":""},"network":{},"observability":{},"tracing":{}}` | Please check out the Knative documentation in https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-core.yaml |
+| config | object | `{"autoscaler":{},"buckets":"1","defaults":{},"deployment":{"queueSidecarImage":"gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"},"domain":{},"features":{},"gc":{},"leaderElection":{"lease-duration":"60s","renew-deadline":"40s","retry-period":"10s"},"logging":{"logging.request-log-template":""},"network":{},"observability":{},"tracing":{}}` | Please check out the Knative documentation in https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-core.yaml |
 | controller.autoscaling.enabled | bool | `true` | Enables autoscaling for controller deployment. |
 | controller.autoscaling.maxReplicas | int | `20` | Maximum number of replicas for controller. |
 | controller.autoscaling.minReplicas | int | `1` | Minimum number of replicas for controller. |
 | controller.autoscaling.targetCPUUtilizationPercentage | int | `50` | Target CPU utlisation before it scales up/down. |
 | controller.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/controller"` | Repository of the controller image |
-| controller.image.sha | string | `"c5a77d5642065ff3452d9b043a7226b85bfc81dc068f8dded905abf88d917a4d"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
+| controller.image.sha | string | `"cc33e6392485e9d015886d4443324b9a41c17f6ce98b31ef4b19e47325a9a7e8"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.image.tag | string | `""` | Tag of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.replicaCount | int | `1` | Number of replicas for the controller deployment. |
 | controller.resources | object | `{"limits":{"cpu":"1000m","memory":"1000Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}` | Resources requests and limits for controller. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | domainMapping.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping"` | Repository of the domain mapping image |
-| domainMapping.image.sha | string | `"6b5356cf3a2b64d52cbbf1bc0de376b816c4d3f610ccc8ff2dabf3d259c0996b"` | SHA256 of the domain mapping image, either provide tag or SHA (SHA will be given priority) |
+| domainMapping.image.sha | string | `"00a26f25ef119952b0ecf890f9f9dcb877b5f5d496f43c44756b93343d71b66e"` | SHA256 of the domain mapping image, either provide tag or SHA (SHA will be given priority) |
 | domainMapping.image.tag | string | `""` | Tag of the domain mapping image, either provide tag or SHA (SHA will be given priority) |
 | domainMapping.replicaCount | int | `1` | Number of replicas for the domain mapping deployment. |
 | domainMapping.resources | object | `{"limits":{"cpu":"300m","memory":"400Mi"},"requests":{"cpu":"30m","memory":"40Mi"}}` | Resources requests and limits for domain mapping. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | domainMappingWebhook.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook"` | Repository of the domain mapping webhook image |
-| domainMappingWebhook.image.sha | string | `"d0cc86f2002660c4804f6e0aed8218d39384c73a8b5006c9ac558becd8f48aa6"` | SHA256 of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority) |
+| domainMappingWebhook.image.sha | string | `"f8f09d3a509b0c25d50be7532d4337a30df4ec5f51b9ed23ad9f21b3940c16ca"` | SHA256 of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority) |
 | domainMappingWebhook.image.tag | string | `""` | Tag of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority) |
 | domainMappingWebhook.replicaCount | int | `1` | Number of replicas for the domain mapping webhook deployment. |
 | domainMappingWebhook.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for domain mapping webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
@@ -108,14 +108,14 @@ The following table lists the configurable parameters of the Knative Serving Cor
 | monitoring.podMonitor.userPortName | string | `"user-port"` |  |
 | monitoring.selectorKey | string | `"serving.knative.dev/revision"` |  |
 | queueProxy.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/queue"` | Repository of the queue proxy image |
-| queueProxy.image.sha | string | `"80dfb4568e08e43093f93b2cae9401f815efcb67ad8442d1f7f4c8a41e071fbe"` | SHA256 of the queue proxy image, either provide tag or SHA (SHA will be given priority) |
+| queueProxy.image.sha | string | `"2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"` | SHA256 of the queue proxy image, either provide tag or SHA (SHA will be given priority) |
 | queueProxy.image.tag | string | `""` | Tag of the queue proxy image, either provide tag or SHA (SHA will be given priority) |
 | webhook.autoscaling.enabled | bool | `true` | Enables autoscaling for webhook deployment. |
 | webhook.autoscaling.maxReplicas | int | `20` | Maximum number of replicas for webhook. |
 | webhook.autoscaling.minReplicas | int | `1` | Minimum number of replicas for webhook. |
 | webhook.autoscaling.targetCPUUtilizationPercentage | int | `50` | Target CPU utlisation before it scales up/down. |
 | webhook.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/webhook"` | Repository of the webhook image |
-| webhook.image.sha | string | `"bd954ec8ced56e359bd4f60ee1886b20000df14126688c796383a3ae40cfffc0"` | SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority) |
+| webhook.image.sha | string | `"b001a58cb7eac7fbae4d83d8a111fa0f6726d36e86844d5b1dc3c9b8fdd5710a"` | SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | webhook.image.tag | string | `""` | Tag of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | webhook.replicaCount | int | `1` | Number of replicas for the webhook deployment. |
 | webhook.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |

--- a/charts/knative-serving-core/crds/autoscaling-metrics.yaml
+++ b/charts/knative-serving-core/crds/autoscaling-metrics.yaml
@@ -19,7 +19,11 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/knative-serving-core/crds/cluster-domain-claims.yaml
+++ b/charts/knative-serving-core/crds/cluster-domain-claims.yaml
@@ -17,7 +17,11 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/knative-serving-core/crds/configurations.yaml
+++ b/charts/knative-serving-core/crds/configurations.yaml
@@ -19,7 +19,11 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
   annotations:
@@ -119,12 +123,12 @@ spec:
                             type: object
                             properties:
                               args:
-                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
                               command:
-                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
@@ -141,7 +145,7 @@ spec:
                                       description: Name of the environment variable. Must be a C_IDENTIFIER.
                                       type: string
                                     value:
-                                      description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                      description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's value. Cannot be used if value is not empty.
@@ -407,7 +411,7 @@ spec:
                                         - type: string
                                       x-kubernetes-int-or-string: true
                               securityContext:
-                                description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                 type: object
                                 properties:
                                   capabilities:

--- a/charts/knative-serving-core/crds/domain-mappings.yaml
+++ b/charts/knative-serving-core/crds/domain-mappings.yaml
@@ -17,7 +17,11 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/knative-serving-core/crds/image-caching.yaml
+++ b/charts/knative-serving-core/crds/image-caching.yaml
@@ -17,6 +17,11 @@ kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
   labels:
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/knative-serving-core/crds/ingresses.yaml
+++ b/charts/knative-serving-core/crds/ingresses.yaml
@@ -17,7 +17,11 @@ kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/knative-serving-core/crds/networking-certificates.yaml
+++ b/charts/knative-serving-core/crds/networking-certificates.yaml
@@ -17,7 +17,11 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/knative-serving-core/crds/pod-autoscalers.yaml
+++ b/charts/knative-serving-core/crds/pod-autoscalers.yaml
@@ -19,7 +19,11 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/knative-serving-core/crds/revisions.yaml
+++ b/charts/knative-serving-core/crds/revisions.yaml
@@ -19,7 +19,11 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
   annotations:
     "helm.sh/resource-policy": keep
@@ -98,12 +102,12 @@ spec:
                     type: object
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         type: array
                         items:
                           type: string
                       command:
-                        description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         type: array
                         items:
                           type: string
@@ -120,7 +124,7 @@ spec:
                               description: Name of the environment variable. Must be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                              description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value. Cannot be used if value is not empty.
@@ -386,7 +390,7 @@ spec:
                                 - type: string
                               x-kubernetes-int-or-string: true
                       securityContext:
-                        description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                         type: object
                         properties:
                           capabilities:
@@ -689,7 +693,18 @@ spec:
                 desiredReplicas:
                   description: DesiredReplicas reflects the desired amount of pods running this revision.
                   type: integer
-                  format: int32
+                  format: 
+                int32initContainerStatuses:	
+                  description: 'InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image to their respective digests and their container name. The digests are resolved during the creation of Revision. ContainerStatuses holds the container name and image digests for both serving and non serving containers. ref: http://bit.ly/image-digests'	
+                  type: array	
+                  items:	
+                    description: ContainerStatus holds the information of container name and image digest value	
+                    type: object	
+                    properties:	
+                      imageDigest:	
+                        type: string	
+                      name:	
+                        type: string
                 logUrl:
                   description: LogURL specifies the generated logging url for this particular revision based on the revision url template specified in the controller's config.
                   type: string

--- a/charts/knative-serving-core/crds/routes.yaml
+++ b/charts/knative-serving-core/crds/routes.yaml
@@ -19,7 +19,11 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
   annotations:

--- a/charts/knative-serving-core/crds/serverless-services.yaml
+++ b/charts/knative-serving-core/crds/serverless-services.yaml
@@ -17,7 +17,11 @@ kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/knative-serving-core/crds/services.yaml
+++ b/charts/knative-serving-core/crds/services.yaml
@@ -19,7 +19,11 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v1.0.1"
+    helm.sh/chart: knative-serving-core
+    app.kubernetes.io/version: "1.3.2"
+    serving.knative.dev/release: "v1.3.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: knative-serving
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -123,12 +127,12 @@ spec:
                             type: object
                             properties:
                               args:
-                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
                               command:
-                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
@@ -145,7 +149,7 @@ spec:
                                       description: Name of the environment variable. Must be a C_IDENTIFIER.
                                       type: string
                                     value:
-                                      description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                      description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's value. Cannot be used if value is not empty.
@@ -411,7 +415,7 @@ spec:
                                         - type: string
                                       x-kubernetes-int-or-string: true
                               securityContext:
-                                description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                 type: object
                                 properties:
                                   capabilities:

--- a/charts/knative-serving-core/templates/_helpers.tpl
+++ b/charts/knative-serving-core/templates/_helpers.tpl
@@ -10,7 +10,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 serving.knative.dev/release: {{ .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: knative-serving
+app.kubernetes.io/name: knative-serving
 {{- end }}
 
 {{/*
@@ -31,7 +31,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 serving.knative.dev/release: {{ .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: knative-serving
+app.kubernetes.io/name: knative-serving
 {{- end }}
 
 {{/*

--- a/charts/knative-serving-core/templates/config-maps/autoscaler.yaml
+++ b/charts/knative-serving-core/templates/config-maps/autoscaler.yaml
@@ -17,10 +17,10 @@ kind: ConfigMap
 metadata:
   name: config-autoscaler
   labels:
-    app.kubernetes.io/name: autoscaler
+    app.kubernetes.io/component: autoscaler
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "604cb513"
+    knative.dev/example-checksum: "16af78ce"
 data:
 {{- if .Values.config.autoscaler }}
   {{- toYaml .Values.config.autoscaler | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/defaults.yaml
+++ b/charts/knative-serving-core/templates/config-maps/defaults.yaml
@@ -17,9 +17,10 @@ kind: ConfigMap
 metadata:
   name: config-defaults
   labels:
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "cdabec96"
+    knative.dev/example-checksum: "a0feb4c6"
 data:
 {{- if .Values.config.defaults }}
   {{- toYaml .Values.config.defaults | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/deployment.yaml
+++ b/charts/knative-serving-core/templates/config-maps/deployment.yaml
@@ -17,6 +17,7 @@ kind: ConfigMap
 metadata:
   name: config-deployment
   labels:
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
     knative.dev/example-checksum: "dd7ee769"

--- a/charts/knative-serving-core/templates/config-maps/domain.yaml
+++ b/charts/knative-serving-core/templates/config-maps/domain.yaml
@@ -17,6 +17,7 @@ kind: ConfigMap
 metadata:
   name: config-domain
   labels:
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
     knative.dev/example-checksum: "81552d0b"

--- a/charts/knative-serving-core/templates/config-maps/features.yaml
+++ b/charts/knative-serving-core/templates/config-maps/features.yaml
@@ -17,9 +17,10 @@ kind: ConfigMap
 metadata:
   name: config-features
   labels:
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "2897f625"
+    knative.dev/example-checksum: "d9e300ba"
 data:
 {{- if .Values.config.features }}
   {{- toYaml .Values.config.features | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/gc.yaml
+++ b/charts/knative-serving-core/templates/config-maps/gc.yaml
@@ -17,9 +17,10 @@ kind: ConfigMap
 metadata:
   name: config-gc
   labels:
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "51b4d68a"
+    knative.dev/example-checksum: "45463e45"
 data:
 {{- if .Values.config.gc }}
   {{- toYaml .Values.config.gc | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/leader-election.yaml
+++ b/charts/knative-serving-core/templates/config-maps/leader-election.yaml
@@ -17,9 +17,10 @@ kind: ConfigMap
 metadata:
   name: config-leader-election
   labels:
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "f7948630"
+    knative.dev/example-checksum: "f4b71f57"
 data:
 {{- if .Values.config.leaderElection }}
   {{- toYaml .Values.config.leaderElection | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/logging.yaml
+++ b/charts/knative-serving-core/templates/config-maps/logging.yaml
@@ -17,9 +17,10 @@ kind: ConfigMap
 metadata:
   name: config-logging
   labels:
+    app.kubernetes.io/component: logging
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "be93ff10"
+    knative.dev/example-checksum: "b0f3c6f2"
 data:
 {{- if .Values.config.logging }}
   {{- toYaml .Values.config.logging | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/network.yaml
+++ b/charts/knative-serving-core/templates/config-maps/network.yaml
@@ -17,9 +17,10 @@ kind: ConfigMap
 metadata:
   name: config-network
   labels:
+    app.kubernetes.io/component: networking
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "6e2033e0"
+    knative.dev/example-checksum: "ddc3250f"
 data:
 {{- if .Values.config.network }}
   {{- toYaml .Values.config.network | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/observability.yaml
+++ b/charts/knative-serving-core/templates/config-maps/observability.yaml
@@ -17,6 +17,7 @@ kind: ConfigMap
 metadata:
   name: config-observability
   labels:
+    app.kubernetes.io/component: observability
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
     knative.dev/example-checksum: "fed4756e"

--- a/charts/knative-serving-core/templates/config-maps/tracing.yaml
+++ b/charts/knative-serving-core/templates/config-maps/tracing.yaml
@@ -17,6 +17,7 @@ kind: ConfigMap
 metadata:
   name: config-tracing
   labels:
+    app.kubernetes.io/component: tracing
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
     knative.dev/example-checksum: "26614636"

--- a/charts/knative-serving-core/templates/deployments/activator.yaml
+++ b/charts/knative-serving-core/templates/deployments/activator.yaml
@@ -17,7 +17,7 @@ kind: Deployment
 metadata:
   name: activator
   labels:
-    app.kubernetes.io/name: activator
+    app.kubernetes.io/component: activator
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.activator.replicaCount }}
@@ -32,7 +32,7 @@ spec:
       labels:
         app: activator
         role: activator
-        app.kubernetes.io/name: activator
+        app.kubernetes.io/component: activator
         {{- include "knative-serving-core.labels" . | nindent 8 }}
       {{- if .Values.global.extraPodLabels }}
         {{- toYaml .Values.global.extraPodLabels | nindent 8 }}
@@ -106,14 +106,16 @@ spec:
               port: 8012
               httpHeaders:
                 - name: k-kubelet-probe
-                  value: "activator"
-            failureThreshold: 12
+                  value: "activator"	
+            periodSeconds: 5	
+            failureThreshold: 5
           livenessProbe:
             httpGet:
               port: 8012
               httpHeaders:
                 - name: k-kubelet-probe
-                  value: "activator"
+                  value: "activator"	
+            periodSeconds: 10
             failureThreshold: 12
             initialDelaySeconds: 15
       # The activator (often) sits on the dataplane, and may proxy long (e.g.

--- a/charts/knative-serving-core/templates/deployments/autoscaler.yaml
+++ b/charts/knative-serving-core/templates/deployments/autoscaler.yaml
@@ -17,20 +17,24 @@ kind: Deployment
 metadata:
   name: autoscaler
   labels:
-    app.kubernetes.io/name: autoscaler
+    app.kubernetes.io/component: autoscaler
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.autoscaler.replicaCount }}
   selector:
     matchLabels:
-      app: autoscaler
+      app: autoscaler	
+  strategy:	
+    type: RollingUpdate	
+    rollingUpdate:	
+      maxUnavailable: 0
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler
-        app.kubernetes.io/name: autoscaler
+        app.kubernetes.io/component: autoscaler
         {{- include "knative-serving-core.labels" . | nindent 8 }}
       {{- if .Values.global.extraPodLabels }}
         {{- toYaml .Values.global.extraPodLabels | nindent 8 }}

--- a/charts/knative-serving-core/templates/deployments/autoscaling-hpa.yaml
+++ b/charts/knative-serving-core/templates/deployments/autoscaling-hpa.yaml
@@ -19,7 +19,7 @@ metadata:
   name: autoscaler-hpa
   labels:
     autoscaling.knative.dev/autoscaler-provider: hpa
-    app.kubernetes.io/name: autoscaler-hpa
+    app.kubernetes.io/component: autoscaler-hpa
     {{- include "knative-serving-hpa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.autoscalerHpa.replicaCount }}
@@ -32,7 +32,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler-hpa
-        app.kubernetes.io/name: autoscaler-hpa
+        app.kubernetes.io/component: autoscaler-hpa
         {{- include "knative-serving-hpa.labels" . | nindent 8 }}
       {{- if .Values.global.extraPodLabels }}
         {{- toYaml .Values.global.extraPodLabels | nindent 8 }}

--- a/charts/knative-serving-core/templates/deployments/controller.yaml
+++ b/charts/knative-serving-core/templates/deployments/controller.yaml
@@ -17,7 +17,7 @@ kind: Deployment
 metadata:
   name: controller
   labels:
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
@@ -30,7 +30,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: controller
-        app.kubernetes.io/name: controller
+        app.kubernetes.io/component: controller
         {{- include "knative-serving-core.labels" . | nindent 8 }}
       {{- if .Values.global.extraPodLabels }}
         {{- toYaml .Values.global.extraPodLabels | nindent 8 }}

--- a/charts/knative-serving-core/templates/deployments/domain-mapping-webhook.yaml
+++ b/charts/knative-serving-core/templates/deployments/domain-mapping-webhook.yaml
@@ -17,7 +17,7 @@ kind: Deployment
 metadata:
   name: domainmapping-webhook
   labels:
-    app.kubernetes.io/name: domainmapping-webhook
+    app.kubernetes.io/component: domainmapping-webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.domainMappingWebhook.replicaCount }}
@@ -31,7 +31,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: domainmapping-webhook
-        app.kubernetes.io/name: domainmapping-webhook
+        app.kubernetes.io/component: domainmapping-webhook
         role: domainmapping-webhook
         {{- include "knative-serving-core.labels" . | nindent 8 }}
       {{- if .Values.global.extraPodLabels }}

--- a/charts/knative-serving-core/templates/deployments/domain-mapping.yaml
+++ b/charts/knative-serving-core/templates/deployments/domain-mapping.yaml
@@ -17,7 +17,7 @@ kind: Deployment
 metadata:
   name: domain-mapping
   labels:
-    app.kubernetes.io/name: domain-mapping
+    app.kubernetes.io/component: domain-mapping
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.domainMapping.replicaCount }}
@@ -30,7 +30,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: domain-mapping
-        app.kubernetes.io/name: domain-mapping
+        app.kubernetes.io/component: domain-mapping
         {{- include "knative-serving-core.labels" . | nindent 8 }}
       {{- if .Values.global.extraPodLabels }}
         {{- toYaml .Values.global.extraPodLabels | nindent 8 }}

--- a/charts/knative-serving-core/templates/deployments/webhook.yaml
+++ b/charts/knative-serving-core/templates/deployments/webhook.yaml
@@ -17,7 +17,7 @@ kind: Deployment
 metadata:
   name: webhook
   labels:
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.webhook.replicaCount }}
@@ -32,7 +32,7 @@ spec:
       labels:
         app: webhook
         role: webhook
-        app.kubernetes.io/name: webhook
+        app.kubernetes.io/component: webhook
         {{- include "knative-serving-core.labels" . | nindent 8 }}
       {{- if .Values.global.extraPodLabels }}
         {{- toYaml .Values.global.extraPodLabels | nindent 8 }}

--- a/charts/knative-serving-core/templates/hpas/activator.yaml
+++ b/charts/knative-serving-core/templates/hpas/activator.yaml
@@ -17,7 +17,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: activator
   labels:
-    app.kubernetes.io/name: activator
+    app.kubernetes.io/component: activator
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   minReplicas: {{ .Values.activator.autoscaling.minReplicas }}

--- a/charts/knative-serving-core/templates/hpas/controller.yaml
+++ b/charts/knative-serving-core/templates/hpas/controller.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: controller
   labels:
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}

--- a/charts/knative-serving-core/templates/hpas/webhook.yaml
+++ b/charts/knative-serving-core/templates/hpas/webhook.yaml
@@ -18,7 +18,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: webhook
   labels:
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   minReplicas: {{ .Values.webhook.autoscaling.minReplicas }}

--- a/charts/knative-serving-core/templates/images/queue-proxy.yaml
+++ b/charts/knative-serving-core/templates/images/queue-proxy.yaml
@@ -17,7 +17,7 @@ kind: Image
 metadata:
   name: queue-proxy
   labels:
-    app.kubernetes.io/name: queue-proxy
+    app.kubernetes.io/component: queue-proxy
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   {{- if .Values.queueProxy.image.sha }}

--- a/charts/knative-serving-core/templates/mutating-webhooks/domain-mapping.yaml
+++ b/charts/knative-serving-core/templates/mutating-webhooks/domain-mapping.yaml
@@ -17,6 +17,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.domainmapping.serving.knative.dev
   labels:
+    app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/knative-serving-core/templates/mutating-webhooks/serving.yaml
+++ b/charts/knative-serving-core/templates/mutating-webhooks/serving.yaml
@@ -17,7 +17,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    app.kubernetes.io/name: defaulting-webhook
+    app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/knative-serving-core/templates/pdbs/activator.yaml
+++ b/charts/knative-serving-core/templates/pdbs/activator.yaml
@@ -6,7 +6,7 @@ kind: PodDisruptionBudget
 metadata:
   name: activator-pdb
   labels:
-    app.kubernetes.io/name: activator
+    app.kubernetes.io/component: activator
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   minAvailable: 80%

--- a/charts/knative-serving-core/templates/pdbs/webhook.yaml
+++ b/charts/knative-serving-core/templates/pdbs/webhook.yaml
@@ -17,7 +17,7 @@ kind: PodDisruptionBudget
 metadata:
   name: webhook-pdb
   labels:
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   minAvailable: 80%

--- a/charts/knative-serving-core/templates/rbac/controller.yaml
+++ b/charts/knative-serving-core/templates/rbac/controller.yaml
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: controller
   labels:
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 ---
 kind: ClusterRole
@@ -38,7 +38,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
     {{- include "knative-serving-core.annotations" . | nindent 4 }}
@@ -56,7 +56,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
     {{- include "knative-serving-core.annotations" . | nindent 4 }}

--- a/charts/knative-serving-core/templates/secrets/domain-mapping.yaml
+++ b/charts/knative-serving-core/templates/secrets/domain-mapping.yaml
@@ -17,5 +17,6 @@ kind: Secret
 metadata:
   name: domainmapping-webhook-certs
   labels:
+    app.kubernetes.io/component: domain-mapping	
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 # The data is populated at install time.

--- a/charts/knative-serving-core/templates/secrets/webhook-certs.yaml
+++ b/charts/knative-serving-core/templates/secrets/webhook-certs.yaml
@@ -17,6 +17,6 @@ kind: Secret
 metadata:
   name: webhook-certs
   labels:
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 # The data is populated at install time.

--- a/charts/knative-serving-core/templates/services/activator.yaml
+++ b/charts/knative-serving-core/templates/services/activator.yaml
@@ -18,7 +18,7 @@ metadata:
   name: activator-service
   labels:
     app: activator
-    app.kubernetes.io/name: activator
+    app.kubernetes.io/component: activator
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
   selector:

--- a/charts/knative-serving-core/templates/services/autoscaler-hpa.yaml
+++ b/charts/knative-serving-core/templates/services/autoscaler-hpa.yaml
@@ -18,7 +18,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler-hpa
-    app.kubernetes.io/name: autoscaler-hpa
+    app.kubernetes.io/component: autoscaler-hpa
     autoscaling.knative.dev/autoscaler-provider: hpa
     {{- include "knative-serving-hpa.labels" . | nindent 4 }}
   name: autoscaler-hpa

--- a/charts/knative-serving-core/templates/services/autoscaler.yaml
+++ b/charts/knative-serving-core/templates/services/autoscaler.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    app.kubernetes.io/name: autoscaler
+    app.kubernetes.io/component: autoscaler
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   name: autoscaler
 spec:

--- a/charts/knative-serving-core/templates/services/controller.yaml
+++ b/charts/knative-serving-core/templates/services/controller.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     app: controller
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   name: controller
 spec:

--- a/charts/knative-serving-core/templates/services/domain-mapping-webhook.yaml
+++ b/charts/knative-serving-core/templates/services/domain-mapping-webhook.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     role: domainmapping-webhook
-    app.kubernetes.io/name: domainmapping-webhook
+    app.kubernetes.io/component: domainmapping-webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   name: domainmapping-webhook
 spec:

--- a/charts/knative-serving-core/templates/services/webhook.yaml
+++ b/charts/knative-serving-core/templates/services/webhook.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   name: webhook
 spec:

--- a/charts/knative-serving-core/templates/validating-webhooks/config.yaml
+++ b/charts/knative-serving-core/templates/validating-webhooks/config.yaml
@@ -17,7 +17,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    app.kubernetes.io/name: configmap-validation-webhook
+    app.kubernetes.io/component: configmap-validation-webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -28,8 +28,12 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: config.webhook.serving.knative.dev
-    namespaceSelector:
+    objectSelector:
       matchExpressions:
-        - key: serving.knative.dev/release
-          operator: Exists
+        - key: app.kubernetes.io/name	
+          operator: In	
+          values: ["knative-serving"]	
+        - key: app.kubernetes.io/component	
+          operator: In	
+          values: ["autoscaler", "controller", "logging", "networking", "observability", "tracing"]
     timeoutSeconds: 10

--- a/charts/knative-serving-core/templates/validating-webhooks/domain-mapping.yaml
+++ b/charts/knative-serving-core/templates/validating-webhooks/domain-mapping.yaml
@@ -17,7 +17,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.domainmapping.serving.knative.dev
   labels:
-    app.kubernetes.io/name: domainmapping-webhook
+    app.kubernetes.io/component: domainmapping-webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/knative-serving-core/templates/validating-webhooks/validation.yaml
+++ b/charts/knative-serving-core/templates/validating-webhooks/validation.yaml
@@ -17,7 +17,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    app.kubernetes.io/name: validating-webhook
+    app.kubernetes.io/component: validating-webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/knative-serving-core/values.yaml
+++ b/charts/knative-serving-core/values.yaml
@@ -16,14 +16,14 @@ config:
   autoscaler: {}
   defaults: {}
   deployment:
-    queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:80dfb4568e08e43093f93b2cae9401f815efcb67ad8442d1f7f4c8a41e071fbe
+    queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b
   domain: {}
   features: {}
   gc: {}
   leaderElection:
-    lease-duration: "15s"
-    renew-deadline: "10s"
-    retry-period: "2s"
+    lease-duration: "60s"
+    renew-deadline: "40s"
+    retry-period: "10s"
   buckets: "1"
   logging:
     logging.request-log-template: ""
@@ -47,7 +47,7 @@ activator:
     # -- Tag of the activator image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the activator image, either provide tag or SHA (SHA will be given priority)
-    sha: "ca607f73e5daef7f3db0358e145220f8423e93c20ee7ea9f5595f13bd508289a"
+    sha: "01270196a1eba7e5fd5fe34b877c82a7e8c93861de535a82342717d28f81d671"
   # -- Number of replicas for the activator deployment.
   replicaCount: 1
   # -- Resources requests and limits for activator. This should be set
@@ -68,7 +68,7 @@ autoscaler:
     # -- Tag of the autoscaler image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority)
-    sha: "31aed8b5b241147585cb0e48366451a96354fc6036d6a5667997237c1d302d98"
+    sha: "c5a03a236bfe2abdc7d40203d787668c8accaaf39062a86e68b4d403077835e2"
   # -- Number of replicas for the autoscaler deployment.
   replicaCount: 1
   # -- Resources requests and limits for autoscaler. This should be set
@@ -98,7 +98,7 @@ controller:
     # -- Tag of the controller image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the controller image, either provide tag or SHA (SHA will be given priority)
-    sha: "c5a77d5642065ff3452d9b043a7226b85bfc81dc068f8dded905abf88d917a4d"
+    sha: "cc33e6392485e9d015886d4443324b9a41c17f6ce98b31ef4b19e47325a9a7e8"
   # -- Number of replicas for the controller deployment.
   replicaCount: 1
   # -- Resources requests and limits for controller. This should be set
@@ -119,7 +119,7 @@ domainMapping:
     # -- Tag of the domain mapping image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the domain mapping image, either provide tag or SHA (SHA will be given priority)
-    sha: "6b5356cf3a2b64d52cbbf1bc0de376b816c4d3f610ccc8ff2dabf3d259c0996b"
+    sha: "00a26f25ef119952b0ecf890f9f9dcb877b5f5d496f43c44756b93343d71b66e"
   # -- Number of replicas for the domain mapping deployment.
   replicaCount: 1
   # -- Resources requests and limits for domain mapping. This should be set
@@ -140,7 +140,7 @@ domainMappingWebhook:
     # -- Tag of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority)
-    sha: "d0cc86f2002660c4804f6e0aed8218d39384c73a8b5006c9ac558becd8f48aa6"
+    sha: "f8f09d3a509b0c25d50be7532d4337a30df4ec5f51b9ed23ad9f21b3940c16ca"
   # -- Number of replicas for the domain mapping webhook deployment.
   replicaCount: 1
   # -- Resources requests and limits for domain mapping webhook. This should be set
@@ -170,7 +170,7 @@ webhook:
     # -- Tag of the webhook image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority)
-    sha: "bd954ec8ced56e359bd4f60ee1886b20000df14126688c796383a3ae40cfffc0"
+    sha: "b001a58cb7eac7fbae4d83d8a111fa0f6726d36e86844d5b1dc3c9b8fdd5710a"
   # -- Number of replicas for the webhook deployment.
   replicaCount: 1
   # -- Resources requests and limits for webhook. This should be set
@@ -191,7 +191,7 @@ queueProxy:
     # -- Tag of the queue proxy image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the queue proxy image, either provide tag or SHA (SHA will be given priority)
-    sha: "80dfb4568e08e43093f93b2cae9401f815efcb67ad8442d1f7f4c8a41e071fbe"
+    sha: "2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"
 
 monitoring:
   enabled: false
@@ -214,7 +214,7 @@ autoscalerHpa:
     # -- Tag of the autoscaler image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority)
-    sha: "c7020d14b51862fae8e92da7b0442aa7843eb81c32699d158a3b24c19d5af8d4"
+    sha: "256373054915e035d3f5df214ca80eea7a235526c93348933f42acf0437bb1a2"
   # -- Number of replicas for the autoscaler deployment.
   replicaCount: 1
   # -- Resources requests and limits for autoscaler. This should be set


### PR DESCRIPTION
# Motivation

The main motivation for upgrading knative is to support UPI, as the current version has issue in liveness probe when using gRPC protocol and fixed in [1.2.3](https://github.com/knative/serving/releases/tag/knative-v1.2.3), in this [PR](https://github.com/knative/serving/pull/12479)

The version 1.3.2 is selected since it's the newest knative version that we tested to be compatible with Merlin and Turing.

# Modification

The modifications are made base of the diff between knative 1.0.1 manifest and knative 1.3.2 manifest. It mainly modifies labels and docker images versions. 


# Checklist
- [X] Chart version bumped
- [X] README.md updated
