### PR TITLE
refactor: Use a default key name for generating secret key name

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,10 +15,10 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.7"
+appVersion: "0.2.8"

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,8 +1,8 @@
 # common
 
 ---
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square)
-![AppVersion: 0.2.7](https://img.shields.io/badge/AppVersion-0.2.7-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square)
+![AppVersion: 0.2.8](https://img.shields.io/badge/AppVersion-0.2.8-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/common/templates/_names.tpl
+++ b/charts/common/templates/_names.tpl
@@ -91,11 +91,10 @@ Get postgres secret key in the following order of precendence: Chart external Po
 */}}
 {{- define "common.postgres-password-secret-key" -}}
 {{- $externalPostgresql := index . 0 -}}
-{{- if lt (len .) 2 -}}
-    {{- $secretKey := "postgresql-password" -}}
-{{- else -}}
-    {{- $secretKey := index . 1 -}}
-{{- end-}}
+{{- $secretKey := "postgresql-password" -}}
+{{- if ge (len .) 2 -}}
+    {{- $secretKey = index . 1 -}}
+{{- end -}}
     {{- if and $externalPostgresql.enabled -}}
         {{- default $secretKey $externalPostgresql.secretKey  -}}
     {{- else -}}

--- a/charts/common/templates/_names.tpl
+++ b/charts/common/templates/_names.tpl
@@ -91,9 +91,14 @@ Get postgres secret key in the following order of precendence: Chart external Po
 */}}
 {{- define "common.postgres-password-secret-key" -}}
 {{- $externalPostgresql := index . 0 -}}
+{{- if lt (len .) 2 -}}
+    {{- $secretKey := "postgresql-password" -}}
+{{- else -}}
+    {{- $secretKey := index . 1 -}}
+{{- end-}}
     {{- if and $externalPostgresql.enabled -}}
-        {{- default "postgresql-password" $externalPostgresql.secretKey  -}}
+        {{- default $secretKey $externalPostgresql.secretKey  -}}
     {{- else -}}
-        {{- printf "postgresql-password" -}}
+        {{- $secretKey  -}}
     {{- end -}}
 {{- end -}}

--- a/charts/common/templates/_names.tpl
+++ b/charts/common/templates/_names.tpl
@@ -87,7 +87,8 @@ Get postgres database secret name in the following order of precendence: Chart s
 
 {{/*
 Get postgres secret key in the following order of precendence: Chart external Postgresql enabled and specific key mentioned > (default)"postgresql-password" , Arguments:
-2) external postgresql object
+1) external postgresql object
+2) default secret key
 */}}
 {{- define "common.postgres-password-secret-key" -}}
 {{- $externalPostgresql := index . 0 -}}


### PR DESCRIPTION
# Motivation
Use arg-driven default value for the secret key name instead of hard-coding the default value. This is needed for cases where the default value will not be consistent across charts. 

# Modification
* Refactor helper function

# Checklist
- [x] Chart version bumped
- [x] README.md updated
