### PR TITLE
fix(mlp): Ingress error due to missing pathType key

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.3.3
+version: 0.3.4

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
 
 MLP API
 

--- a/charts/mlp/templates/ingress.yaml
+++ b/charts/mlp/templates/ingress.yaml
@@ -14,9 +14,10 @@ spec:
       http:
         paths:
           - path: {{ .Values.ingress.path | default "/" }}
+            pathType: {{ .Values.ingress.pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ template "mlp.fullname" .}}
-                port: 
+                port:
                   number: {{ .Values.service.externalPort }}
 {{- end }}

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -75,9 +75,11 @@ deployment:
 
 ingress:
   enabled: false
-  # class:
-  # host:
+  # class: "nginx"
+  # host: "localhost"
   # path: "/"
+  # Ref for pathTypes https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+  # pathType: "Prefix"
 
 encryption:
   # encryption.key must be specified using --set flag.


### PR DESCRIPTION
# Motivation
Path type is mandatory while creating an ingress in kube. Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types. Ingress created in mlp did not have it in the template. This PR will add the key for the same. 

# Modification
* Add pathType to ingress template.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
