### PR TITLE
chore(merlin): Use name overrides for resource names, Remove app version from resource names

### DIFF
--- a/charts/merlin/Chart.lock
+++ b/charts/merlin/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.1
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.3
+  version: 0.4.5
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
@@ -20,5 +20,5 @@ dependencies:
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.6
-digest: sha256:11312220bb19c6760d5b932ea2f5318bdf06ac2db3951ac7109fbbbbc4fb470e
-generated: "2022-11-29T05:32:37.947860733Z"
+digest: sha256:cfde19966714b832d63caef97c53b95cd7b4d622dc20c3d25d7669131fa90daa
+generated: "2022-11-29T11:26:33.708667+05:30"

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 - condition: mlp.enabled
   name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.3
+  version: 0.4.5
 - alias: kserve
   condition: kserve.enabled
   name: generic-dep-installer
@@ -38,4 +38,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.9.20
+version: 0.9.21

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,6 +1,6 @@
 # merlin
 
-![Version: 0.9.20](https://img.shields.io/badge/Version-0.9.20-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.9.21](https://img.shields.io/badge/Version-0.9.21-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -18,7 +18,7 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | https://caraml-dev.github.io/helm-charts | vault(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | kserve(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | minio(generic-dep-installer) | 0.2.1 |
-| https://caraml-dev.github.io/helm-charts | mlp | 0.4.3 |
+| https://caraml-dev.github.io/helm-charts | mlp | 0.4.5 |
 | https://charts.helm.sh/stable | mlflow-postgresql(postgresql) | 7.0.2 |
 | https://charts.helm.sh/stable | merlin-postgresql(postgresql) | 7.0.2 |
 

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -6,25 +6,33 @@ Generated names
 */}}
 
 {{- define "merlin.resource-prefix-with-release-name" -}}
-    {{- $deployedChart := .Chart.Name -}}
-    {{- $appVersion := .Chart.AppVersion | replace "." "-" -}}
-    {{- $deployedReleaseName := .Release.Name -}}
-    {{ printf "%s-%s-%s"  $deployedChart $appVersion $deployedReleaseName }}
+    {{- if .Values.fullnameOverride -}}
+        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- $deployedChart := .Chart.Name -}}
+        {{- $appVersion := .Chart.AppVersion | replace "." "-" -}}
+        {{- $deployedReleaseName := .Release.Name -}}
+        {{ printf "%s-%s-%s"  $deployedChart $appVersion $deployedReleaseName  | trunc 63 | trimSuffix "-" }}
+    {{- end -}}
 {{- end -}}
 
 {{- define "merlin.resource-prefix" -}}
-    {{- $deployedChart := .Chart.Name -}}
-    {{- $appVersion := .Chart.AppVersion | replace "." "-" -}}
-    {{ printf "%s-%s"  $deployedChart $appVersion }}
+    {{- if .Values.nameOverride -}}
+        {{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- $deployedChart := .Chart.Name -}}
+        {{- $appVersion := .Chart.AppVersion | replace "." "-" -}}
+        {{ printf "%s-%s"  $deployedChart $appVersion | trunc 63 | trimSuffix "-" }}
+    {{- end -}}
 {{- end -}}
 
 
 {{- define "merlin.name" -}}
-    {{- if .Values.nameOverride -}}
-        {{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-    {{- else -}}
-        {{- printf "%s" (include "merlin.resource-prefix" .) | trunc 63 | trimSuffix "-" -}}
-    {{- end -}}
+    {{- printf "%s" (include "merlin.resource-prefix" .) -}}
+{{- end -}}
+
+{{- define "merlin.fullname" -}}
+    {{- printf "%s" (include "merlin.resource-prefix-with-release-name" .) -}}
 {{- end -}}
 
 {{- define "merlin.envs-cm-name" -}}
@@ -54,14 +62,6 @@ Generated names
 
 {{- define "merlin.chart" -}}
     {{- printf "%s-%s" .Chart.Name .Chart.Version -}}
-{{- end -}}
-
-{{- define "merlin.fullname" -}}
-    {{- if .Values.fullnameOverride -}}
-        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-    {{- else -}}
-        {{- printf "%s" (include "merlin.resource-prefix-with-release-name" .) | trunc 63 | trimSuffix "-" -}}
-    {{- end -}}
 {{- end -}}
 
 {{- define "mlflow.fullname" -}}

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -9,10 +9,12 @@ Generated names
     {{- if .Values.fullnameOverride -}}
         {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
-        {{- $deployedChart := .Chart.Name -}}
-        {{- $appVersion := .Chart.AppVersion | replace "." "-" -}}
-        {{- $deployedReleaseName := .Release.Name -}}
-        {{ printf "%s-%s-%s"  $deployedChart $appVersion $deployedReleaseName  | trunc 63 | trimSuffix "-" }}
+        {{- $name := default .Chart.Name .Values.nameOverride -}}
+        {{- if contains $name .Release.Name -}}
+            {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+        {{- else -}}
+            {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
 
@@ -21,8 +23,7 @@ Generated names
         {{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
         {{- $deployedChart := .Chart.Name -}}
-        {{- $appVersion := .Chart.AppVersion | replace "." "-" -}}
-        {{ printf "%s-%s"  $deployedChart $appVersion | trunc 63 | trimSuffix "-" }}
+        {{ printf "%s"  $deployedChart | trunc 63 | trimSuffix "-" }}
     {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
# Motivation
Remove app version from resource name prefixes, It can cause recreation of resource for every chart version upgrade. 

# Modification

# Checklist
- [x] Chart version bumped
- [x] README.md updated
