### PR TITLE
refactor(mlp): Support configuration to be passed via ConfigMap

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.7.1
+appVersion: 1.8.0
 dependencies:
 - condition: postgresql.enabled
   name: postgresql

--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.3.4
+version: 0.4.0

--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.8.0
+appVersion: 1.7.1
 dependencies:
 - condition: postgresql.enabled
   name: postgresql

--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.7.1
+appVersion: v1.7.4-build.5-ac5d3eb
 dependencies:
 - condition: postgresql.enabled
   name: postgresql

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
 
 MLP API
 
@@ -24,7 +24,7 @@ MLP API
 | deployment.apiHost | string | `"http://mlp/v1"` |  |
 | deployment.authorization.enabled | bool | `false` |  |
 | deployment.authorization.serverUrl | string | `"http://mlp-authorization-keto"` |  |
-| deployment.docs | list | `[{"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},{"href":"https://github.com/gojek/turing","label":"Turing User Guide"},{"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"}]` | Documentation list for caraml components, Added as part of env variables. |
+| deployment.docs | list | `[{"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},{"href":"https://github.com/gojek/turing","label":"Turing User Guide"},{"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"}]` | Documentation list for caraml components |
 | deployment.environment | string | `"production"` |  |
 | deployment.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"gojek/mlp","tag":"v1.7.1"}` | mlp image related configs |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` |  |
@@ -34,8 +34,7 @@ MLP API
 | deployment.readinessProbe.path | string | `"/v1/internal/ready"` |  |
 | deployment.replicaCount | int | `1` |  |
 | deployment.resources | object | `{}` | Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/ |
-| deployment.streams | list | `["promotion-marketing","operation-strategy","business-analyst"]` | Streams list |
-| deployment.teams | list | `["marketing","operation","business"]` | teams list |
+| deployment.streams | object | `{"business":["operations"],"marketing":["promotions","growth"]}` | Streams list |
 | deployment.ui.clockworkHomepage | string | `"http://clockwork.dev"` |  |
 | deployment.ui.feastCoreApi | string | `"http://feast.dev/v1"` |  |
 | deployment.ui.feastHomepage | string | `"http://feast.dev"` |  |

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![AppVersion: v1.7.4-build.5-ac5d3eb](https://img.shields.io/badge/AppVersion-v1.7.4--build.5--ac5d3eb-informational?style=flat-square)
 
 MLP API
 
@@ -26,7 +26,7 @@ MLP API
 | deployment.authorization.serverUrl | string | `"http://mlp-authorization-keto"` |  |
 | deployment.docs | list | `[{"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},{"href":"https://github.com/gojek/turing","label":"Turing User Guide"},{"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"}]` | Documentation list for caraml components |
 | deployment.environment | string | `"production"` |  |
-| deployment.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"gojek/mlp","tag":"v1.7.1"}` | mlp image related configs |
+| deployment.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"gojek/mlp","tag":"v1.7.4-build.5-ac5d3eb"}` | mlp image related configs |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` |  |
 | deployment.mlflowTrackingUrl | string | `"http://mlflow.mlp"` |  |
 | deployment.oauthClientID | string | `""` | OAuth client id for login |

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -23,16 +23,16 @@ Generated names
     {{- if .Values.nameOverride -}}
         {{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
-        {{- printf "%s" (include "mlp.resource-prefix" .) | trunc 63 | trimSuffix "-" -}}
+        {{- printf "%s" (include "mlp.name" .) | trunc 63 | trimSuffix "-" -}}
     {{- end -}}
 {{- end -}}
 
 {{- define "mlp.config-cm-name" -}}
-    {{- printf "%s-config" (include "mlp.resource-prefix" .) | trunc 63 | trimSuffix "-" -}}
+    {{- printf "%s-config" (include "mlp.name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "mlp.encryption-key-name" -}}
-    {{- printf "%s-encryption-key" (include "mlp.resource-prefix" .) | trunc 63 | trimSuffix "-" -}}
+    {{- printf "%s-encryption-key" (include "mlp.name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -23,7 +23,7 @@ Generated names
     {{- if .Values.nameOverride -}}
         {{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
-        {{- printf "%s" (include "mlp.name" .) | trunc 63 | trimSuffix "-" -}}
+        {{- printf "%s" (include "mlp.resource-prefix" .) | trunc 63 | trimSuffix "-" -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -27,6 +27,10 @@ Generated names
     {{- end -}}
 {{- end -}}
 
+{{- define "mlp.config-cm-name" -}}
+    {{- printf "%s-config" (include "mlp.resource-prefix" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "mlp.encryption-key-name" -}}
     {{- printf "%s-encryption-key" (include "mlp.resource-prefix" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/mlp/templates/configmap.yaml
+++ b/charts/mlp/templates/configmap.yaml
@@ -1,0 +1,60 @@
+{{- $globOauthClientID := include "common.get-oauth-client" .Values.global }}
+{{- $globApiHost := include "common.get-component-value" (list .Values.global "mlp"  (list "vsPrefix" "apiPrefix")) }}
+{{- $globFeastApi := include "common.get-component-value" (list .Values.global "feast" (list "vsPrefix" "apiPrefix")) }}
+{{- $globMerlinApi := include "common.get-component-value" (list .Values.global "merlin" (list "vsPrefix" "apiPrefix")) }}
+{{- $globTuringApi := include "common.get-component-value" (list .Values.global "turing" (list "vsPrefix" "apiPrefix")) }}
+{{- $globFeastUI := include "common.get-component-value" (list .Values.global "feast" (list "uiPrefix")) }}
+{{- $globMerlinUI := include "common.get-component-value" (list .Values.global "merlin" (list "uiPrefix")) }}
+{{- $globTuringUI := include "common.get-component-value" (list .Values.global "turing" (list "uiPrefix")) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "mlp.config-cm-name" . }}
+  labels:
+    {{- include "mlp.labels" . | nindent 4 }}
+data:
+  mlp-config.yaml: |
+    APIHost: {{ include "common.set-value" (list .Values.deployment.apiHost $globApiHost) | quote }}
+
+    Environment: {{ .Values.deployment.environment }}
+
+    Port: {{ .Values.service.internalPort }}}
+
+    SentryDSN: {{ .Values.deployment.sentryDSN }}
+
+    OauthClientID: {{ include "common.set-value" (list .Values.deployment.oauthClientID $globOauthClientID) | quote }}
+
+    Authorization:
+      Enabled: {{ .Values.deployment.authorization.enabled }}
+      {{- if .Values.deployment.authorization.enabled }}
+      KetoServerURL: {{ default "" .Values.deployment.authorization.serverUrl }}
+      {{- end }}
+
+    Database:
+      Host: {{ template "postgres.host" . }}
+      User: {{ template "postgres.username" . }}
+      Database: {{ template "postgres.database" . }}
+
+    {{- if .Values.deployment.docs }}
+    Docs:
+      {{ toYaml .Values.deployment.streams | indent 6 }}
+    {{- end }}
+
+    Mlflow:
+      TrackingURL: {{ .Values.deployment.mlflowTrackingUrl }}
+
+    {{- if .Values.deployment.streams }}
+    Streams:
+      {{ toYaml .Values.deployment.streams | indent 6 }}
+    {{- end }}
+
+    UI:
+      FeastCoreAPI: {{ include "common.set-value" (list .Values.deployment.ui.feastCoreApi $globFeastApi) | quote }}
+      MerlinAPI: {{ include "common.set-value" (list .Values.deployment.ui.merlinApi $globMerlinApi) | quote }}
+      TuringAPI: {{ include "common.set-value" (list .Values.deployment.ui.turingApi $globTuringApi) | quote }}
+      ClockworkUIHomepage: "{{ .Values.deployment.ui.clockworkHomepage }}"
+      FeastUIHomepage: {{ include "common.set-value" (list .Values.deployment.ui.feastHomepage $globFeastUI) | quote }}
+      KubeflowUIHomepage: "{{ .Values.deployment.ui.kubeflowHomepage }}"
+      MerlinUIHomepage: {{ include "common.set-value" (list .Values.deployment.ui.merlinHomepage $globMerlinUI) | quote }}
+      TuringUIHomepage: {{ include "common.set-value" (list .Values.deployment.ui.turingHomepage $globTuringUI) | quote }}

--- a/charts/mlp/templates/configmap.yaml
+++ b/charts/mlp/templates/configmap.yaml
@@ -16,39 +16,29 @@ metadata:
 data:
   mlp-config.yaml: |
     APIHost: {{ include "common.set-value" (list .Values.deployment.apiHost $globApiHost) | quote }}
-
     Environment: {{ .Values.deployment.environment }}
-
-    Port: {{ .Values.service.internalPort }}}
-
+    Port: {{ .Values.service.internalPort }}
     SentryDSN: {{ .Values.deployment.sentryDSN }}
-
     OauthClientID: {{ include "common.set-value" (list .Values.deployment.oauthClientID $globOauthClientID) | quote }}
-
     Authorization:
       Enabled: {{ .Values.deployment.authorization.enabled }}
       {{- if .Values.deployment.authorization.enabled }}
       KetoServerURL: {{ default "" .Values.deployment.authorization.serverUrl }}
       {{- end }}
-
     Database:
       Host: {{ template "postgres.host" . }}
       User: {{ template "postgres.username" . }}
       Database: {{ template "postgres.database" . }}
-
     {{- if .Values.deployment.docs }}
     Docs:
-      {{ toYaml .Values.deployment.streams | indent 6 }}
+      {{- toYaml .Values.deployment.docs | nindent 6 }}
     {{- end }}
-
     Mlflow:
       TrackingURL: {{ .Values.deployment.mlflowTrackingUrl }}
-
     {{- if .Values.deployment.streams }}
     Streams:
-      {{ toYaml .Values.deployment.streams | indent 6 }}
+      {{- toYaml .Values.deployment.streams | nindent 6 }}
     {{- end }}
-
     UI:
       FeastCoreAPI: {{ include "common.set-value" (list .Values.deployment.ui.feastCoreApi $globFeastApi) | quote }}
       MerlinAPI: {{ include "common.set-value" (list .Values.deployment.ui.merlinApi $globMerlinApi) | quote }}

--- a/charts/mlp/templates/deployment.yaml
+++ b/charts/mlp/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
 {{ toYaml .Values.deployment.command | indent 12 -}}
 {{ end }}
           env:
-            - name: DATABASE_PASSWORD
+            - name: DATABASE__PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "postgres.password-secret-name" . }}

--- a/charts/mlp/templates/deployment.yaml
+++ b/charts/mlp/templates/deployment.yaml
@@ -63,12 +63,12 @@ spec:
 {{ toYaml .Values.deployment.command | indent 12 -}}
 {{ end }}
           env:
-            - name: CARAML_DATABASE__PASSWORD
+            - name: DATABASE__PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "postgres.password-secret-name" . }}
                   key: {{ template "postgres.password-secret-key" . }}
-            - name: CARAML_ENCRYPTION_KEY
+            - name: ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mlp.encryption-key-name" . | quote}}

--- a/charts/mlp/templates/deployment.yaml
+++ b/charts/mlp/templates/deployment.yaml
@@ -63,12 +63,12 @@ spec:
 {{ toYaml .Values.deployment.command | indent 12 -}}
 {{ end }}
           env:
-            - name: DATABASE__PASSWORD
+            - name: CARAML_DATABASE__PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "postgres.password-secret-name" . }}
                   key: {{ template "postgres.password-secret-key" . }}
-            - name: ENCRYPTION_KEY
+            - name: CARAML_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mlp.encryption-key-name" . | quote}}

--- a/charts/mlp/templates/deployment.yaml
+++ b/charts/mlp/templates/deployment.yaml
@@ -1,11 +1,3 @@
-{{- $globOauthClientID := include "common.get-oauth-client" .Values.global }}
-{{- $globApiHost := include "common.get-component-value" (list .Values.global "mlp"  (list "vsPrefix" "apiPrefix")) }}
-{{- $globFeastApi := include "common.get-component-value" (list .Values.global "feast" (list "vsPrefix" "apiPrefix")) }}
-{{- $globMerlinApi := include "common.get-component-value" (list .Values.global "merlin" (list "vsPrefix" "apiPrefix")) }}
-{{- $globTuringApi := include "common.get-component-value" (list .Values.global "turing" (list "vsPrefix" "apiPrefix")) }}
-{{- $globFeastUI := include "common.get-component-value" (list .Values.global "feast" (list "uiPrefix")) }}
-{{- $globMerlinUI := include "common.get-component-value" (list .Values.global "merlin" (list "uiPrefix")) }}
-{{- $globTuringUI := include "common.get-component-value" (list .Values.global "turing" (list "uiPrefix")) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -60,73 +52,30 @@ spec:
           {{- if .Values.deployment.resources }}
           resources: {{- toYaml .Values.deployment.resources | nindent 12 }}
           {{- end }}
-{{- if .Values.deployment.args }}
           args:
-{{ toYaml .Values.deployment.args | indent 10 -}}
+            - --config
+            - /etc/caraml/mlp-config.yaml
+{{- if .Values.deployment.args }}
+{{ toYaml .Values.deployment.args | indent 12 -}}
 {{ end }}
 {{- if .Values.deployment.command }}
           command:
-{{ toYaml .Values.deployment.command | indent 10 -}}
+{{ toYaml .Values.deployment.command | indent 12 -}}
 {{ end }}
           env:
-            - name: ENVIRONMENT
-              value: "{{ .Values.deployment.environment }}"
-            - name: API_HOST
-              value: {{ include "common.set-value" (list .Values.deployment.apiHost $globApiHost) | quote }}
-            - name: PORT
-              value: "{{ .Values.service.internalPort }}"
-            - name: DATABASE_HOST
-              value: {{ template "postgres.host" . }}
-            - name: DATABASE_USER
-              value: {{ template "postgres.username" . }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "postgres.password-secret-name" . }}
                   key: {{ template "postgres.password-secret-key" . }}
-            - name: DATABASE_NAME
-              value: {{ template "postgres.database" . }}
-            - name: MLFLOW_TRACKING_URL
-              value: "{{ .Values.deployment.mlflowTrackingUrl }}"
             - name: ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mlp.encryption-key-name" . | quote}}
                   key: encryption-key
-            - name: AUTHORIZATION_ENABLED
-              value: "{{ .Values.deployment.authorization.enabled }}"
-            {{- if .Values.deployment.authorization.enabled }}
-            - name: AUTHORIZATION_SERVER_URL
-              value: "{{ .Values.deployment.authorization.serverUrl }}"
-            {{- end }}
-            - name: OAUTH_CLIENT_ID
-              value: {{ include "common.set-value" (list .Values.deployment.oauthClientID $globOauthClientID) | quote }}
-            - name: SENTRY_DSN
-              value: "{{ .Values.deployment.sentryDSN }}"
-            - name: TEAM_LIST
-              value: "{{ join "," .Values.deployment.teams }}"
-            - name: STREAM_LIST
-              value: "{{ join "," .Values.deployment.streams }}"
-            {{- if .Values.deployment.docs }}
-            - name: DOC_LIST
-              value: {{ .Values.deployment.docs | toJson | quote  }}
-            {{- end }}
-            - name: REACT_APP_FEAST_CORE_API
-              value: {{ include "common.set-value" (list .Values.deployment.ui.feastCoreApi $globFeastApi) | quote }}
-            - name: REACT_APP_MERLIN_API
-              value: {{ include "common.set-value" (list .Values.deployment.ui.merlinApi $globMerlinApi) | quote }}
-            - name: REACT_APP_TURING_API
-              value: {{ include "common.set-value" (list .Values.deployment.ui.turingApi $globTuringApi) | quote }}
-            - name: REACT_APP_CLOCKWORK_UI_HOMEPAGE
-              value: "{{ .Values.deployment.ui.clockworkHomepage }}"
-            - name: REACT_APP_FEAST_UI_HOMEPAGE
-              value: {{ include "common.set-value" (list .Values.deployment.ui.feastHomepage $globFeastUI) | quote }}
-            - name: REACT_APP_KUBEFLOW_UI_HOMEPAGE
-              value: "{{ .Values.deployment.ui.kubeflowHomepage }}"
-            - name: REACT_APP_MERLIN_UI_HOMEPAGE
-              value: {{ include "common.set-value" (list .Values.deployment.ui.merlinHomepage $globMerlinUI) | quote }}
-            - name: REACT_APP_TURING_UI_HOMEPAGE
-              value: {{ include "common.set-value" (list .Values.deployment.ui.turingHomepage $globTuringUI) | quote }}
+          volumeMounts:
+            - mountPath: /etc/caraml
+              name: config
 {{- if .Values.deployment.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.deployment.imagePullSecrets | indent 6 }}
@@ -136,3 +85,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.deployment.nodeSelector | indent 8 }}
 {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "mlp.config-cm-name" . }}

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -5,7 +5,7 @@ deployment:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: gojek/mlp
-    tag: v1.7.1
+    tag: v1.7.4-build.5-ac5d3eb
 
   replicaCount: 1
 

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -5,7 +5,7 @@ deployment:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: gojek/mlp
-    tag: v1.8.0
+    tag: v1.7.1
 
   replicaCount: 1
 

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -5,7 +5,7 @@ deployment:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: gojek/mlp
-    tag: v1.7.1
+    tag: v1.8.0
 
   replicaCount: 1
 

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -31,34 +31,22 @@ deployment:
     enabled: false
     serverUrl: http://mlp-authorization-keto
 
-  # -- teams list
-  teams:
-    - marketing
-    - operation
-    - business
-
   # -- Streams list
   streams:
-    - promotion-marketing
-    - operation-strategy
-    - business-analyst
+    marketing:
+      - promotions
+      - growth
+    business:
+      - operations
 
-  # -- Documentation list for caraml components, Added as part of env variables.
+  # -- Documentation list for caraml components
   docs:
-    [
-      {
-        "label": "Merlin User Guide",
-        "href": "https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md",
-      },
-      {
-        "label": "Turing User Guide",
-        "href": "https://github.com/gojek/turing",
-      },
-      {
-        "label": "Feast User Guide",
-        "href": "https://docs.feast.dev/user-guide/overview",
-      },
-    ]
+    - label: "Merlin User Guide"
+      href: "https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md"
+    - label: "Turing User Guide"
+      href: "https://github.com/gojek/turing"
+    - label: "Feast User Guide"
+      href: "https://docs.feast.dev/user-guide/overview"
 
   ui:
     feastCoreApi: "http://feast.dev/v1"


### PR DESCRIPTION
# Motivation

As of now, all the configuration values are passed to [`gojek/mlp`](https://github.com/gojek/mlp) via environment variables. With the growing complexity of the required config, this way of passing runtime config became inconvenient because it needed some sort of encoding to pass a complex struct/object data (i.e. serializing data as JSON-string. Example: [charts/mlp/values.yaml#L47](https://github.com/caraml-dev/helm-charts/blob/c06cb5d7bd046eb9533c796060a9446327101777/charts/mlp/values.yaml#L47)). 

This Draft PR [gojek/mlp!71 ](https://github.com/gojek/mlp/pull/71) brings support of reading MLP configuration from YAML config files, hence the changes introduced in this PR are adding support of the config file into MLP's chart.

# Modification
* [`configmap`](https://github.com/caraml-dev/helm-charts/compare/main...romanwozniak:feat-mlp-support-configmap?expand=1#diff-93c48bd7bd3dc2f31bba54f38af992e5c5ac050d74b20010dabd17643b35e75f) added
* Redundant Env variables are removed from the [`deployement`](https://github.com/caraml-dev/helm-charts/compare/main...romanwozniak:feat-mlp-support-configmap?expand=1#diff-07141fdc7f3530d6cf1b2958a742e7ee126eb187dd5c0a3651a76321778538aa)
* Type of `stream`/`team` values has been changed from `array[string]` to `map[string][]string` to support the `stream > team` hierarchy (i.e. each team should be mapped to one and only one stream)

# Checklist
- [x] Chart version bumped
- [x] README.md updated
