### PR TITLE
fix(kserve): fix redundant labels in kserve sa

### DIFF
--- a/charts/kserve/Chart.yaml
+++ b/charts/kserve/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
   name: caraml-dev
 name: kserve
 type: application
-version: 0.8.14
+version: 0.8.15

--- a/charts/kserve/README.md
+++ b/charts/kserve/README.md
@@ -1,7 +1,7 @@
 # kserve
 
 ---
-![Version: 0.8.14](https://img.shields.io/badge/Version-0.8.14-informational?style=flat-square)
+![Version: 0.8.15](https://img.shields.io/badge/Version-0.8.15-informational?style=flat-square)
 ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for installing Kserve

--- a/charts/kserve/templates/serviceaccount.yaml
+++ b/charts/kserve/templates/serviceaccount.yaml
@@ -2,8 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: kserve-controller-manager
-    app.kubernetes.io/managed-by: kserve-controller-manager
-    app.kubernetes.io/name: kserve-controller-manager
     {{- include "kserve.labels" . | nindent 4 }}
   name: kserve-controller-manager


### PR DESCRIPTION
# Motivation
Redundant labels are causing validation errors in ArgoCD:
```
rpc error: code = Unknown desc = Manifest generation error (cached): plugin sidecar failed. error generating manifests in cmp: 
rpc error: code = Unknown desc = error generating manifests: `sh -c helm template ${ARGOCD_APP_NAME} --version ${ARGOCD_ENV_HELM_CHART_VERSION} --repo ${ARGOCD_ENV_HELM_CHART_REPO} --namespace ${ARGOCD_APP_NAMESPACE} ${ARGOCD_ENV_HELM_CHART_NAME} -f ${ARGOCD_ENV_HELM_VALUES_FILE} > all.yaml && kubectl kustomize .`

failed exit status 1: error: map[string]interface {}(nil): yaml: unmarshal errors: line 11: mapping key "app.kubernetes.io/instance" already defined at line 6 line 13: mapping key "app.kubernetes.io/managed-by" already defined at line 7 line 10: mapping key "app.kubernetes.io/name" already defined at line 8
```

# Modification
Remove redundant labels

# Checklist
- [x] Chart version bumped
- [x] README.md updated
