### PR TITLE
test: Knative update test dep

### DIFF
--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -8,7 +8,7 @@ Installs Knative Serving core and CRDs.
 
 ## Introduction
 
-This Helm chart installs [Knative Serving Core](https://knative.dev/docs/serving/) and it's CRDs. It is based off v1.3.2 of Knative serving release.
+This Helm chart installs [Knative Serving Core](https://knative.dev/docs/serving/) and it's CRDs.
 
 ## Prerequisites
 

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -8,7 +8,7 @@ Installs Knative Serving core and CRDs.
 
 ## Introduction
 
-This Helm chart installs [Knative Serving Core](https://knative.dev/docs/serving/) and it's CRDs.
+This Helm chart installs [Knative Serving Core](https://knative.dev/docs/serving/) and it's CRDs. It is based off v1.3.2 of Knative serving release.
 
 ## Prerequisites
 

--- a/charts/knative-serving-istio/Chart.lock
+++ b/charts/knative-serving-istio/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: knative-serving-core
   repository: https://caraml-dev.github.io/helm-charts
-  version: 1.1.2
+  version: 1.3.2
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
@@ -14,5 +14,5 @@ dependencies:
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
-digest: sha256:9408e353d51141b412b573ccfdc0239b9e34e9399a5a5875b1fbd7cc4d84690b
-generated: "2022-11-04T04:44:10.154368357Z"
+digest: sha256:e65632a01dfdd52c311bafafddf88b3ed2f9463990e87ab0b3c5e3758cccbb83
+generated: "2022-11-07T16:15:43.815261+08:00"

--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v2
-appVersion: v1.3.0
 dependencies:
 - alias: knativeServingCore
   condition: knativeServingCore.enabled
@@ -32,4 +31,4 @@ maintainers:
   name: caraml-dev
 name: knative-serving-istio
 type: application
-version: 1.3.9
+version: 1.3.10

--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: knativeServingCore.enabled
   name: knative-serving-core
   repository: https://caraml-dev.github.io/helm-charts
-  version: 1.1.2
+  version: 1.3.2
 - alias: istiod
   condition: istiod.enabled
   name: generic-dep-installer

--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -32,3 +32,4 @@ maintainers:
 name: knative-serving-istio
 type: application
 version: 1.3.10
+appVersion: "v1.3.0"

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,14 +1,14 @@
 # knative-serving-istio
 
 ---
-![Version: 1.3.9](https://img.shields.io/badge/Version-1.3.9-informational?style=flat-square)
+![Version: 1.3.10](https://img.shields.io/badge/Version-1.3.9-informational?style=flat-square)
 ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 Installs Knative-serving for Istio
 
 ## Introduction
 
-This Helm chart installs [Knative Serving Istio](https://knative.dev/docs/serving/) and it's CRDs.
+This Helm chart installs [Knative Serving Istio](https://knative.dev/docs/serving/) and it's CRDs. It is based off v1.3.0 of Knative Net Istio release.
 
 ## Prerequisites
 

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -8,7 +8,7 @@ Installs Knative-serving for Istio
 
 ## Introduction
 
-This Helm chart installs [Knative Serving Istio](https://knative.dev/docs/serving/) and it's CRDs. It is based off v1.3.0 of Knative Net Istio release.
+This Helm chart installs [Knative Serving Istio](https://knative.dev/docs/serving/) and it's CRDs.
 
 ## Prerequisites
 

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.3.10](https://img.shields.io/badge/Version-1.3.9-informational?style=flat-square)
+![Version: 1.3.10](https://img.shields.io/badge/Version-1.3.10-informational?style=flat-square)
 ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 Installs Knative-serving for Istio


### PR DESCRIPTION
# Motivation
Update the depedency version of knative-serving-istio, knative-serving-core  from 1.1.2 to 1.3.2

Version bump to 1.3.10 for serving-istio. Added to the readme, hopefully it can help to be clearer which knative release it originated from as we bump the minor versions.

# Modification
Updated readme and test chart test dep version

# Checklist
- [x] Chart version bumped
- [x] README.md updated
