### PR TITLE
chore(knative): fix PDB configuration for knative pods

### DIFF
--- a/charts/knative-serving-core/Chart.yaml
+++ b/charts/knative-serving-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: knative-serving-core
 description: Installs Knative Serving core and CRDs.
 type: application
-version: 1.3.3
+version: 1.3.4
 appVersion: "v1.3.2"
 maintainers:
   - name: caraml-dev

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -1,7 +1,7 @@
 # knative-serving-core
 
 ---
-![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square)
+![Version: 1.3.4](https://img.shields.io/badge/Version-1.3.4-informational?style=flat-square)
 ![AppVersion: v1.3.2](https://img.shields.io/badge/AppVersion-v1.3.2-informational?style=flat-square)
 
 Installs Knative Serving core and CRDs.

--- a/charts/knative-serving-core/templates/deployments/activator.yaml
+++ b/charts/knative-serving-core/templates/deployments/activator.yaml
@@ -20,7 +20,9 @@ metadata:
     app.kubernetes.io/component: activator
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
+{{- if not .Values.activator.autoscaling.enabled }}
   replicas: {{ .Values.activator.replicaCount }}
+{{- end}}
   selector:
     matchLabels:
       app: activator

--- a/charts/knative-serving-core/templates/deployments/controller.yaml
+++ b/charts/knative-serving-core/templates/deployments/controller.yaml
@@ -20,7 +20,9 @@ metadata:
     app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
+{{- if .Values.controller.autoscaling.enabled }}
   replicas: {{ .Values.controller.replicaCount }}
+{{- end}}
   selector:
     matchLabels:
       app: controller

--- a/charts/knative-serving-core/templates/deployments/webhook.yaml
+++ b/charts/knative-serving-core/templates/deployments/webhook.yaml
@@ -20,7 +20,9 @@ metadata:
     app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
+{{- if .Values.webhook.autoscaling.enabled }}
   replicas: {{ .Values.webhook.replicaCount }}
+{{- end}}
   selector:
     matchLabels:
       app: webhook

--- a/charts/knative-serving-core/templates/pdbs/activator.yaml
+++ b/charts/knative-serving-core/templates/pdbs/activator.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: activator
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
-  minAvailable: 80%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: activator

--- a/charts/knative-serving-core/templates/pdbs/webhook.yaml
+++ b/charts/knative-serving-core/templates/pdbs/webhook.yaml
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/component: webhook
     {{- include "knative-serving-core.labels" . | nindent 4 }}
 spec:
-  minAvailable: 80%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: webhook


### PR DESCRIPTION
# Motivation
The current PDB configuration is too strict and prevents small deployments from being voluntarily disrupted during upgrades.

# Modification
Change default PDBs from `minAvailable: 80%` to `maxUnavailable: 1`.
Also, make deployment replicas configuration only applied when autoscaling is turned off.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
