### PR TITLE
feat: Update knative-serving-istio chart to 1.7.1

### DIFF
--- a/charts/knative-serving-istio/Chart.lock
+++ b/charts/knative-serving-istio/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: knative-serving-core
   repository: https://caraml-dev.github.io/helm-charts
-  version: 1.3.4
+  version: 1.7.4
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
@@ -14,5 +14,5 @@ dependencies:
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
-digest: sha256:c614c45ee5ffaa36f057993565223453fa3fc62e97dc8ce63b6c5c9c7a44a9ee
-generated: "2023-01-19T07:27:24.350330813Z"
+digest: sha256:99e26e7766d1149b29b4a79fb9f4ff68db00f71454bb38a235ae00d9586b95cb
+generated: "2023-01-25T13:28:12.553676+08:00"

--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
-appVersion: v1.3.0
+appVersion: v1.7.1
 dependencies:
 - alias: knativeServingCore
   condition: knativeServingCore.enabled
   name: knative-serving-core
   repository: https://caraml-dev.github.io/helm-charts
-  version: 1.3.3
+  version: 1.7.3
 - alias: istiod
   condition: istiod.enabled
   name: generic-dep-installer
@@ -32,4 +32,4 @@ maintainers:
   name: caraml-dev
 name: knative-serving-istio
 type: application
-version: 1.4.0
+version: 1.7.1

--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: knativeServingCore.enabled
   name: knative-serving-core
   repository: https://caraml-dev.github.io/helm-charts
-  version: 1.7.3
+  version: 1.7.4
 - alias: istiod
   condition: istiod.enabled
   name: generic-dep-installer

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,8 +1,8 @@
 # knative-serving-istio
 
 ---
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square)
-![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square)
+![AppVersion: v1.7.1](https://img.shields.io/badge/AppVersion-v1.7.1-informational?style=flat-square)
 
 Installs Knative-serving for Istio
 
@@ -93,7 +93,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | config | object | `{"istio":{"enable-virtualservice-status":"false","gateway.{{ .Release.Namespace }}.knative-ingress-gateway":"istio-ingressgateway.istio-system.svc.cluster.local","local-gateway.mesh":"mesh","local-gateway.{{ .Release.Namespace }}.knative-local-gateway":"cluster-local-gateway.istio-system.svc.cluster.local"}}` | Please check out the Knative documentation in https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.0.0/net-istio.yaml |
 | controller.autoscaling.enabled | bool | `false` | Enables autoscaling for net-istio-controller deployment. |
 | controller.image.repository | string | `"gcr.io/knative-releases/knative.dev/net-istio/cmd/controller"` | Repository of the controller image |
-| controller.image.sha | string | `"7f17fb47568a74de3f82bb512422a174017b7c06643a330557bc3445c8869932"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
+| controller.image.sha | string | `"c110b0b5d545561f220d23bdb48a6c75f5591d068de9fb079baad47c82903e28"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.image.tag | string | `""` | Tag of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.replicaCount | int | `1` | Number of replicas for the net-istio-controller deployment. |
 | controller.resources | object | `{"limits":{"cpu":"1000m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | Resources requests and limits for net-istio-controller. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
@@ -201,7 +201,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | monitoring.serving.podMonitor.userPortName | string | `"user-port"` |  |
 | revision | string | `""` |  |
 | webhook.image.repository | string | `"gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook"` | Repository of the webhook image |
-| webhook.image.sha | string | `"75d502bdff93e9c0e4611c2747d868b8d471f8d3a0402394de76ec2d98b89ce3"` | SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority) |
+| webhook.image.sha | string | `"d74e79f7db426c1d24e060009e31344cad2d6e8c7e161184f121fde78b2f4a1d"` | SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | webhook.image.tag | string | `""` | Tag of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | webhook.replicaCount | int | `1` | Number of replicas for the net-istio-webhook deployment. |
 | webhook.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for net-istio-webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -90,7 +90,7 @@ The following table lists the configurable parameters of the Knative Net Istio c
 | clusterLocalGateway.helmChart.version | string | `"1.13.9"` |  |
 | clusterLocalGateway.hook.weight | int | `1` |  |
 | clusterLocalGatewayIstioSelector | string | `"cluster-local-gateway"` |  |
-| config | object | `{"istio":{"enable-virtualservice-status":"false","gateway.{{ .Release.Namespace }}.knative-ingress-gateway":"istio-ingressgateway.istio-system.svc.cluster.local","local-gateway.mesh":"mesh","local-gateway.{{ .Release.Namespace }}.knative-local-gateway":"cluster-local-gateway.istio-system.svc.cluster.local"}}` | Please check out the Knative documentation in https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.0.0/net-istio.yaml |
+| config | object | `{"istio":{"enable-virtualservice-status":"false","gateway.{{ .Release.Namespace }}.knative-ingress-gateway":"istio-ingressgateway.istio-system.svc.cluster.local","local-gateway.{{ .Release.Namespace }}.knative-local-gateway":"cluster-local-gateway.istio-system.svc.cluster.local"}}` | Please check out the Knative documentation in https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.0.0/net-istio.yaml |
 | controller.autoscaling.enabled | bool | `false` | Enables autoscaling for net-istio-controller deployment. |
 | controller.image.repository | string | `"gcr.io/knative-releases/knative.dev/net-istio/cmd/controller"` | Repository of the controller image |
 | controller.image.sha | string | `"c110b0b5d545561f220d23bdb48a6c75f5591d068de9fb079baad47c82903e28"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |

--- a/charts/knative-serving-istio/templates/deployments/net-istio-controller.yaml
+++ b/charts/knative-serving-istio/templates/deployments/net-istio-controller.yaml
@@ -66,6 +66,8 @@ spec:
               value: config-logging
             - name: CONFIG_OBSERVABILITY_NAME
               value: config-observability
+            - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
+              value: "false"
             # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
             - name: METRICS_DOMAIN
               value: knative.dev/net-istio

--- a/charts/knative-serving-istio/values.yaml
+++ b/charts/knative-serving-istio/values.yaml
@@ -37,7 +37,7 @@ controller:
     # -- Tag of the controller image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the controller image, either provide tag or SHA (SHA will be given priority)
-    sha: "7f17fb47568a74de3f82bb512422a174017b7c06643a330557bc3445c8869932"
+    sha: "c110b0b5d545561f220d23bdb48a6c75f5591d068de9fb079baad47c82903e28"
   # -- Number of replicas for the net-istio-controller deployment.
   replicaCount: 1
   # -- Resources requests and limits for net-istio-controller. This should be set
@@ -57,7 +57,7 @@ webhook:
     # -- Tag of the webhook image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority)
-    sha: "75d502bdff93e9c0e4611c2747d868b8d471f8d3a0402394de76ec2d98b89ce3"
+    sha: "d74e79f7db426c1d24e060009e31344cad2d6e8c7e161184f121fde78b2f4a1d"
   # -- Number of replicas for the net-istio-webhook deployment.
   replicaCount: 1
   # -- Resources requests and limits for net-istio-webhook. This should be set

--- a/charts/knative-serving-istio/values.yaml
+++ b/charts/knative-serving-istio/values.yaml
@@ -17,7 +17,6 @@ config:
     # NOTE: assumes istio edge proxies (*-gateway deployments) are deployed in istio-system namespace
     gateway.{{ .Release.Namespace }}.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
     local-gateway.{{ .Release.Namespace }}.knative-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
-    local-gateway.mesh: "mesh"
     enable-virtualservice-status: "false"
 clusterLocalGatewayIstioSelector: cluster-local-gateway
 controller:


### PR DESCRIPTION
# Motivation

Current knative version that we are currently using (1.3.3) suffers from issue in readiness probe after restart (https://github.com/knative/serving/issues/12571). The fix to the issue is in 1.7.X. 
Note: current knative serving version is 1.8.0, however there are breaking change that will take longer to analyse so we settle with 1.7.X 

# Modification

Update knative-serving-istio chart based on knative istio release 1.7.1

Notes: requires https://github.com/caraml-dev/helm-charts/pull/162 to be merged first to pass the test

# Checklist
- [X] Chart version bumped
- [X] README.md updated
