### PR TITLE
feat(mlp): add application configuration into MLP's runtime configuration

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.4.5
+version: 0.4.6

--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.7.4-build.5-ac5d3eb
+appVersion: v1.7.4-build.6-322163a
 dependencies:
 - condition: postgresql.enabled
   name: postgresql

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![AppVersion: v1.7.4-build.5-ac5d3eb](https://img.shields.io/badge/AppVersion-v1.7.4--build.5--ac5d3eb-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![AppVersion: v1.7.4-build.5-ac5d3eb](https://img.shields.io/badge/AppVersion-v1.7.4--build.5--ac5d3eb-informational?style=flat-square)
 
 MLP API
 
@@ -22,6 +22,7 @@ MLP API
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | deployment.apiHost | string | `"http://mlp/v1"` |  |
+| deployment.applications | list | `[{"configuration":{"api":"/api/merlin","iconName":"machineLearningApp","navigation":[{"destination":"/models","label":"Models"},{"destination":"/transformer-simulator","label":"Transformer Simulator"}]},"description":"Platform for deploying machine learning models","homepage":"/merlin","name":"Merlin"},{"configuration":{"api":"/api/turing","iconName":"graphApp","navigation":[{"destination":"/routers","label":"Routers"},{"destination":"/ensemblers","label":"Ensemblers"},{"destination":"/jobs","label":"Ensembling Jobs"},{"destination":"/experiments","label":"Experiments"}]},"description":"Platform for setting up ML experiments","homepage":"/turing","name":"Turing"},{"configuration":{"api":"/feast/api","iconName":"appSearchApp","navigation":[{"destination":"/entities","label":"Entities"},{"destination":"/featuretables","label":"Feature Tables"},{"destination":"/jobs/batch","label":"Batch Ingestion Jobs"},{"destination":"/jobs/stream","label":"Stream Ingestion Jobs"}]},"description":"Platform for managing and serving ML features","homepage":"/feast","name":"Feast"},{"configuration":{"iconName":"pipelineApp"},"description":"Platform for managing ML pipelines","homepage":"/pipeline","name":"Pipelines"}]` | Enabled CaraML applications |
 | deployment.authorization.enabled | bool | `false` |  |
 | deployment.authorization.serverUrl | string | `"http://mlp-authorization-keto"` |  |
 | deployment.docs | list | `[{"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},{"href":"https://github.com/gojek/turing","label":"Turing User Guide"},{"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"}]` | Documentation list for caraml components |
@@ -36,13 +37,7 @@ MLP API
 | deployment.resources | object | `{}` | Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/ |
 | deployment.streams | object | `{"business":["operations"],"marketing":["promotions","growth"]}` | Streams list |
 | deployment.ui.clockworkHomepage | string | `"http://clockwork.dev"` |  |
-| deployment.ui.feastCoreApi | string | `"http://feast.dev/v1"` |  |
-| deployment.ui.feastHomepage | string | `"http://feast.dev"` |  |
 | deployment.ui.kubeflowHomepage | string | `"http://kubeflow.org"` |  |
-| deployment.ui.merlinApi | string | `"http://merlin.dev/v1"` |  |
-| deployment.ui.merlinHomepage | string | `"http://merlin.dev"` |  |
-| deployment.ui.turingApi | string | `"http://turing.dev/v1"` |  |
-| deployment.ui.turingHomepage | string | `"http://turing.dev"` |  |
 | encryption.key | string | `"example-key-here"` |  |
 | externalPostgresql.address | string | `"127.0.0.1"` | Host address for the External postgres |
 | externalPostgresql.createSecret | bool | `false` |  |

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![AppVersion: v1.7.4-build.5-ac5d3eb](https://img.shields.io/badge/AppVersion-v1.7.4--build.5--ac5d3eb-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
 
 MLP API
 
@@ -22,12 +22,12 @@ MLP API
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | deployment.apiHost | string | `"http://mlp/v1"` |  |
-| deployment.applications | list | `[{"configuration":{"api":"/api/merlin","iconName":"machineLearningApp","navigation":[{"destination":"/models","label":"Models"},{"destination":"/transformer-simulator","label":"Transformer Simulator"}]},"description":"Platform for deploying machine learning models","homepage":"/merlin","name":"Merlin"},{"configuration":{"api":"/api/turing","iconName":"graphApp","navigation":[{"destination":"/routers","label":"Routers"},{"destination":"/ensemblers","label":"Ensemblers"},{"destination":"/jobs","label":"Ensembling Jobs"},{"destination":"/experiments","label":"Experiments"}]},"description":"Platform for setting up ML experiments","homepage":"/turing","name":"Turing"},{"configuration":{"api":"/feast/api","iconName":"appSearchApp","navigation":[{"destination":"/entities","label":"Entities"},{"destination":"/featuretables","label":"Feature Tables"},{"destination":"/jobs/batch","label":"Batch Ingestion Jobs"},{"destination":"/jobs/stream","label":"Stream Ingestion Jobs"}]},"description":"Platform for managing and serving ML features","homepage":"/feast","name":"Feast"},{"configuration":{"iconName":"pipelineApp"},"description":"Platform for managing ML pipelines","homepage":"/pipeline","name":"Pipelines"}]` | Enabled CaraML applications |
+| deployment.applications | list | `[{"configuration":{"api":"/api/merlin/v1","iconName":"machineLearningApp","navigation":[{"destination":"/models","label":"Models"},{"destination":"/transformer-simulator","label":"Transformer Simulator"}]},"description":"Platform for deploying machine learning models","homepage":"/merlin","name":"Merlin"},{"configuration":{"api":"/api/turing/v1","iconName":"graphApp","navigation":[{"destination":"/routers","label":"Routers"},{"destination":"/ensemblers","label":"Ensemblers"},{"destination":"/jobs","label":"Ensembling Jobs"},{"destination":"/experiments","label":"Experiments"}]},"description":"Platform for setting up ML experiments","homepage":"/turing","name":"Turing"},{"configuration":{"api":"/feast/api","iconName":"appSearchApp","navigation":[{"destination":"/entities","label":"Entities"},{"destination":"/featuretables","label":"Feature Tables"},{"destination":"/jobs/batch","label":"Batch Ingestion Jobs"},{"destination":"/jobs/stream","label":"Stream Ingestion Jobs"}]},"description":"Platform for managing and serving ML features","homepage":"/feast","name":"Feast"},{"configuration":{"iconName":"pipelineApp"},"description":"Platform for managing ML pipelines","homepage":"/pipeline","name":"Pipelines"}]` | Enabled CaraML applications |
 | deployment.authorization.enabled | bool | `false` |  |
 | deployment.authorization.serverUrl | string | `"http://mlp-authorization-keto"` |  |
 | deployment.docs | list | `[{"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},{"href":"https://github.com/gojek/turing","label":"Turing User Guide"},{"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"}]` | Documentation list for caraml components |
 | deployment.environment | string | `"production"` |  |
-| deployment.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"gojek/mlp","tag":"v1.7.4-build.5-ac5d3eb"}` | mlp image related configs |
+| deployment.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"gojek/mlp","tag":"v1.7.4-build.6-322163a"}` | mlp image related configs |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` |  |
 | deployment.mlflowTrackingUrl | string | `"http://mlflow.mlp"` |  |
 | deployment.oauthClientID | string | `""` | OAuth client id for login |
@@ -35,7 +35,7 @@ MLP API
 | deployment.readinessProbe.path | string | `"/v1/internal/ready"` |  |
 | deployment.replicaCount | int | `1` |  |
 | deployment.resources | object | `{}` | Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/ |
-| deployment.streams | object | `{"business":["operations"],"marketing":["promotions","growth"]}` | Streams list |
+| deployment.streams | object | `{}` | Streams list |
 | deployment.ui.clockworkHomepage | string | `"http://clockwork.dev"` |  |
 | deployment.ui.kubeflowHomepage | string | `"http://kubeflow.org"` |  |
 | encryption.key | string | `"example-key-here"` |  |

--- a/charts/mlp/templates/configmap.yaml
+++ b/charts/mlp/templates/configmap.yaml
@@ -15,36 +15,32 @@ metadata:
     {{- include "mlp.labels" . | nindent 4 }}
 data:
   mlp-config.yaml: |
-    APIHost: {{ include "common.set-value" (list .Values.deployment.apiHost $globApiHost) | quote }}
-    Environment: {{ .Values.deployment.environment }}
-    Port: {{ .Values.service.internalPort }}
-    SentryDSN: {{ .Values.deployment.sentryDSN }}
-    OauthClientID: {{ include "common.set-value" (list .Values.deployment.oauthClientID $globOauthClientID) | quote }}
-    Authorization:
-      Enabled: {{ .Values.deployment.authorization.enabled }}
+    apiHost: {{ include "common.set-value" (list .Values.deployment.apiHost $globApiHost) | quote }}
+    environment: {{ .Values.deployment.environment }}
+    port: {{ .Values.service.internalPort }}
+    sentryDSN: {{ .Values.deployment.sentryDSN }}
+    oauthClientID: {{ include "common.set-value" (list .Values.deployment.oauthClientID $globOauthClientID) | quote }}
+    applications:
+      {{- toYaml .Values.deployment.applications | nindent 6 }}
+    authorization:
+      enabled: {{ .Values.deployment.authorization.enabled }}
       {{- if .Values.deployment.authorization.enabled }}
-      KetoServerURL: {{ include "authorization.server.url" . | quote}}
+      ketoServerURL: {{ include "authorization.server.url" . | quote}}
       {{- end }}
-    Database:
-      Host: {{ template "postgres.host" . }}
-      User: {{ template "postgres.username" . }}
-      Database: {{ template "postgres.database" . }}
+    database:
+      host: {{ template "postgres.host" . }}
+      user: {{ template "postgres.username" . }}
+      database: {{ template "postgres.database" . }}
     {{- if .Values.deployment.docs }}
-    Docs:
+    docs:
       {{- toYaml .Values.deployment.docs | nindent 6 }}
     {{- end }}
-    Mlflow:
-      TrackingURL: {{ .Values.deployment.mlflowTrackingUrl }}
+    mlflow:
+      trackingURL: {{ .Values.deployment.mlflowTrackingUrl }}
     {{- if .Values.deployment.streams }}
-    Streams:
+    streams:
       {{- toYaml .Values.deployment.streams | nindent 6 }}
     {{- end }}
-    UI:
-      FeastCoreAPI: {{ include "common.set-value" (list .Values.deployment.ui.feastCoreApi $globFeastApi) | quote }}
-      MerlinAPI: {{ include "common.set-value" (list .Values.deployment.ui.merlinApi $globMerlinApi) | quote }}
-      TuringAPI: {{ include "common.set-value" (list .Values.deployment.ui.turingApi $globTuringApi) | quote }}
-      ClockworkUIHomepage: "{{ .Values.deployment.ui.clockworkHomepage }}"
-      FeastUIHomepage: {{ include "common.set-value" (list .Values.deployment.ui.feastHomepage $globFeastUI) | quote }}
-      KubeflowUIHomepage: "{{ .Values.deployment.ui.kubeflowHomepage }}"
-      MerlinUIHomepage: {{ include "common.set-value" (list .Values.deployment.ui.merlinHomepage $globMerlinUI) | quote }}
-      TuringUIHomepage: {{ include "common.set-value" (list .Values.deployment.ui.turingHomepage $globTuringUI) | quote }}
+    ui:
+      clockworkUIHomepage: "{{ .Values.deployment.ui.clockworkHomepage }}"
+      kubeflowUIHomepage: "{{ .Values.deployment.ui.kubeflowHomepage }}"

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -34,7 +34,7 @@ deployment:
       description: Platform for deploying machine learning models
       homepage: /merlin
       configuration:
-        api: /api/merlin
+        api: /api/merlin/v1
         iconName: machineLearningApp
         navigation:
           - label: Models
@@ -45,7 +45,7 @@ deployment:
       description: Platform for setting up ML experiments
       homepage: /turing
       configuration:
-        api: /api/turing
+        api: /api/turing/v1
         iconName: graphApp
         navigation:
           - label: Routers

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -28,6 +28,56 @@ deployment:
   mlflowTrackingUrl: "http://mlflow.mlp"
   environment: "production"
 
+  # -- Enabled CaraML applications
+  applications:
+    - name: Merlin
+      description: Platform for deploying machine learning models
+      homepage: /merlin
+      configuration:
+        api: /api/merlin
+        iconName: machineLearningApp
+        navigation:
+          - label: Models
+            destination: /models
+          - label: Transformer Simulator
+            destination: /transformer-simulator
+    - name: Turing
+      description: Platform for setting up ML experiments
+      homepage: /turing
+      configuration:
+        api: /api/turing
+        iconName: graphApp
+        navigation:
+          - label: Routers
+            destination: /routers
+          - label: Ensemblers
+            destination: /ensemblers
+          - label: Ensembling Jobs
+            destination: /jobs
+          - label: Experiments
+            destination: /experiments
+    - name: Feast
+      description: Platform for managing and serving ML features
+      homepage: /feast
+      configuration:
+        api: /feast/api
+        iconName: appSearchApp
+        navigation:
+          - label: Entities
+            destination: /entities
+          - label: Feature Tables
+            destination: /featuretables
+          - label: Batch Ingestion Jobs
+            destination: /jobs/batch
+          - label: Stream Ingestion Jobs
+            destination: /jobs/stream
+    - name: Pipelines
+      description: Platform for managing ML pipelines
+      homepage: /pipeline
+      configuration:
+        iconName: pipelineApp
+
+
   authorization:
     enabled: false
     serverUrl: http://mlp-authorization-keto
@@ -50,14 +100,8 @@ deployment:
       href: "https://docs.feast.dev/user-guide/overview"
 
   ui:
-    feastCoreApi: "http://feast.dev/v1"
-    merlinApi: "http://merlin.dev/v1"
-    turingApi: "http://turing.dev/v1"
     clockworkHomepage: "http://clockwork.dev"
-    feastHomepage: "http://feast.dev"
     kubeflowHomepage: "http://kubeflow.org"
-    merlinHomepage: "http://merlin.dev"
-    turingHomepage: "http://turing.dev"
 
   # -- OAuth client id for login
   oauthClientID: ""

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -6,7 +6,7 @@ deployment:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: gojek/mlp
-    tag: v1.7.4-build.5-ac5d3eb
+    tag: v1.7.4-build.6-322163a
 
   replicaCount: 1
 
@@ -83,12 +83,12 @@ deployment:
     serverUrl: http://mlp-authorization-keto
 
   # -- Streams list
-  streams:
-    marketing:
-      - promotions
-      - growth
-    business:
-      - operations
+  streams: {}
+  #   marketing:
+  #     - promotions
+  #     - growth
+  #   business:
+  #     - operations
 
   # -- Documentation list for caraml components
   docs:


### PR DESCRIPTION
# Motivation
To support https://github.com/gojek/mlp/pull/72

# Modification
- `.Values.deployment.applications` section is added to Helm values
- Lower camel-case is used to define keys in the config map

# Checklist
- [x] Chart version bumped
- [x] README.md updated
