### PR TITLE
fix(knative-serving-istio): Use istio namespace from values file during helm tests

### DIFF
--- a/charts/knative-serving-istio/Chart.lock
+++ b/charts/knative-serving-istio/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.2.1
 - name: base
   repository: https://istio-release.storage.googleapis.com/charts
-  version: 1.13.4
+  version: 1.13.9
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
-digest: sha256:101b301b8f7aef771e1bf1217974c594b41a723704612919ae1e573a089b9c98
-generated: "2022-11-02T09:52:11.691203+05:30"
+digest: sha256:9408e353d51141b412b573ccfdc0239b9e34e9399a5a5875b1fbd7cc4d84690b
+generated: "2022-11-04T17:01:43.916236+05:30"

--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -1,35 +1,35 @@
 apiVersion: v2
-name: knative-serving-istio
-description: Installs Knative-serving for Istio
-type: application
-version: 1.3.0
-appVersion: "v1.3.0"
-maintainers:
-  - name: caraml-dev
-    email: caraml-dev@caraml.dev
+appVersion: v1.3.0
 dependencies:
-  - name: knative-serving-core
-    repository: "https://caraml-dev.github.io/helm-charts"
-    version: ~1.1.0
-    alias: knativeServingCore
-    condition: knativeServingCore.enabled
-  - name: generic-dep-installer
-    repository: "https://caraml-dev.github.io/helm-charts"
-    version: ~0.2.1
-    alias: istiod
-    condition: istiod.enabled
-  - name: base
-    repository: "https://istio-release.storage.googleapis.com/charts"
-    version: 1.13.4
-    alias: base
-    condition: base.enabled
-  - name: generic-dep-installer
-    repository: "https://caraml-dev.github.io/helm-charts"
-    version: ~0.2.1
-    alias: istioIngressGateway
-    condition: istioIngressGateway.global.enabled
-  - name: generic-dep-installer
-    repository: "https://caraml-dev.github.io/helm-charts"
-    version: ~0.2.1
-    alias: clusterLocalGateway
-    condition: clusterLocalGateway.global.enabled
+- alias: knativeServingCore
+  condition: knativeServingCore.enabled
+  name: knative-serving-core
+  repository: https://caraml-dev.github.io/helm-charts
+  version: 1.1.2
+- alias: istiod
+  condition: istiod.enabled
+  name: generic-dep-installer
+  repository: https://caraml-dev.github.io/helm-charts
+  version: 0.2.1
+- alias: base
+  condition: base.enabled
+  name: base
+  repository: https://istio-release.storage.googleapis.com/charts
+  version: 1.13.9
+- alias: istioIngressGateway
+  condition: istioIngressGateway.global.enabled
+  name: generic-dep-installer
+  repository: https://caraml-dev.github.io/helm-charts
+  version: 0.2.1
+- alias: clusterLocalGateway
+  condition: clusterLocalGateway.global.enabled
+  name: generic-dep-installer
+  repository: https://caraml-dev.github.io/helm-charts
+  version: 0.2.1
+description: Installs Knative-serving for Istio
+maintainers:
+- email: caraml-dev@caraml.dev
+  name: caraml-dev
+name: knative-serving-istio
+type: application
+version: 1.3.8

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square)
+![Version: 1.3.8](https://img.shields.io/badge/Version-1.3.8-informational?style=flat-square)
 ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 Installs Knative-serving for Istio
@@ -87,7 +87,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | clusterLocalGateway.helmChart.namespace | string | `"istio-system"` |  |
 | clusterLocalGateway.helmChart.release | string | `"cluster-local-gateway"` |  |
 | clusterLocalGateway.helmChart.repository | string | `"https://istio-release.storage.googleapis.com/charts"` |  |
-| clusterLocalGateway.helmChart.version | string | `"1.13.4"` |  |
+| clusterLocalGateway.helmChart.version | string | `"1.13.9"` |  |
 | clusterLocalGateway.hook.weight | int | `1` |  |
 | clusterLocalGatewayIstioSelector | string | `"cluster-local-gateway"` |  |
 | config | object | `{"istio":{"enable-virtualservice-status":"false","gateway.{{ .Release.Namespace }}.knative-ingress-gateway":"istio-ingressgateway.istio-system.svc.cluster.local","local-gateway.mesh":"mesh","local-gateway.{{ .Release.Namespace }}.knative-local-gateway":"cluster-local-gateway.istio-system.svc.cluster.local"}}` | Please check out the Knative documentation in https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.0.0/net-istio.yaml |
@@ -117,7 +117,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | istioIngressGateway.helmChart.namespace | string | `"istio-system"` |  |
 | istioIngressGateway.helmChart.release | string | `"istio-ingress-gateway"` |  |
 | istioIngressGateway.helmChart.repository | string | `"https://istio-release.storage.googleapis.com/charts"` |  |
-| istioIngressGateway.helmChart.version | string | `"1.13.4"` |  |
+| istioIngressGateway.helmChart.version | string | `"1.13.9"` |  |
 | istioIngressGateway.hook.weight | int | `1` |  |
 | istiod.chartValues.configValidation | bool | `true` |  |
 | istiod.chartValues.deployInReleaseNs | bool | `false` |  |
@@ -135,7 +135,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | istiod.helmChart.namespace | string | `"istio-system"` |  |
 | istiod.helmChart.release | string | `"istiod"` |  |
 | istiod.helmChart.repository | string | `"https://istio-release.storage.googleapis.com/charts"` |  |
-| istiod.helmChart.version | string | `"1.13.4"` |  |
+| istiod.helmChart.version | string | `"1.13.9"` |  |
 | istiod.hook.weight | int | `0` |  |
 | knativeServingCore.activator.autoscaling.enabled | bool | `false` | Enables autoscaling for activator deployment. |
 | knativeServingCore.activator.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/activator"` | Repository of the activator image |

--- a/charts/knative-serving-istio/ci/ci-values.yaml
+++ b/charts/knative-serving-istio/ci/ci-values.yaml
@@ -1,3 +1,9 @@
+config:
+  istio:
+    # NOTE: assumes istio edge proxies (*-gateway deployments) are deployed in istio-system-knative-serving-istio namespace
+    gateway.{{ .Release.Namespace }}.knative-ingress-gateway: "istio-ingressgateway.istio-system-knative-serving-istio.svc.cluster.local"
+    local-gateway.{{ .Release.Namespace }}.knative-local-gateway: "cluster-local-gateway.istio-system-knative-serving-istio.svc.cluster.local"
+
 controller:
   resources:
     requests:
@@ -80,8 +86,17 @@ knativeServingCore:
         cpu: 250m
         memory: 500Mi
 
+base:
+  global:
+    istioNamespace: "istio-system-knative-serving-istio"
+
+
 istiod:
+  helmChart:
+    namespace: "istio-system-knative-serving-istio"
   chartValues:
+    global:
+      istioNamespace: "istio-system-knative-serving-istio"
     pilot:
       resources:
         requests:
@@ -92,7 +107,11 @@ istiod:
           memory: 1024Mi
 
 istioIngressGateway:
+  helmChart:
+    namespace: "istio-system-knative-serving-istio"
   chartValues:
+    global:
+      istioNamespace: "istio-system-knative-serving-istio"
     resources:
       requests:
         cpu: 50m
@@ -102,7 +121,11 @@ istioIngressGateway:
         memory: 512Mi
 
 clusterLocalGateway:
+  helmChart:
+    namespace: "istio-system-knative-serving-istio"
   chartValues:
+    global:
+      istioNamespace: "istio-system-knative-serving-istio"
     resources:
       requests:
         cpu: 50m

--- a/charts/knative-serving-istio/files/run_test.sh
+++ b/charts/knative-serving-istio/files/run_test.sh
@@ -3,6 +3,8 @@ set -ex
 
 which kubectl > /dev/null 2>&1|| { echo "Kubectl not installed"; exit 1; }
 
+ISTIO_NAMESPACE="$1"
+
 cat << EOF > /tmp/knative_service.yaml
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -25,7 +27,7 @@ kubectl apply -f /tmp/knative_service.yaml
 kubectl wait ksvc/hello --for=condition=Ready --timeout=60s
 
 HOSTNAME=$(kubectl get ksvc hello -o jsonpath='{.status.url}' | awk -F '//' '{print $2}')
-LOAD_BALANCER_IP=$(kubectl get services -n istio-system istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+LOAD_BALANCER_IP=$(kubectl get services -n $ISTIO_NAMESPACE istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
 output=$(curl $LOAD_BALANCER_IP -o /dev/null -w "%{http_code}" -H "Host: $HOSTNAME")
 

--- a/charts/knative-serving-istio/templates/test-resources/job.yaml
+++ b/charts/knative-serving-istio/templates/test-resources/job.yaml
@@ -2,6 +2,7 @@
 {{- $serviceAccountName := "knative-net-istio-test-sa" }}
 {{- $resourceName := "knative-net-istio-test-job" }}
 {{- $configMap := "knative-net-istio-test-cm" }}
+{{- $istioNamespace := .Values.istioIngressGateway.helmChart.namespace }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -29,6 +30,8 @@ spec:
             - name: run-script
               mountPath: /scripts
           command: ["/scripts/run_test.sh"]
+          args:
+            - {{  $istioNamespace }}
       restartPolicy: Never
   backoffLimit: 10
 ---

--- a/charts/knative-serving-istio/values.yaml
+++ b/charts/knative-serving-istio/values.yaml
@@ -324,7 +324,7 @@ istiod:
   helmChart:
     repository: "https://istio-release.storage.googleapis.com/charts"
     chart: istiod
-    version: 1.13.4
+    version: 1.13.9
     release: istiod
     namespace: "istio-system"
   hook:
@@ -366,7 +366,7 @@ istioIngressGateway:
   helmChart:
     repository: "https://istio-release.storage.googleapis.com/charts"
     chart: gateway
-    version: 1.13.4
+    version: 1.13.9
     release: istio-ingress-gateway
     namespace: "istio-system"
     createNamespace: false
@@ -412,7 +412,7 @@ clusterLocalGateway:
   helmChart:
     repository: "https://istio-release.storage.googleapis.com/charts"
     chart: gateway
-    version: 1.13.4
+    version: 1.13.9
     release: cluster-local-gateway
     namespace: "istio-system"
     createNamespace: false


### PR DESCRIPTION
# Motivation
Test workflow ends up in a failed state when multiple charts are being updated at the same time which has istio as a common dependency.  For eg. If a PR has changes in caraml-routes and knative-serving-istio. Tests fail to install for routes because istio-system namespace is already created by knative-serving-istio chart. Since chart tester uses the same kind cluster to test.

To avoid this, Adding a different istio namespace for knative-serving-istio chart. This also needs the tests in the chart to use the namespace from the values file instead of hardcoding it to the test script.

Releasing this chart earlier to https://github.com/caraml-dev/helm-charts/pull/70 so that this released version can be used in the kserve chart, so that it passes the helm tests as well. 

# Modification
* Update helm tests to use istio namespace from values file.
* Update istio components version

# Checklist
- [x] Chart version bumped
- [x] README.md updated
