### PR TITLE
feat(knative-serving-istio): Add service and pod monitors for istiod, gateways and knative serving pods

### DIFF
--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
   name: caraml-dev
 name: knative-serving-istio
 type: application
-version: 1.3.11
+version: 1.3.12

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -192,16 +192,11 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | monitoring.istioEnvoy.enabled | bool | `false` |  |
 | monitoring.istioEnvoy.envoyStats[0].path | string | `"/stats/prometheus"` |  |
 | monitoring.istioEnvoy.envoyStats[0].port | string | `".*-envoy-prom"` |  |
-| monitoring.istioEnvoy.metricRelabelings[0].action | string | `"labeldrop"` |  |
-| monitoring.istioEnvoy.metricRelabelings[0].regex | string | `"(.*_canonical_.*|connection_security_policy|destination_app|destination_cluster|destination_principal|destination_service|destination_service_namespace|destination_version|destination_workload|response_flags|source_app|source_cluster|source_principal|source_version|source_workload|source_workload_namespace)"` |  |
 | monitoring.istioEnvoy.namespaceSelector | object | `{}` |  |
 | monitoring.istioEnvoy.selector.matchExpressions[0].key | string | `"service.istio.io/canonical-name"` |  |
 | monitoring.istioEnvoy.selector.matchExpressions[0].operator | string | `"Exists"` |  |
 | monitoring.serving.allNamespaces | bool | `true` |  |
 | monitoring.serving.enabled | bool | `false` |  |
-| monitoring.serving.metricRelabelingRegex | string | `"(gojek_com_team|gojek_com_stream|gojek_com_orchestrator|gojek_com_environment|gojek_com_app)"` |  |
-| monitoring.serving.podMonitor.metricRelabelings[0].action | string | `"drop"` |  |
-| monitoring.serving.podMonitor.metricRelabelings[0].regex | string | `"{{ .Values.monitoring.serving.metricRelabelingRegex }}"` |  |
 | monitoring.serving.podMonitor.selector.matchExpressions[0].key | string | `"serving.knative.dev/revision"` |  |
 | monitoring.serving.podMonitor.selector.matchExpressions[0].operator | string | `"Exists"` |  |
 | monitoring.serving.podMonitor.userMetricPortName | string | `"http-usermetric"` |  |

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -137,6 +137,9 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | istiod.helmChart.repository | string | `"https://istio-release.storage.googleapis.com/charts"` |  |
 | istiod.helmChart.version | string | `"1.13.9"` |  |
 | istiod.hook.weight | int | `0` |  |
+| istiod.monitoring.enabled | bool | `true` |  |
+| istiod.monitoring.namespace | string | `"istio-system"` |  |
+| istiod.monitoring.selector.matchLabels.app | string | `"istiod"` |  |
 | knativeServingCore.activator.autoscaling.enabled | bool | `false` | Enables autoscaling for activator deployment. |
 | knativeServingCore.activator.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/activator"` | Repository of the activator image |
 | knativeServingCore.activator.image.sha | string | `"ca607f73e5daef7f3db0358e145220f8423e93c20ee7ea9f5595f13bd508289a"` | SHA256 of the activator image, either provide tag or SHA (SHA will be given priority) |
@@ -186,6 +189,23 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | knativeServingCore.webhook.image.tag | string | `""` | Tag of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | knativeServingCore.webhook.replicaCount | int | `1` | Number of replicas for the webhook deployment. |
 | knativeServingCore.webhook.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| monitoring.istioEnvoy.enabled | bool | `true` |  |
+| monitoring.istioEnvoy.envoyStats[0].path | string | `"/stats/prometheus"` |  |
+| monitoring.istioEnvoy.envoyStats[0].port | string | `".*-envoy-prom"` |  |
+| monitoring.istioEnvoy.metricRelabelings[0].action | string | `"labeldrop"` |  |
+| monitoring.istioEnvoy.metricRelabelings[0].regex | string | `"(.*_canonical_.*|connection_security_policy|destination_app|destination_cluster|destination_principal|destination_service|destination_service_namespace|destination_version|destination_workload|response_flags|source_app|source_cluster|source_principal|source_version|source_workload|source_workload_namespace)"` |  |
+| monitoring.istioEnvoy.namespaceSelector | object | `{}` |  |
+| monitoring.istioEnvoy.selector.matchExpressions[0].key | string | `"service.istio.io/canonical-name"` |  |
+| monitoring.istioEnvoy.selector.matchExpressions[0].operator | string | `"Exists"` |  |
+| monitoring.serving.allNamespaces | bool | `true` |  |
+| monitoring.serving.enabled | bool | `true` |  |
+| monitoring.serving.metricRelabelingRegex | string | `"(gojek_com_team|gojek_com_stream|gojek_com_orchestrator|gojek_com_environment|gojek_com_app)"` |  |
+| monitoring.serving.podMonitor.metricRelabelings[0].action | string | `"drop"` |  |
+| monitoring.serving.podMonitor.metricRelabelings[0].regex | string | `"{{ .Values.monitoring.serving.metricRelabelingRegex }}"` |  |
+| monitoring.serving.podMonitor.selector.matchExpressions[0].key | string | `"serving.knative.dev/revision"` |  |
+| monitoring.serving.podMonitor.selector.matchExpressions[0].operator | string | `"Exists"` |  |
+| monitoring.serving.podMonitor.userMetricPortName | string | `"http-usermetric"` |  |
+| monitoring.serving.podMonitor.userPortName | string | `"user-port"` |  |
 | revision | string | `""` |  |
 | webhook.image.repository | string | `"gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook"` | Repository of the webhook image |
 | webhook.image.sha | string | `"75d502bdff93e9c0e4611c2747d868b8d471f8d3a0402394de76ec2d98b89ce3"` | SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority) |

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.3.11](https://img.shields.io/badge/Version-1.3.11-informational?style=flat-square)
+![Version: 1.3.12](https://img.shields.io/badge/Version-1.3.12-informational?style=flat-square)
 ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 Installs Knative-serving for Istio

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -137,7 +137,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | istiod.helmChart.repository | string | `"https://istio-release.storage.googleapis.com/charts"` |  |
 | istiod.helmChart.version | string | `"1.13.9"` |  |
 | istiod.hook.weight | int | `0` |  |
-| istiod.monitoring.enabled | bool | `true` |  |
+| istiod.monitoring.enabled | bool | `false` |  |
 | istiod.monitoring.namespace | string | `"istio-system"` |  |
 | istiod.monitoring.selector.matchLabels.app | string | `"istiod"` |  |
 | knativeServingCore.activator.autoscaling.enabled | bool | `false` | Enables autoscaling for activator deployment. |
@@ -189,7 +189,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | knativeServingCore.webhook.image.tag | string | `""` | Tag of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | knativeServingCore.webhook.replicaCount | int | `1` | Number of replicas for the webhook deployment. |
 | knativeServingCore.webhook.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
-| monitoring.istioEnvoy.enabled | bool | `true` |  |
+| monitoring.istioEnvoy.enabled | bool | `false` |  |
 | monitoring.istioEnvoy.envoyStats[0].path | string | `"/stats/prometheus"` |  |
 | monitoring.istioEnvoy.envoyStats[0].port | string | `".*-envoy-prom"` |  |
 | monitoring.istioEnvoy.metricRelabelings[0].action | string | `"labeldrop"` |  |
@@ -198,7 +198,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | monitoring.istioEnvoy.selector.matchExpressions[0].key | string | `"service.istio.io/canonical-name"` |  |
 | monitoring.istioEnvoy.selector.matchExpressions[0].operator | string | `"Exists"` |  |
 | monitoring.serving.allNamespaces | bool | `true` |  |
-| monitoring.serving.enabled | bool | `true` |  |
+| monitoring.serving.enabled | bool | `false` |  |
 | monitoring.serving.metricRelabelingRegex | string | `"(gojek_com_team|gojek_com_stream|gojek_com_orchestrator|gojek_com_environment|gojek_com_app)"` |  |
 | monitoring.serving.podMonitor.metricRelabelings[0].action | string | `"drop"` |  |
 | monitoring.serving.podMonitor.metricRelabelings[0].regex | string | `"{{ .Values.monitoring.serving.metricRelabelingRegex }}"` |  |

--- a/charts/knative-serving-istio/templates/deployments/net-istio-controller.yaml
+++ b/charts/knative-serving-istio/templates/deployments/net-istio-controller.yaml
@@ -35,9 +35,9 @@ spec:
         app: net-istio-controller
         serving.knative.dev/release: "v1.0.0"
         {{- include "knative-net-istio.labels" . | nindent 8 }}
-      {{- if .Values.config.defaults }}
-        {{- toYaml .Values.global.extraPodLabels | nindent 8 }}
-      {{- end }}
+        {{- if .Values.global.extraPodLabels }}
+          {{- toYaml .Values.global.extraPodLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: controller
       {{- if .Values.global.nodeSelector }}

--- a/charts/knative-serving-istio/templates/deployments/net-istio-webhook.yaml
+++ b/charts/knative-serving-istio/templates/deployments/net-istio-webhook.yaml
@@ -30,6 +30,9 @@ spec:
         app: net-istio-webhook
         role: net-istio-webhook
         {{- include "knative-net-istio.labels" . | nindent 8 }}
+        {{- if .Values.global.extraPodLabels }}
+          {{- toYaml .Values.global.extraPodLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: controller
       {{- if .Values.global.nodeSelector }}

--- a/charts/knative-serving-istio/templates/monitoring/envoy-stats-metrics.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/envoy-stats-metrics.yaml
@@ -18,8 +18,4 @@ spec:
 {{- end }}
   podMetricsEndpoints:
 {{ toYaml .Values.monitoring.istioEnvoy.envoyStats | indent 4 }}
-{{- if .Values.monitoring.istioEnvoy.metricRelabelings }}
-      metricRelabelings:
-{{ toYaml .Values.monitoring.istioEnvoy.metricRelabelings | indent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/knative-serving-istio/templates/monitoring/envoy-stats-metrics.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/envoy-stats-metrics.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: envoy-stats-metrics
+  name: envoy-stats-metrics-monitor
   namespace: {{ .Values.monitoring.istioSystemNS }}
   labels:
 {{ include "monitoring.labels" . | indent 4 }}

--- a/charts/knative-serving-istio/templates/monitoring/envoy-stats-metrics.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/envoy-stats-metrics.yaml
@@ -1,0 +1,25 @@
+---
+{{- if .Values.monitoring.istioEnvoy.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-stats-metrics
+  namespace: {{ .Values.monitoring.istioSystemNS }}
+  labels:
+{{ include "monitoring.labels" . | indent 4 }}
+spec:
+{{- if .Values.monitoring.istioEnvoy.selector }}
+  selector:
+{{ toYaml .Values.monitoring.istioEnvoy.selector | indent 4 }}
+{{- end }}
+{{- if .Values.monitoring.istioEnvoy.namespaceSelector }}
+  namespaceSelector:
+{{ toYaml .Values.monitoring.istioEnvoy.namespaceSelector | indent 4 }}
+{{- end }}
+  podMetricsEndpoints:
+{{ toYaml .Values.monitoring.istioEnvoy.envoyStats | indent 4 }}
+{{- if .Values.monitoring.istioEnvoy.metricRelabelings }}
+      metricRelabelings:
+{{ toYaml .Values.monitoring.istioEnvoy.metricRelabelings | indent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/knative-serving-istio/templates/monitoring/istiod-service-monitor.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/istiod-service-monitor.yaml
@@ -1,0 +1,17 @@
+---
+{{- if .Values.istiod.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod
+  namespace: {{ .Values.istiod.monitoring.namespace }}
+  labels:
+{{ include "knative-net-istio.labels" . | indent 4 }}
+spec:
+{{- if .Values.istiod.monitoring.selector }}
+  selector:
+{{ toYaml .Values.istiod.monitoring.selector | indent 4 }}
+{{- end }}
+  endpoints:
+    - port: http-monitoring
+{{- end }}

--- a/charts/knative-serving-istio/templates/monitoring/istiod-service-monitor.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/istiod-service-monitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: istiod
+  name: istiod-monitor
   namespace: {{ .Values.istiod.monitoring.namespace }}
   labels:
 {{ include "knative-net-istio.labels" . | indent 4 }}

--- a/charts/knative-serving-istio/templates/monitoring/knative-serving-pod-monitor.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/knative-serving-pod-monitor.yaml
@@ -23,8 +23,4 @@ spec:
 {{ tpl (toYaml .Values.monitoring.serving.podMonitor.metricRelabelings | indent 6) . }}
 {{- end }}
     - port: {{ .Values.monitoring.serving.podMonitor.userPortName }}
-{{- if .Values.monitoring.serving.podMonitor.metricRelabelings }}
-      metricRelabelings:
-{{ tpl (toYaml .Values.monitoring.serving.podMonitor.metricRelabelings | indent 6) . }}
-{{- end }}
 {{- end }}

--- a/charts/knative-serving-istio/templates/monitoring/knative-serving-pod-monitor.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/knative-serving-pod-monitor.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.monitoring.serving.enabled }}
+# Queue proxy PodMonitor
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: knative-pod
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "monitoring.labels" . | indent 4 }}
+spec:
+{{- if .Values.monitoring.serving.allNamespaces }}
+  namespaceSelector:
+    any: true
+{{- end }}
+{{- if .Values.monitoring.serving.podMonitor.selector }}
+  selector:
+{{ tpl (toYaml .Values.monitoring.serving.podMonitor.selector | indent 4) . }}
+{{- end }}
+  podMetricsEndpoints:
+    - port: {{ .Values.monitoring.serving.podMonitor.userMetricPortName }}
+{{- if .Values.monitoring.serving.podMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ tpl (toYaml .Values.monitoring.serving.podMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+    - port: {{ .Values.monitoring.serving.podMonitor.userPortName }}
+{{- if .Values.monitoring.serving.podMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ tpl (toYaml .Values.monitoring.serving.podMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- end }}

--- a/charts/knative-serving-istio/templates/monitoring/knative-serving-pod-monitor.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/knative-serving-pod-monitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: knative-pod
+  name: knative-serving-pod-monitor
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "monitoring.labels" . | indent 4 }}

--- a/charts/knative-serving-istio/values.yaml
+++ b/charts/knative-serving-istio/values.yaml
@@ -337,7 +337,7 @@ istiod:
     meshConfig:
       enableTracing: false
   monitoring:
-    enabled: true
+    enabled: false
     namespace: "istio-system"
     selector:
       matchLabels:
@@ -445,7 +445,7 @@ clusterLocalGateway:
 ############################################################
 monitoring:
   istioEnvoy:
-    enabled: true
+    enabled: false
     namespaceSelector: {}
     selector:
       matchExpressions:
@@ -459,7 +459,7 @@ monitoring:
         action: labeldrop
   serving:
     # Install Monitoring CRs related to knative service pods
-    enabled: true
+    enabled: false
     podMonitor:
       userMetricPortName: http-usermetric
       userPortName: user-port

--- a/charts/knative-serving-istio/values.yaml
+++ b/charts/knative-serving-istio/values.yaml
@@ -454,9 +454,6 @@ monitoring:
     envoyStats:
       - port: ".*-envoy-prom"
         path: /stats/prometheus
-    metricRelabelings:
-      - regex: "(.*_canonical_.*|connection_security_policy|destination_app|destination_cluster|destination_principal|destination_service|destination_service_namespace|destination_version|destination_workload|response_flags|source_app|source_cluster|source_principal|source_version|source_workload|source_workload_namespace)"
-        action: labeldrop
   serving:
     # Install Monitoring CRs related to knative service pods
     enabled: false
@@ -467,8 +464,4 @@ monitoring:
         matchExpressions:
           - key: "serving.knative.dev/revision"
             operator: Exists
-      metricRelabelings:
-        - action: drop
-          regex: "{{ .Values.monitoring.serving.metricRelabelingRegex }}"
-    metricRelabelingRegex: (gojek_com_team|gojek_com_stream|gojek_com_orchestrator|gojek_com_environment|gojek_com_app)
     allNamespaces: true

--- a/charts/knative-serving-istio/values.yaml
+++ b/charts/knative-serving-istio/values.yaml
@@ -336,6 +336,13 @@ istiod:
         targetAverageUtilization: 80
     meshConfig:
       enableTracing: false
+  monitoring:
+    enabled: true
+    namespace: "istio-system"
+    selector:
+      matchLabels:
+        app: istiod
+
 ############################################################
 # istioIngressGateway - installed using helm-dep-installer chart
 ############################################################
@@ -433,3 +440,35 @@ clusterLocalGateway:
           name: http2
         - port: 443
           name: https
+############################################################
+# Monitoring related - Prometheus Service Monitors and Pod Monitors
+############################################################
+monitoring:
+  istioEnvoy:
+    enabled: true
+    namespaceSelector: {}
+    selector:
+      matchExpressions:
+        - key: service.istio.io/canonical-name
+          operator: Exists
+    envoyStats:
+      - port: ".*-envoy-prom"
+        path: /stats/prometheus
+    metricRelabelings:
+      - regex: "(.*_canonical_.*|connection_security_policy|destination_app|destination_cluster|destination_principal|destination_service|destination_service_namespace|destination_version|destination_workload|response_flags|source_app|source_cluster|source_principal|source_version|source_workload|source_workload_namespace)"
+        action: labeldrop
+  serving:
+    # Install Monitoring CRs related to knative service pods
+    enabled: true
+    podMonitor:
+      userMetricPortName: http-usermetric
+      userPortName: user-port
+      selector:
+        matchExpressions:
+          - key: "serving.knative.dev/revision"
+            operator: Exists
+      metricRelabelings:
+        - action: drop
+          regex: "{{ .Values.monitoring.serving.metricRelabelingRegex }}"
+    metricRelabelingRegex: (gojek_com_team|gojek_com_stream|gojek_com_orchestrator|gojek_com_environment|gojek_com_app)
+    allNamespaces: true


### PR DESCRIPTION
# Motivation
Add Prometheus Monitors for Istiod service, ClusterGateway, IstioIngressgateway (via envoy-state-metrics), and the knative serving pods that are created for the predictors.  These monitors are supposed to be used in conjunction with the Prometheus stack for monitoring. These will be disabled by default When needed users can install Prometheus stack and enable these monitors to pull pod-exposed metrics. 

# Modification
* Add istiod service monitor
* Add envoy-state-metrics pod monitor 
* Add queue-proxy pod monitor for knative serving pods.


# Checklist
- [x] Chart version bumped
- [x] README.md updated
