### PR TITLE
fix(caraml-store): fix match label for serving component's service monitor

### DIFF
--- a/charts/caraml-store/Chart.yaml
+++ b/charts/caraml-store/Chart.yaml
@@ -20,4 +20,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: caraml-store
-version: 0.1.4
+version: 0.1.5

--- a/charts/caraml-store/README.md
+++ b/charts/caraml-store/README.md
@@ -1,6 +1,6 @@
 # caraml-store
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
 
 CaraML store registry: Feature registry for CaraML store.
 

--- a/charts/caraml-store/templates/serving/servicemonitor.yaml
+++ b/charts/caraml-store/templates/serving/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-{{- include "caraml-store.registry.selectorLabels" . | nindent 6 }}
+{{- include "caraml-store.serving.selectorLabels" . | nindent 6 }}
   endpoints:
     - path: /actuator/prometheus
     - targetPort: {{ .Values.serving.actuator.port }}


### PR DESCRIPTION
# Motivation
The match label for caraml serving's service monitor is currently wrongly set to regisry's.

# Modification
Update the match label to use the correct values.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
