### PR TITLE
fix(merlin): Create db secrets only when enabled

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.9.16
+version: 0.9.17

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,6 +1,6 @@
 # merlin
 
-![Version: 0.9.16](https://img.shields.io/badge/Version-0.9.16-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.9.17](https://img.shields.io/badge/Version-0.9.17-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -111,6 +111,7 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | merlin-postgresql.resources.requests.cpu | string | `"100m"` |  |
 | merlin-postgresql.resources.requests.memory | string | `"512Mi"` |  |
 | merlinExternalPostgresql.address | string | `"127.0.0.1"` | Host address for the External postgres |
+| merlinExternalPostgresql.createSecret | bool | `false` | Enable this if you need the chart to create a secret when you provide the password above. |
 | merlinExternalPostgresql.database | string | `"merlin"` | External postgres database schema |
 | merlinExternalPostgresql.enabled | bool | `false` | If you would like to use an external postgres database, enable it here using this |
 | merlinExternalPostgresql.password | string | `"password"` |  |
@@ -175,6 +176,7 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | mlflow.statefulset.updateStrategy | string | `"RollingUpdate"` |  |
 | mlflow.trackingURL | string | `"http://www.example.com"` |  |
 | mlflowExternalPostgresql.address | string | `"127.0.0.1"` | Host address for the External postgres |
+| mlflowExternalPostgresql.createSecret | bool | `false` | Enable this if you need the chart to create a secret when you provide the password above. |
 | mlflowExternalPostgresql.database | string | `"mlflow"` | External postgres database schema |
 | mlflowExternalPostgresql.enabled | bool | `false` | If you would like to use an external postgres database, enable it here using this |
 | mlflowExternalPostgresql.password | string | `"password"` |  |

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -128,7 +128,7 @@ Merlin Postgres related
     {{- if index .Values "merlin-postgresql" "enabled" -}}
         {{- printf "%s-%s-postgresql" .Release.Name .Chart.Name -}}
     {{- else if .Values.merlinExternalPostgresql.enabled -}}
-        {{- default (printf "%s-%s-external-postgresql" .Release.Name .Chart.Name) .Values.externalPostgresql.secretName -}}
+        {{- default (printf "%s-%s-external-postgresql" .Release.Name .Chart.Name) .Values.merlinExternalPostgresql.secretName -}}
     {{- else -}}
         {{- printf "%s-postgresql" .Release.Name -}}
     {{- end -}}
@@ -136,7 +136,7 @@ Merlin Postgres related
 
 {{- define "merlin-postgresql.password-secret-key" -}}
     {{- if and .Values.merlinExternalPostgresql.enabled -}}
-        {{- default "postgresql-password" .Values.externalPostgresql.secretKey  -}}
+        {{- default "postgresql-password" .Values.merlinExternalPostgresql.secretKey  -}}
     {{- else -}}
         {{- printf "postgresql-password" -}}
     {{- end -}}
@@ -190,7 +190,7 @@ MLflow Postgres related
     {{- if index .Values "mlflow-postgresql" "enabled" -}}
         {{- printf "%s-mlflow-postgresql" .Release.Name -}}
     {{- else if .Values.mlflowExternalPostgresql.enabled -}}
-        {{- default (printf "%s-mlflow-external-postgresql" .Release.Name) .Values.externalPostgresql.secretName -}}
+        {{- default (printf "%s-mlflow-external-postgresql" .Release.Name) .Values.mlflowExternalPostgresql.secretName -}}
     {{- else -}}
         {{- printf "%s-postgresql" .Release.Name -}}
     {{- end -}}
@@ -198,7 +198,7 @@ MLflow Postgres related
 
 {{- define "mlflow-postgresql.password-secret-key" -}}
     {{- if and .Values.mlflowExternalPostgresql.enabled -}}
-        {{- default "postgresql-password" .Values.externalPostgresql.secretKey  -}}
+        {{- default "postgresql-password" .Values.mlflowExternalPostgresql.secretKey  -}}
     {{- else -}}
         {{- printf "postgresql-password" -}}
     {{- end -}}

--- a/charts/merlin/templates/merlin-database-secret.yaml
+++ b/charts/merlin/templates/merlin-database-secret.yaml
@@ -1,4 +1,4 @@
-{{- if (index .Values "merlin-postgresql" "useExternalPostgresql") }}
+{{- if and .Values.merlinExternalPostgresql.enabled .Values.merlinExternalPostgresql.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +8,5 @@ metadata:
     {{- include "merlin.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  postgresql-password: {{ index .Values "merlin-postgresql" "postgresqlPassword" }}
+  {{ template "merlin-postgres.password-secret-key" . }}: {{ .Values.merlinExternalPostgresql.password }}
 {{- end }}

--- a/charts/merlin/templates/mlflow-database-secret.yaml
+++ b/charts/merlin/templates/mlflow-database-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.mlflowExternalPostgresql.enabled .Values.mlflowExternalPostgresql.createSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "mlflow-postgresql.password-secret-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "merlin.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ template "mlflow-postgres.password-secret-key" . }}: {{ .Values.mlflowExternalPostgresql.password }}
+{{- end }}

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -187,6 +187,8 @@ merlinExternalPostgresql:
   password: password
   # -- Host address for the External postgres
   address: 127.0.0.1
+  # -- Enable this if you need the chart to create a secret when you provide the password above.
+  createSecret: false
   # -- If a secret is created by external systems (eg. Vault)., mention the secret name here
   secretName: ""
   # -- If a secret is created by external systems (eg. Vault)., mention the key under which password is stored in secret (eg. postgresql-password)
@@ -322,6 +324,8 @@ mlflowExternalPostgresql:
   password: password
   # -- Host address for the External postgres
   address: 127.0.0.1
+  # -- Enable this if you need the chart to create a secret when you provide the password above.
+  createSecret: false
   # -- If a secret is created by external systems (eg. Vault)., mention the secret name here
   secretName: ""
   # -- If a secret is created by external systems (eg. Vault)., mention the key under which password is stored in secret (eg. postgresql-password)


### PR DESCRIPTION
# Motivation
A secret is created if external db is used. But ideally, it should be created if there is a need to create one. There can be cases where secrets are already created by external operators and we just need to point the right name and key in our templates.

# Modification
* Add check to create secret
* Add template to create secret for mlflow db if enabled

# Checklist
- [x] Chart version bumped
- [x] README.md updated
