### PR TITLE
feat: Update knative-serving istio to 1.3.0

### DIFF
--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: knative-serving-istio
 description: Installs Knative-serving for Istio
 type: application
-version: 1.0.7
-appVersion: "v1.0.0"
+version: 1.3.0
+appVersion: "v1.3.0"
 maintainers:
   - name: caraml-dev
     email: caraml-dev@caraml.dev

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,8 +1,8 @@
 # knative-serving-istio
 
 ---
-![Version: 1.0.7](https://img.shields.io/badge/Version-1.0.7-informational?style=flat-square)
-![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square)
+![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 Installs Knative-serving for Istio
 
@@ -93,7 +93,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | config | object | `{"istio":{"enable-virtualservice-status":"false","gateway.{{ .Release.Namespace }}.knative-ingress-gateway":"istio-ingressgateway.istio-system.svc.cluster.local","local-gateway.mesh":"mesh","local-gateway.{{ .Release.Namespace }}.knative-local-gateway":"cluster-local-gateway.istio-system.svc.cluster.local"}}` | Please check out the Knative documentation in https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.0.0/net-istio.yaml |
 | controller.autoscaling.enabled | bool | `false` | Enables autoscaling for net-istio-controller deployment. |
 | controller.image.repository | string | `"gcr.io/knative-releases/knative.dev/net-istio/cmd/controller"` | Repository of the controller image |
-| controller.image.sha | string | `"1ef74af101cc89d86a2e6b37b9a74545bfd9892d48b1b036d419a635a19c0081"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
+| controller.image.sha | string | `"7f17fb47568a74de3f82bb512422a174017b7c06643a330557bc3445c8869932"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.image.tag | string | `""` | Tag of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.replicaCount | int | `1` | Number of replicas for the net-istio-controller deployment. |
 | controller.resources | object | `{"limits":{"cpu":"1000m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | Resources requests and limits for net-istio-controller. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
@@ -188,7 +188,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | knativeServingCore.webhook.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | revision | string | `""` |  |
 | webhook.image.repository | string | `"gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook"` | Repository of the webhook image |
-| webhook.image.sha | string | `"ab3dfcf1574780448b3453cc717d6eb2bc33e794d36c090eff1076aa65f05ca0"` | SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority) |
+| webhook.image.sha | string | `"75d502bdff93e9c0e4611c2747d868b8d471f8d3a0402394de76ec2d98b89ce3"` | SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | webhook.image.tag | string | `""` | Tag of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | webhook.replicaCount | int | `1` | Number of replicas for the net-istio-webhook deployment. |
 | webhook.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for net-istio-webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |

--- a/charts/knative-serving-istio/templates/_helpers.tpl
+++ b/charts/knative-serving-istio/templates/_helpers.tpl
@@ -10,7 +10,8 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 serving.knative.dev/release: {{ .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: knative-serving
+app.kubernetes.io/name: knative-serving
+app.kubernetes.io/component: net-istio
 networking.knative.dev/ingress-provider: istio
 {{- end }}
 

--- a/charts/knative-serving-istio/templates/peer-authentication/webhook.yaml
+++ b/charts/knative-serving-istio/templates/peer-authentication/webhook.yaml
@@ -25,5 +25,5 @@ spec:
     matchLabels:
       app: webhook
   portLevelMtls:
-    8443:
+    "8443":
       mode: PERMISSIVE

--- a/charts/knative-serving-istio/templates/validating-webhooks/webhook-config.yaml
+++ b/charts/knative-serving-istio/templates/validating-webhooks/webhook-config.yaml
@@ -29,7 +29,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: config.webhook.istio.networking.internal.knative.dev
-    namespaceSelector:
-      matchExpressions:
-        - key: serving.knative.dev/release
-          operator: Exists
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/component: net-istio

--- a/charts/knative-serving-istio/values.yaml
+++ b/charts/knative-serving-istio/values.yaml
@@ -41,7 +41,7 @@ controller:
     # -- Tag of the controller image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the controller image, either provide tag or SHA (SHA will be given priority)
-    sha: "1ef74af101cc89d86a2e6b37b9a74545bfd9892d48b1b036d419a635a19c0081"
+    sha: "7f17fb47568a74de3f82bb512422a174017b7c06643a330557bc3445c8869932"
   # -- Number of replicas for the net-istio-controller deployment.
   replicaCount: 1
   # -- Resources requests and limits for net-istio-controller. This should be set
@@ -62,7 +62,7 @@ webhook:
     # -- Tag of the webhook image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority)
-    sha: "ab3dfcf1574780448b3453cc717d6eb2bc33e794d36c090eff1076aa65f05ca0"
+    sha: "75d502bdff93e9c0e4611c2747d868b8d471f8d3a0402394de76ec2d98b89ce3"
   # -- Number of replicas for the net-istio-webhook deployment.
   replicaCount: 1
   # -- Resources requests and limits for net-istio-webhook. This should be set


### PR DESCRIPTION
# Motivation

Similar to https://github.com/caraml-dev/helm-charts/pull/68 . Knative 1.0.1 has issue on handling liveness probe when using gRPC protocol and is fixed in version [1.2.3 or later](https://github.com/knative/serving/releases/tag/knative-v1.2.3).

# Modification
The modifications are made base of the diff between knative istio 1.0.0 manifest and knative  istio 1.3.0 manifest. It mainly modifies labels and docker images versions.
Note that knative net istio component doesn't create new release for every new patch of knative serving core hence the patch version is always 0.

# Checklist
- [X] Chart version bumped
- [X] README.md updated
