### PR TITLE
fix(authz): Upgrade keto app version to work with pg14

### DIFF
--- a/charts/caraml-authz/Chart.lock
+++ b/charts/caraml-authz/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.helm.sh/stable
-  version: 8.0.0
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.8.0
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.7
-digest: sha256:d6d92501f67473275d45829f3046cad77813d1a79517c385562c432f38120118
-generated: "2023-01-03T05:06:29.162203464Z"
+digest: sha256:f4080521780614f5c2ef7fb8dcfbb2a0fb5650686820baa44929f440adf835a1
+generated: "2023-01-06T11:03:24.069013+05:30"

--- a/charts/caraml-authz/Chart.yaml
+++ b/charts/caraml-authz/Chart.yaml
@@ -4,8 +4,8 @@ dependencies:
 - alias: caraml-authz-postgresql
   condition: caraml-authz-postgresql.enabled
   name: postgresql
-  repository: https://charts.helm.sh/stable
-  version: 8.0.0
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.8.0
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.7
@@ -14,4 +14,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: authz
-version: 0.1.3
+version: 0.1.4

--- a/charts/caraml-authz/README.md
+++ b/charts/caraml-authz/README.md
@@ -27,8 +27,7 @@ Helm chart for deploying Ory Keto
 | bootstrap.resources.requests.cpu | string | `"10m"` |  |
 | bootstrap.resources.requests.memory | string | `"50Mi"` |  |
 | bootstrap.roles | string | `nil` |  |
-| caraml-authz-postgresql.auth.database | string | `"oryketo"` |  |
-| caraml-authz-postgresql.auth.username | string | `"oryketo"` |  |
+| caraml-authz-postgresql.auth | object | `{"database":"oryketo","username":"oryketo"}` | Postgres chart 11.8 needs username and database to be specified in under `auth` to create them when initialized. |
 | caraml-authz-postgresql.enabled | bool | `true` |  |
 | caraml-authz-postgresql.nameOverride | string | `"authz-postgresql"` |  |
 | caraml-authz-postgresql.persistence.accessMode | string | `"ReadWriteOnce"` |  |

--- a/charts/caraml-authz/README.md
+++ b/charts/caraml-authz/README.md
@@ -1,6 +1,6 @@
 # authz
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
 
 Helm chart for deploying Ory Keto
 
@@ -15,7 +15,7 @@ Helm chart for deploying Ory Keto
 | Repository | Name | Version |
 |------------|------|---------|
 | https://caraml-dev.github.io/helm-charts | common | 0.2.7 |
-| https://charts.helm.sh/stable | caraml-authz-postgresql(postgresql) | 8.0.0 |
+| https://charts.bitnami.com/bitnami | caraml-authz-postgresql(postgresql) | 11.8.0 |
 
 ## Values
 
@@ -27,6 +27,8 @@ Helm chart for deploying Ory Keto
 | bootstrap.resources.requests.cpu | string | `"10m"` |  |
 | bootstrap.resources.requests.memory | string | `"50Mi"` |  |
 | bootstrap.roles | string | `nil` |  |
+| caraml-authz-postgresql.auth.database | string | `"oryketo"` |  |
+| caraml-authz-postgresql.auth.username | string | `"oryketo"` |  |
 | caraml-authz-postgresql.enabled | bool | `true` |  |
 | caraml-authz-postgresql.nameOverride | string | `"authz-postgresql"` |  |
 | caraml-authz-postgresql.persistence.accessMode | string | `"ReadWriteOnce"` |  |
@@ -48,7 +50,7 @@ Helm chart for deploying Ory Keto
 | caramlAuthzExternalPostgresql.username | string | `"oryketo"` | External postgres database user |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.repository | string | `"oryd/keto"` |  |
-| deployment.image.tag | string | `"v0.4.3"` |  |
+| deployment.image.tag | string | `"v0.5.4"` |  |
 | deployment.initResources.requests.cpu | string | `"250m"` |  |
 | deployment.initResources.requests.memory | string | `"128Mi"` |  |
 | deployment.replicaCount | int | `1` |  |

--- a/charts/caraml-authz/templates/_helpers.tpl
+++ b/charts/caraml-authz/templates/_helpers.tpl
@@ -103,9 +103,9 @@ CaraML Authz Postgres related
 
 {{- define "caraml-authz-postgresql.password-secret-key" -}}
     {{- if .Values.caramlAuthzExternalPostgresql.enabled -}}
-        {{- default "postgresql-password" .Values.caramlAuthzExternalPostgresql.secretKey  -}}
+        {{- default "password" .Values.caramlAuthzExternalPostgresql.secretKey  -}}
     {{- else -}}
-        {{- printf "postgresql-password" -}}
+        {{- printf "password" -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/caraml-authz/values.yaml
+++ b/charts/caraml-authz/values.yaml
@@ -7,7 +7,7 @@ deployment:
 
   image:
     repository: oryd/keto
-    tag: v0.4.3
+    tag: v0.5.4
     pullPolicy: IfNotPresent
 
   service:
@@ -44,6 +44,9 @@ caramlAuthzExternalPostgresql:
 
 caraml-authz-postgresql:
   enabled: true
+  auth:
+    username: oryketo
+    database: oryketo
   postgresqlUsername: oryketo
   postgresqlDatabase: oryketo
   # -- By default postgres will generate a password, if you wish to choose the password, secret will be created using this password, must be specified using --set flag.
@@ -73,18 +76,18 @@ bootstrap:
       cpu: 100m
       memory: 200Mi
   roles:
-  # - id: role:admin
-  #   subjects: [alice]
-  # - id: role:member
-  #   subjects: [bob]
+    # - id: role:admin
+    #   subjects: [alice]
+    # - id: role:member
+    #   subjects: [bob]
   policies:
-  # - id: example-policy
-  #   subjects: [alice]
-  #   resources: ["blog_posts:my-first-blog-post"]
-  #   actions: [delete]
-  #   effect: allow
-  # - id: example-policy-2
-  #   subjects: [admin]
-  #   resources: ["blog_posts:my-first-blog-post-2"]
-  #   actions: [delete]
-  #   effect: allow
+    # - id: example-policy
+    #   subjects: [alice]
+    #   resources: ["blog_posts:my-first-blog-post"]
+    #   actions: [delete]
+    #   effect: allow
+    # - id: example-policy-2
+    #   subjects: [admin]
+    #   resources: ["blog_posts:my-first-blog-post-2"]
+    #   actions: [delete]
+    #   effect: allow

--- a/charts/caraml-authz/values.yaml
+++ b/charts/caraml-authz/values.yaml
@@ -44,6 +44,7 @@ caramlAuthzExternalPostgresql:
 
 caraml-authz-postgresql:
   enabled: true
+  # -- Postgres chart 11.8 needs username and database to be specified in under `auth` to create them when initialized.
   auth:
     username: oryketo
     database: oryketo


### PR DESCRIPTION
# Motivation
Authz is failing to start/run init migrations when connecting to pg14.
```
level=error msg="Unable to ping SQL database backend" dsn="postgres://*:*@postgresql:5432/authz?sslmode=disable" error="pq: unknown authentication response: 10"  
```


looks like it's due to the Postgres version we have. Authz chart was made with default Postgres version as 8.0

> You have to upgrade the PostgreSQL driver or library on the client side so that it supports the scram-sha-256 authentication method introduced in PostgreSQL v10. ref: https://stackoverflow.com/a/64322735


# Modification
* Upgrade the keto version to 0.5.4
* Upgrade the Postgres chart version in the authz chart to have Postgresql 14 db version.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
