### PR TITLE
fix(caraml-store): fix endpoint for service monitor

### DIFF
--- a/charts/caraml-store/Chart.yaml
+++ b/charts/caraml-store/Chart.yaml
@@ -20,4 +20,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: caraml-store
-version: 0.1.5
+version: 0.1.6

--- a/charts/caraml-store/README.md
+++ b/charts/caraml-store/README.md
@@ -1,6 +1,6 @@
 # caraml-store
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
 
 CaraML store registry: Feature registry for CaraML store.
 

--- a/charts/caraml-store/templates/registry/servicemonitor.yaml
+++ b/charts/caraml-store/templates/registry/servicemonitor.yaml
@@ -11,5 +11,5 @@ spec:
 {{- include "caraml-store.registry.selectorLabels" . | nindent 6 }}
   endpoints:
     - path: /actuator/prometheus
-    - targetPort: {{ .Values.registry.actuator.port }}
+      targetPort: {{ .Values.registry.actuator.port }}
 {{- end }}

--- a/charts/caraml-store/templates/serving/servicemonitor.yaml
+++ b/charts/caraml-store/templates/serving/servicemonitor.yaml
@@ -11,5 +11,5 @@ spec:
 {{- include "caraml-store.serving.selectorLabels" . | nindent 6 }}
   endpoints:
     - path: /actuator/prometheus
-    - targetPort: {{ .Values.serving.actuator.port }}
+      targetPort: {{ .Values.serving.actuator.port }}
 {{- end }}


### PR DESCRIPTION
# Motivation
Due to a typo the endpoint is not being set correctly for the servicemonitor.

# Modification
Updated the endpoint to the correct value.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
