### PR TITLE
fix(mlp): Create a secret for db password only if enabled

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.4.1
+version: 0.4.2

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![AppVersion: v1.7.4-build.5-ac5d3eb](https://img.shields.io/badge/AppVersion-v1.7.4--build.5--ac5d3eb-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: v1.7.4-build.5-ac5d3eb](https://img.shields.io/badge/AppVersion-v1.7.4--build.5--ac5d3eb-informational?style=flat-square)
 
 MLP API
 
@@ -45,11 +45,12 @@ MLP API
 | deployment.ui.turingHomepage | string | `"http://turing.dev"` |  |
 | encryption.key | string | `"example-key-here"` |  |
 | externalPostgresql.address | string | `"127.0.0.1"` | Host address for the External postgres |
+| externalPostgresql.createSecret | bool | `false` |  |
 | externalPostgresql.database | string | `"mlp"` | External postgres database schema |
 | externalPostgresql.enabled | bool | `false` | If you would like to use an external postgres database, enable it here using this |
 | externalPostgresql.password | string | `"password"` |  |
-| externalPostgresql.secretKey | string | `""` | If a secret is created by external systems (eg. Valut)., mention the key under which password is stored in secret (eg. postgresql-password) |
-| externalPostgresql.secretName | string | `""` | If a secret is created by external systems (eg. Valut)., mention the secret name here |
+| externalPostgresql.secretKey | string | `"postgresql-password"` | If a secret is created by external systems (eg. Vault)., mention the key under which password is stored in secret (eg. postgresql-password) |
+| externalPostgresql.secretName | string | `""` | If a secret is created by external systems (eg. Vault)., mention the secret name here |
 | externalPostgresql.username | string | `"mlp"` | External postgres database user |
 | global | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/mlp/templates/postgres-secret.yaml
+++ b/charts/mlp/templates/postgres-secret.yaml
@@ -8,5 +8,5 @@ metadata:
     {{- include "mlp.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{ .Values.externalPostgresql.secretKey }}: {{ .Values.externalPostgresql.password }}
+  {{ template "postgres.password-secret-key" . }}: {{ .Values.externalPostgresql.password }}
 {{- end -}}

--- a/charts/mlp/templates/postgres-secret.yaml
+++ b/charts/mlp/templates/postgres-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.externalPostgresql.enabled }}
+{{- if and .Values.externalPostgresql.enabled .Values.externalPostgresql.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +8,5 @@ metadata:
     {{- include "mlp.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  postgresql-password: {{ .Values.externalPostgresql.password }}
+  {{ .Values.externalPostgresql.secretKey }}: {{ .Values.externalPostgresql.password }}
 {{- end -}}

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -88,10 +88,11 @@ externalPostgresql:
   password: password
   # -- Host address for the External postgres
   address: 127.0.0.1
-  # -- If a secret is created by external systems (eg. Valut)., mention the secret name here
+  createSecret: false
+  # -- If a secret is created by external systems (eg. Vault)., mention the secret name here
   secretName: ""
-# -- If a secret is created by external systems (eg. Valut)., mention the key under which password is stored in secret (eg. postgresql-password)
-  secretKey: ""
+# -- If a secret is created by external systems (eg. Vault)., mention the key under which password is stored in secret (eg. postgresql-password)
+  secretKey: "postgresql-password"
 
 postgresql:
   # -- Enable creating mlp specific postgres instance


### PR DESCRIPTION
# Motivation
A secret is created if external db is used. But ideally, it should be created if there is a need to create one. There can be cases where secrets are already created by external operators and we just need to point the right name and key in our templates. 


# Modification
* Add check to create secret

# Checklist
- [x] Chart version bumped
- [x] README.md updated
