### PR TITLE
feat(merlin): add ServiceMonitor for merlin and refactor monitoring config in knative

### DIFF
--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
   name: caraml-dev
 name: knative-serving-istio
 type: application
-version: 1.3.12
+version: 1.4.0

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.3.12](https://img.shields.io/badge/Version-1.3.12-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square)
 ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 Installs Knative-serving for Istio
@@ -137,9 +137,6 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | istiod.helmChart.repository | string | `"https://istio-release.storage.googleapis.com/charts"` |  |
 | istiod.helmChart.version | string | `"1.13.9"` |  |
 | istiod.hook.weight | int | `0` |  |
-| istiod.monitoring.enabled | bool | `false` |  |
-| istiod.monitoring.namespace | string | `"istio-system"` |  |
-| istiod.monitoring.selector.matchLabels.app | string | `"istiod"` |  |
 | knativeServingCore.activator.autoscaling.enabled | bool | `false` | Enables autoscaling for activator deployment. |
 | knativeServingCore.activator.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/activator"` | Repository of the activator image |
 | knativeServingCore.activator.image.sha | string | `"ca607f73e5daef7f3db0358e145220f8423e93c20ee7ea9f5595f13bd508289a"` | SHA256 of the activator image, either provide tag or SHA (SHA will be given priority) |
@@ -189,14 +186,15 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | knativeServingCore.webhook.image.tag | string | `""` | Tag of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | knativeServingCore.webhook.replicaCount | int | `1` | Number of replicas for the webhook deployment. |
 | knativeServingCore.webhook.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
-| monitoring.istioEnvoy.enabled | bool | `false` |  |
+| monitoring.enabled | bool | `false` |  |
 | monitoring.istioEnvoy.envoyStats[0].path | string | `"/stats/prometheus"` |  |
 | monitoring.istioEnvoy.envoyStats[0].port | string | `".*-envoy-prom"` |  |
 | monitoring.istioEnvoy.namespaceSelector | object | `{}` |  |
 | monitoring.istioEnvoy.selector.matchExpressions[0].key | string | `"service.istio.io/canonical-name"` |  |
 | monitoring.istioEnvoy.selector.matchExpressions[0].operator | string | `"Exists"` |  |
+| monitoring.istiod.namespace | string | `"istio-system"` |  |
+| monitoring.istiod.selector.matchLabels.app | string | `"istiod"` |  |
 | monitoring.serving.allNamespaces | bool | `true` |  |
-| monitoring.serving.enabled | bool | `false` |  |
 | monitoring.serving.podMonitor.selector.matchExpressions[0].key | string | `"serving.knative.dev/revision"` |  |
 | monitoring.serving.podMonitor.selector.matchExpressions[0].operator | string | `"Exists"` |  |
 | monitoring.serving.podMonitor.userMetricPortName | string | `"http-usermetric"` |  |

--- a/charts/knative-serving-istio/templates/monitoring/envoy-stats-metrics.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/envoy-stats-metrics.yaml
@@ -1,12 +1,12 @@
 ---
-{{- if .Values.monitoring.istioEnvoy.enabled }}
+{{- if and (or .Values.istioIngressGateway.global.enabled .Values.clusterLocalGateway.global.enabled) .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: envoy-stats-metrics-monitor
   namespace: {{ .Values.monitoring.istioSystemNS }}
   labels:
-{{ include "monitoring.labels" . | indent 4 }}
+{{ include "knative-net-istio.labels" . | indent 4 }}
 spec:
 {{- if .Values.monitoring.istioEnvoy.selector }}
   selector:

--- a/charts/knative-serving-istio/templates/monitoring/istiod-service-monitor.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/istiod-service-monitor.yaml
@@ -1,16 +1,16 @@
 ---
-{{- if .Values.istiod.monitoring.enabled }}
+{{- if and .Values.istiod.enabled .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: istiod-monitor
-  namespace: {{ .Values.istiod.monitoring.namespace }}
+  namespace: {{ .Values.monitoring.istiod.namespace }}
   labels:
 {{ include "knative-net-istio.labels" . | indent 4 }}
 spec:
-{{- if .Values.istiod.monitoring.selector }}
+{{- if .Values.monitoring.istiod.selector }}
   selector:
-{{ toYaml .Values.istiod.monitoring.selector | indent 4 }}
+{{ toYaml .Values.monitoring.istiod.selector | indent 4 }}
 {{- end }}
   endpoints:
     - port: http-monitoring

--- a/charts/knative-serving-istio/templates/monitoring/knative-serving-pod-monitor.yaml
+++ b/charts/knative-serving-istio/templates/monitoring/knative-serving-pod-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.serving.enabled }}
+{{- if .Values.monitoring.enabled }}
 # Queue proxy PodMonitor
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -6,7 +6,7 @@ metadata:
   name: knative-serving-pod-monitor
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "monitoring.labels" . | indent 4 }}
+{{ include "knative-net-istio.labels" . | indent 4 }}
 spec:
 {{- if .Values.monitoring.serving.allNamespaces }}
   namespaceSelector:

--- a/charts/knative-serving-istio/values.yaml
+++ b/charts/knative-serving-istio/values.yaml
@@ -336,12 +336,6 @@ istiod:
         targetAverageUtilization: 80
     meshConfig:
       enableTracing: false
-  monitoring:
-    enabled: false
-    namespace: "istio-system"
-    selector:
-      matchLabels:
-        app: istiod
 
 ############################################################
 # istioIngressGateway - installed using helm-dep-installer chart
@@ -440,12 +434,18 @@ clusterLocalGateway:
           name: http2
         - port: 443
           name: https
+
 ############################################################
 # Monitoring related - Prometheus Service Monitors and Pod Monitors
 ############################################################
 monitoring:
+  enabled: false
+  istiod:
+    namespace: "istio-system"
+    selector:
+      matchLabels:
+        app: istiod
   istioEnvoy:
-    enabled: false
     namespaceSelector: {}
     selector:
       matchExpressions:
@@ -456,7 +456,6 @@ monitoring:
         path: /stats/prometheus
   serving:
     # Install Monitoring CRs related to knative service pods
-    enabled: false
     podMonitor:
       userMetricPortName: http-usermetric
       userPortName: user-port

--- a/charts/merlin/Chart.lock
+++ b/charts/merlin/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.1
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.6
+  version: 0.4.7
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
@@ -20,5 +20,5 @@ dependencies:
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.6
-digest: sha256:41d0ca1be6cdb03f0f4b3c60f7ccf8bf70fcb004d654837fa133cc6e3f985f67
-generated: "2022-11-30T10:22:30.529596081Z"
+digest: sha256:89990bd61330fd8d59baec0bbed7330afed08484670e0e6bbf5f784612bd9a81
+generated: "2022-12-13T16:29:17.827705+08:00"

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 - condition: mlp.enabled
   name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.6
+  version: 0.4.7
 - alias: kserve
   condition: kserve.enabled
   name: generic-dep-installer

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.9.23
+version: 0.9.24

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -187,7 +187,6 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | mlpApi.apiHost | string | `"http://mlp.mlp:8080/v1"` |  |
 | mlpApi.encryptionKey | string | `"secret-encyrption"` |  |
 | monitoring.enabled | bool | `false` |  |
-| monitoring.enabled | bool | `false` |  |
 | newrelic.appname | string | `"merlin-api-dev"` |  |
 | newrelic.enabled | bool | `false` |  |
 | newrelic.licenseSecretName | string | `"newrelic-license-secret"` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,6 +1,6 @@
 # merlin
 
-![Version: 0.9.23](https://img.shields.io/badge/Version-0.9.23-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.9.24](https://img.shields.io/badge/Version-0.9.24-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -186,6 +186,7 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | mlp.enabled | bool | `true` |  |
 | mlpApi.apiHost | string | `"http://mlp.mlp:8080/v1"` |  |
 | mlpApi.encryptionKey | string | `"secret-encyrption"` |  |
+| monitoring.enabled | bool | `false` |  |
 | monitoring.enabled | bool | `false` |  |
 | newrelic.appname | string | `"merlin-api-dev"` |  |
 | newrelic.enabled | bool | `false` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -18,7 +18,7 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | https://caraml-dev.github.io/helm-charts | vault(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | kserve(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | minio(generic-dep-installer) | 0.2.1 |
-| https://caraml-dev.github.io/helm-charts | mlp | 0.4.6 |
+| https://caraml-dev.github.io/helm-charts | mlp | 0.4.7 |
 | https://charts.helm.sh/stable | mlflow-postgresql(postgresql) | 7.0.2 |
 | https://charts.helm.sh/stable | merlin-postgresql(postgresql) | 7.0.2 |
 

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -78,6 +78,8 @@ Generated names
 Common labels
 */}}
 {{- define "merlin.labels" -}}
+app: {{ template "merlin.name" .}}
+release: {{ .Release.Name }}
 app.kubernetes.io/name: {{ template "merlin.name" . }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote}}
 {{- if .Chart.AppVersion }}

--- a/charts/merlin/templates/service-monitor.yaml
+++ b/charts/merlin/templates/service-monitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "merlin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "merlin.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "merlin.name" .}}
+      release: {{ .Release.Name }}
+  endpoints:
+    - targetPort: {{ .Values.service.internalPort }}
+{{- end }}

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -426,6 +426,3 @@ kserve:
     release: kserve
     namespace: kserve
     createNamespace: true
-
-monitoring:
-  enabled: false

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -426,3 +426,6 @@ kserve:
     release: kserve
     namespace: kserve
     createNamespace: true
+
+monitoring:
+  enabled: false


### PR DESCRIPTION
# Motivation
Missing ServiceMonitor for merlin deployment.
Also, the current monitoring configuration in knative charts requires many toggles to control monitoring resources. 

# Modification
- add ServiceMonitor
- adjust merlin labels template
- Use just one flag `monitoring.enabled` 

# Checklist
- [x] Chart version bumped
- [x] README.md updated
