### PR TITLE
fix(mlp): Update name and fullname templating

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.4.2
+version: 0.4.3

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: v1.7.4-build.5-ac5d3eb](https://img.shields.io/badge/AppVersion-v1.7.4--build.5--ac5d3eb-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![AppVersion: v1.7.4-build.5-ac5d3eb](https://img.shields.io/badge/AppVersion-v1.7.4--build.5--ac5d3eb-informational?style=flat-square)
 
 MLP API
 
@@ -52,7 +52,8 @@ MLP API
 | externalPostgresql.secretKey | string | `"postgresql-password"` | If a secret is created by external systems (eg. Vault)., mention the key under which password is stored in secret (eg. postgresql-password) |
 | externalPostgresql.secretName | string | `""` | If a secret is created by external systems (eg. Vault)., mention the secret name here |
 | externalPostgresql.username | string | `"mlp"` | External postgres database user |
-| global | object | `{}` |  |
+| global.ingressIP | string | `""` |  |
+| global.oauthClientID | string | `"123"` |  |
 | ingress.enabled | bool | `false` |  |
 | postgresql.enabled | bool | `true` | Enable creating mlp specific postgres instance |
 | postgresql.nameOverride | string | `"mlp-postgresql"` | override the name here so that db gets created like <release_name>-mlp-postgresql |

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -52,8 +52,7 @@ MLP API
 | externalPostgresql.secretKey | string | `"postgresql-password"` | If a secret is created by external systems (eg. Vault)., mention the key under which password is stored in secret (eg. postgresql-password) |
 | externalPostgresql.secretName | string | `""` | If a secret is created by external systems (eg. Vault)., mention the secret name here |
 | externalPostgresql.username | string | `"mlp"` | External postgres database user |
-| global.ingressIP | string | `""` |  |
-| global.oauthClientID | string | `"123"` |  |
+| global | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | postgresql.enabled | bool | `true` | Enable creating mlp specific postgres instance |
 | postgresql.nameOverride | string | `"mlp-postgresql"` | override the name here so that db gets created like <release_name>-mlp-postgresql |

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -35,12 +35,20 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{- define "mlp.resource-prefix-with-release-name" -}}
+    {{- (include "mlp.fullname" .) -}}
+{{- end -}}
+
+{{- define "mlp.resource-prefix" -}}
+    {{- (include "mlp.name" .) -}}
+{{- end -}}
+
 {{- define "mlp.config-cm-name" -}}
-    {{- printf "%s-config" (include "mlp.fullname" .) | trunc 63 | trimSuffix "-" -}}
+    {{- printf "%s-config" (include "mlp.resource-prefix-with-release-name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "mlp.encryption-key-name" -}}
-    {{- printf "%s-encryption-key" (include "mlp.fullname" .) | trunc 63 | trimSuffix "-" -}}
+    {{- printf "%s-encryption-key" (include "mlp.resource-prefix-with-release-name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -5,47 +5,42 @@
 Generated names
 */}}
 
-{{- define "mlp.resource-prefix-with-release-name" -}}
-    {{- $deployedChart := .Chart.Name -}}
-    {{- $chartVersion := .Chart.Version | replace "." "-" -}}
-    {{- $deployedReleaseName := .Release.Name -}}
-    {{ printf "%s-%s-%s"  $deployedChart $chartVersion $deployedReleaseName }}
-{{- end -}}
 
-{{- define "mlp.resource-prefix" -}}
-    {{- $deployedChart := .Chart.Name -}}
-    {{- $chartVersion := .Chart.Version | replace "." "-" -}}
-    {{ printf "%s-%s"  $deployedChart $chartVersion }}
-{{- end -}}
-
-
+{{/*
+Expand the name of the chart.
+*/}}
 {{- define "mlp.name" -}}
-    {{- if .Values.nameOverride -}}
-        {{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-    {{- else -}}
-        {{- printf "%s" (include "mlp.resource-prefix" .) | trunc 63 | trimSuffix "-" -}}
-    {{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{- define "mlp.config-cm-name" -}}
-    {{- printf "%s-config" (include "mlp.name" .) | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "mlp.encryption-key-name" -}}
-    {{- printf "%s-encryption-key" (include "mlp.name" .) | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
 
 {{- define "mlp.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version -}}
 {{- end -}}
 
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
 {{- define "mlp.fullname" -}}
-    {{- if .Values.fullnameOverride -}}
-        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-    {{- else -}}
-        {{- printf "%s" (include "mlp.resource-prefix-with-release-name" .) | trunc 63 | trimSuffix "-" -}}
-    {{- end -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mlp.config-cm-name" -}}
+    {{- printf "%s-config" (include "mlp.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mlp.encryption-key-name" -}}
+    {{- printf "%s-encryption-key" (include "mlp.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
# Motivation
- Trying to install 2 Helm release of MLP in the same namespace is failing without specifying name overrides due to same resource name being generated that lead to ownership conflict.
```
Error: INSTALLATION FAILED: rendered manifests contain a resource that already exists. Unable to continue with install: Secret "mlp-0-3-4-encryption-key" in namespace "mlp" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "merlin-e2e-mlp-3797adfd": current value is "merlin-e2e-mlp-05f0fff9"
```
- Remove chart version from being used when generating `name` and `fullname`, the reason is that when we upgrade to new chart version, all resource name will also change. This will cause issue since a new resource will be created and previous resource will be deleted, instead of modifying existing resource. 

# Modification

- Update the method for generating `name` and `fullname` to follow convention from https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_names.tpl 
- Use `fullname` for naming secret and configmap so that it contains release name.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
