### PR TITLE
fix(common): Fix the istio lookup helper function

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,10 +15,10 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.4"
+appVersion: "0.2.5"

--- a/charts/common/templates/_routes.tpl
+++ b/charts/common/templates/_routes.tpl
@@ -31,8 +31,7 @@ subdomain, domain
 {{- define "common.istio-lookup" }}
 {{- $istioLookupResult := "" }}
 {{- $outer := .istioLookUp | default dict -}}
-{{- $inner := $outer.inner | default dict -}}
-{{- if and (hasKey $inner "namespace") (hasKey $inner "name") }}
+{{- if and (hasKey $outer "namespace") (hasKey $outer "name") }}
 {{- $istioLookupResult = (lookup "v1" "Service" .istioLookUp.namespace .istioLookUp.name ) }}
 {{- end }}
 {{- if $istioLookupResult }}


### PR DESCRIPTION
# Motivation
The helper function(`common.istio-lookup`) while trying to check the relevant key present in the context to do a lookup of istioIP, Was looking at an empty map always, hence getting the domain empty for the helper func (`common.get-external-hostname`

# Modification
* Fix the if condition to check the right map for keys to be present.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
