### PR TITLE
fix(knative-serving-core): Fix monitoring selector key and metrics port

### DIFF
--- a/charts/knative-serving-core/Chart.yaml
+++ b/charts/knative-serving-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: knative-serving-core
 description: Installs Knative Serving core and CRDs.
 type: application
-version: 1.3.2
+version: 1.3.3
 appVersion: "v1.3.2"
 maintainers:
   - name: caraml-dev

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -100,12 +100,11 @@ The following table lists the configurable parameters of the Knative Serving Cor
 | global.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | global.tolerations | list | `[]` | If specified, the pod's tolerations. ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | monitoring.allNamespaces | bool | `true` |  |
-| monitoring.enabled | bool | `false` |  |
+| monitoring.enabled | bool | `true` |  |
+| monitoring.podMonitor.metricPortName | string | `"metrics"` |  |
 | monitoring.podMonitor.metricRelabelings | object | `{}` |  |
 | monitoring.podMonitor.selector.matchExpressions[0].key | string | `"{{ .Values.monitoring.selectorKey }}"` |  |
 | monitoring.podMonitor.selector.matchExpressions[0].operator | string | `"Exists"` |  |
-| monitoring.podMonitor.userMetricPortName | string | `"metrics"` |  |
-| monitoring.podMonitor.userPortName | string | `"user-port"` |  |
 | monitoring.selectorKey | string | `"serving.knative.dev/release"` |  |
 | queueProxy.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/queue"` | Repository of the queue proxy image |
 | queueProxy.image.sha | string | `"2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"` | SHA256 of the queue proxy image, either provide tag or SHA (SHA will be given priority) |

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -100,13 +100,13 @@ The following table lists the configurable parameters of the Knative Serving Cor
 | global.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | global.tolerations | list | `[]` | If specified, the pod's tolerations. ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | monitoring.allNamespaces | bool | `true` |  |
-| monitoring.enabled | bool | `false` |  |
+| monitoring.enabled | bool | `true` |  |
 | monitoring.podMonitor.metricRelabelings | object | `{}` |  |
 | monitoring.podMonitor.selector.matchExpressions[0].key | string | `"{{ .Values.monitoring.selectorKey }}"` |  |
 | monitoring.podMonitor.selector.matchExpressions[0].operator | string | `"Exists"` |  |
-| monitoring.podMonitor.userMetricPortName | string | `"http-usermetric"` |  |
+| monitoring.podMonitor.userMetricPortName | string | `"metrics"` |  |
 | monitoring.podMonitor.userPortName | string | `"user-port"` |  |
-| monitoring.selectorKey | string | `"serving.knative.dev/revision"` |  |
+| monitoring.selectorKey | string | `"serving.knative.dev/release"` |  |
 | queueProxy.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/queue"` | Repository of the queue proxy image |
 | queueProxy.image.sha | string | `"2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"` | SHA256 of the queue proxy image, either provide tag or SHA (SHA will be given priority) |
 | queueProxy.image.tag | string | `""` | Tag of the queue proxy image, either provide tag or SHA (SHA will be given priority) |

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -1,7 +1,7 @@
 # knative-serving-core
 
 ---
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square)
+![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square)
 ![AppVersion: v1.3.2](https://img.shields.io/badge/AppVersion-v1.3.2-informational?style=flat-square)
 
 Installs Knative Serving core and CRDs.

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -100,7 +100,7 @@ The following table lists the configurable parameters of the Knative Serving Cor
 | global.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | global.tolerations | list | `[]` | If specified, the pod's tolerations. ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | monitoring.allNamespaces | bool | `true` |  |
-| monitoring.enabled | bool | `true` |  |
+| monitoring.enabled | bool | `false` |  |
 | monitoring.podMonitor.metricRelabelings | object | `{}` |  |
 | monitoring.podMonitor.selector.matchExpressions[0].key | string | `"{{ .Values.monitoring.selectorKey }}"` |  |
 | monitoring.podMonitor.selector.matchExpressions[0].operator | string | `"Exists"` |  |

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -100,7 +100,7 @@ The following table lists the configurable parameters of the Knative Serving Cor
 | global.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | global.tolerations | list | `[]` | If specified, the pod's tolerations. ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | monitoring.allNamespaces | bool | `true` |  |
-| monitoring.enabled | bool | `true` |  |
+| monitoring.enabled | bool | `false` |  |
 | monitoring.podMonitor.metricPortName | string | `"metrics"` |  |
 | monitoring.podMonitor.metricRelabelings | object | `{}` |  |
 | monitoring.podMonitor.selector.matchExpressions[0].key | string | `"{{ .Values.monitoring.selectorKey }}"` |  |

--- a/charts/knative-serving-core/templates/monitoring/monitoring.yaml
+++ b/charts/knative-serving-core/templates/monitoring/monitoring.yaml
@@ -14,7 +14,7 @@ spec:
 {{ tpl (toYaml .Values.monitoring.podMonitor.selector | indent 4) . }}
 {{- end }}
   podMetricsEndpoints:
-    - port: {{ .Values.monitoring.podMonitor.userMetricPortName }}
+    - port: {{ .Values.monitoring.podMonitor.metricPortName }}
 {{- if .Values.monitoring.podMonitor.metricRelabelings }}
       metricRelabelings:
 {{ tpl (toYaml .Values.monitoring.podMonitor.metricRelabelings | indent 6) . }}

--- a/charts/knative-serving-core/values.yaml
+++ b/charts/knative-serving-core/values.yaml
@@ -194,10 +194,9 @@ queueProxy:
     sha: "2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"
 
 monitoring:
-  enabled: false
+  enabled: true
   podMonitor:
-    userMetricPortName: metrics
-    userPortName: user-port
+    metricPortName: metrics
     selector:
       matchExpressions:
         - key: "{{ .Values.monitoring.selectorKey }}"

--- a/charts/knative-serving-core/values.yaml
+++ b/charts/knative-serving-core/values.yaml
@@ -194,16 +194,16 @@ queueProxy:
     sha: "2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"
 
 monitoring:
-  enabled: false
+  enabled: true
   podMonitor:
-    userMetricPortName: http-usermetric
+    userMetricPortName: metrics
     userPortName: user-port
     selector:
       matchExpressions:
         - key: "{{ .Values.monitoring.selectorKey }}"
           operator: Exists
     metricRelabelings: {}
-  selectorKey: serving.knative.dev/revision
+  selectorKey: serving.knative.dev/release
   allNamespaces: true
 
 autoscalerHpa:

--- a/charts/knative-serving-core/values.yaml
+++ b/charts/knative-serving-core/values.yaml
@@ -194,7 +194,7 @@ queueProxy:
     sha: "2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"
 
 monitoring:
-  enabled: true
+  enabled: false
   podMonitor:
     metricPortName: metrics
     selector:

--- a/charts/knative-serving-core/values.yaml
+++ b/charts/knative-serving-core/values.yaml
@@ -194,7 +194,7 @@ queueProxy:
     sha: "2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"
 
 monitoring:
-  enabled: true
+  enabled: false
   podMonitor:
     userMetricPortName: metrics
     userPortName: user-port


### PR DESCRIPTION
# Motivation
Monitoring values are misconfigured with the wrong selector key and port name.

# Modification
- Use a standard selector key for pod monitors created for the knative-core chart. 
- The port name for metrics is updated to the latest.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
