### PR TITLE
feat: Update knative-serving-core to 1.7.4

### DIFF
--- a/charts/knative-serving-core/Chart.yaml
+++ b/charts/knative-serving-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: knative-serving-core
 description: Installs Knative Serving core and CRDs.
 type: application
-version: 1.3.3
-appVersion: "v1.3.2"
+version: 1.7.4
+appVersion: "v1.7.4"
 maintainers:
   - name: caraml-dev
     email: caraml-dev@caraml.dev

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -1,8 +1,8 @@
 # knative-serving-core
 
 ---
-![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square)
-![AppVersion: v1.3.2](https://img.shields.io/badge/AppVersion-v1.3.2-informational?style=flat-square)
+![Version: 1.7.4](https://img.shields.io/badge/Version-1.7.4-informational?style=flat-square)
+![AppVersion: v1.7.4](https://img.shields.io/badge/AppVersion-v1.7.4-informational?style=flat-square)
 
 Installs Knative Serving core and CRDs.
 
@@ -60,38 +60,38 @@ The following table lists the configurable parameters of the Knative Serving Cor
 | activator.autoscaling.minReplicas | int | `1` | Minimum number of replicas for activator. |
 | activator.autoscaling.targetCPUUtilizationPercentage | int | `50` | Target CPU utlisation before it scales up/down. |
 | activator.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/activator"` | Repository of the activator image |
-| activator.image.sha | string | `"01270196a1eba7e5fd5fe34b877c82a7e8c93861de535a82342717d28f81d671"` | SHA256 of the activator image, either provide tag or SHA (SHA will be given priority) |
+| activator.image.sha | string | `"2a71f86db077e2af4dc02cd8662c545b8206c6d5c853056225967c719251cc20"` | SHA256 of the activator image, either provide tag or SHA (SHA will be given priority) |
 | activator.image.tag | string | `""` | Tag of the activator image, either provide tag or SHA (SHA will be given priority) |
 | activator.replicaCount | int | `1` | Number of replicas for the activator deployment. |
 | activator.resources | object | `{"limits":{"cpu":"1000m","memory":"600Mi"},"requests":{"cpu":"300m","memory":"100Mi"}}` | Resources requests and limits for activator. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | autoscaler.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler"` | Repository of the autoscaler image |
-| autoscaler.image.sha | string | `"c5a03a236bfe2abdc7d40203d787668c8accaaf39062a86e68b4d403077835e2"` | SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
+| autoscaler.image.sha | string | `"cbc663928cc3e3dc60c1d6cdd054d203895c4ee0ebe2b19d86804bd708f3fa2e"` | SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
 | autoscaler.image.tag | string | `""` | Tag of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
 | autoscaler.replicaCount | int | `1` | Number of replicas for the autoscaler deployment. |
 | autoscaler.resources | object | `{"limits":{"cpu":"1000m","memory":"1000Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}` | Resources requests and limits for autoscaler. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | autoscalerHpa.enabled | bool | `true` |  |
 | autoscalerHpa.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa"` | Repository of the autoscaler image |
-| autoscalerHpa.image.sha | string | `"256373054915e035d3f5df214ca80eea7a235526c93348933f42acf0437bb1a2"` | SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
+| autoscalerHpa.image.sha | string | `"f81c354e13768a11ecdcb84c512af339a0cef596a418daa932e378c6c9c2c87e"` | SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
 | autoscalerHpa.image.tag | string | `""` | Tag of the autoscaler image, either provide tag or SHA (SHA will be given priority) |
 | autoscalerHpa.replicaCount | int | `1` | Number of replicas for the autoscaler deployment. |
 | autoscalerHpa.resources | object | `{"limits":{"cpu":"1000m","memory":"256Mi"},"requests":{"cpu":"500m","memory":"128Mi"}}` | Resources requests and limits for autoscaler. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
-| config | object | `{"autoscaler":{},"buckets":"1","defaults":{},"deployment":{"queueSidecarImage":"gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"},"domain":{},"features":{},"gc":{},"leaderElection":{"lease-duration":"60s","renew-deadline":"40s","retry-period":"10s"},"logging":{"logging.request-log-template":""},"network":{},"observability":{},"tracing":{}}` | Please check out the Knative documentation in https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-core.yaml |
+| config | object | `{"autoscaler":{},"defaults":{},"deployment":{"queueSidecarImage":"gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:fec35c5d66dad3d520e39de7f4f75ec6057962401f85761c143efc902f34efe7"},"domain":{},"features":{},"gc":{},"leaderElection":{"buckets":"1","lease-duration":"60s","renew-deadline":"40s","retry-period":"10s"},"logging":{"logging.request-log-template":""},"network":{},"observability":{},"tracing":{}}` | Please check out the Knative documentation in https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-core.yaml |
 | controller.autoscaling.enabled | bool | `true` | Enables autoscaling for controller deployment. |
 | controller.autoscaling.maxReplicas | int | `20` | Maximum number of replicas for controller. |
 | controller.autoscaling.minReplicas | int | `1` | Minimum number of replicas for controller. |
 | controller.autoscaling.targetCPUUtilizationPercentage | int | `50` | Target CPU utlisation before it scales up/down. |
 | controller.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/controller"` | Repository of the controller image |
-| controller.image.sha | string | `"cc33e6392485e9d015886d4443324b9a41c17f6ce98b31ef4b19e47325a9a7e8"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
+| controller.image.sha | string | `"f81c354e13768a11ecdcb84c512af339a0cef596a418daa932e378c6c9c2c87e"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.image.tag | string | `""` | Tag of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.replicaCount | int | `1` | Number of replicas for the controller deployment. |
 | controller.resources | object | `{"limits":{"cpu":"1000m","memory":"1000Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}` | Resources requests and limits for controller. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | domainMapping.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping"` | Repository of the domain mapping image |
-| domainMapping.image.sha | string | `"00a26f25ef119952b0ecf890f9f9dcb877b5f5d496f43c44756b93343d71b66e"` | SHA256 of the domain mapping image, either provide tag or SHA (SHA will be given priority) |
+| domainMapping.image.sha | string | `"ed47da2c95a9bf73dd3b511323023578e15730864852fb0c869f8f64a2bab39f"` | SHA256 of the domain mapping image, either provide tag or SHA (SHA will be given priority) |
 | domainMapping.image.tag | string | `""` | Tag of the domain mapping image, either provide tag or SHA (SHA will be given priority) |
 | domainMapping.replicaCount | int | `1` | Number of replicas for the domain mapping deployment. |
 | domainMapping.resources | object | `{"limits":{"cpu":"300m","memory":"400Mi"},"requests":{"cpu":"30m","memory":"40Mi"}}` | Resources requests and limits for domain mapping. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | domainMappingWebhook.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook"` | Repository of the domain mapping webhook image |
-| domainMappingWebhook.image.sha | string | `"f8f09d3a509b0c25d50be7532d4337a30df4ec5f51b9ed23ad9f21b3940c16ca"` | SHA256 of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority) |
+| domainMappingWebhook.image.sha | string | `"ed47da2c95a9bf73dd3b511323023578e15730864852fb0c869f8f64a2bab39f"` | SHA256 of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority) |
 | domainMappingWebhook.image.tag | string | `""` | Tag of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority) |
 | domainMappingWebhook.replicaCount | int | `1` | Number of replicas for the domain mapping webhook deployment. |
 | domainMappingWebhook.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for domain mapping webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
@@ -107,14 +107,14 @@ The following table lists the configurable parameters of the Knative Serving Cor
 | monitoring.podMonitor.selector.matchExpressions[0].operator | string | `"Exists"` |  |
 | monitoring.selectorKey | string | `"serving.knative.dev/release"` |  |
 | queueProxy.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/queue"` | Repository of the queue proxy image |
-| queueProxy.image.sha | string | `"2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"` | SHA256 of the queue proxy image, either provide tag or SHA (SHA will be given priority) |
+| queueProxy.image.sha | string | `"fec35c5d66dad3d520e39de7f4f75ec6057962401f85761c143efc902f34efe7"` | SHA256 of the queue proxy image, either provide tag or SHA (SHA will be given priority) |
 | queueProxy.image.tag | string | `""` | Tag of the queue proxy image, either provide tag or SHA (SHA will be given priority) |
 | webhook.autoscaling.enabled | bool | `true` | Enables autoscaling for webhook deployment. |
 | webhook.autoscaling.maxReplicas | int | `20` | Maximum number of replicas for webhook. |
 | webhook.autoscaling.minReplicas | int | `1` | Minimum number of replicas for webhook. |
 | webhook.autoscaling.targetCPUUtilizationPercentage | int | `50` | Target CPU utlisation before it scales up/down. |
 | webhook.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/webhook"` | Repository of the webhook image |
-| webhook.image.sha | string | `"b001a58cb7eac7fbae4d83d8a111fa0f6726d36e86844d5b1dc3c9b8fdd5710a"` | SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority) |
+| webhook.image.sha | string | `"1dc88f22b885d56efc88aae8f0b3160d9bd9632bd0256847eed774e68b3a769b"` | SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | webhook.image.tag | string | `""` | Tag of the webhook image, either provide tag or SHA (SHA will be given priority) |
 | webhook.replicaCount | int | `1` | Number of replicas for the webhook deployment. |
 | webhook.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources requests and limits for webhook. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |

--- a/charts/knative-serving-core/README.md
+++ b/charts/knative-serving-core/README.md
@@ -81,12 +81,12 @@ The following table lists the configurable parameters of the Knative Serving Cor
 | controller.autoscaling.minReplicas | int | `1` | Minimum number of replicas for controller. |
 | controller.autoscaling.targetCPUUtilizationPercentage | int | `50` | Target CPU utlisation before it scales up/down. |
 | controller.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/controller"` | Repository of the controller image |
-| controller.image.sha | string | `"f81c354e13768a11ecdcb84c512af339a0cef596a418daa932e378c6c9c2c87e"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
+| controller.image.sha | string | `"97125c7b1ee8c188ddb9d39786161f18bc9166d4a81a01ceae320863c9d3c4e6"` | SHA256 of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.image.tag | string | `""` | Tag of the controller image, either provide tag or SHA (SHA will be given priority) |
 | controller.replicaCount | int | `1` | Number of replicas for the controller deployment. |
 | controller.resources | object | `{"limits":{"cpu":"1000m","memory":"1000Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}` | Resources requests and limits for controller. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | domainMapping.image.repository | string | `"gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping"` | Repository of the domain mapping image |
-| domainMapping.image.sha | string | `"ed47da2c95a9bf73dd3b511323023578e15730864852fb0c869f8f64a2bab39f"` | SHA256 of the domain mapping image, either provide tag or SHA (SHA will be given priority) |
+| domainMapping.image.sha | string | `"ff5c657ea01d3377be33d88bd3756f3fde49d99b1796c7adf5463b4eb20f37af"` | SHA256 of the domain mapping image, either provide tag or SHA (SHA will be given priority) |
 | domainMapping.image.tag | string | `""` | Tag of the domain mapping image, either provide tag or SHA (SHA will be given priority) |
 | domainMapping.replicaCount | int | `1` | Number of replicas for the domain mapping deployment. |
 | domainMapping.resources | object | `{"limits":{"cpu":"300m","memory":"400Mi"},"requests":{"cpu":"30m","memory":"40Mi"}}` | Resources requests and limits for domain mapping. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |

--- a/charts/knative-serving-core/crds/autoscaling-metrics.yaml
+++ b/charts/knative-serving-core/crds/autoscaling-metrics.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/autoscaling-metrics.yaml
+++ b/charts/knative-serving-core/crds/autoscaling-metrics.yaml
@@ -19,12 +19,11 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.7.4"
     knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/charts/knative-serving-core/crds/cluster-domain-claims.yaml
+++ b/charts/knative-serving-core/crds/cluster-domain-claims.yaml
@@ -17,12 +17,12 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.7.4"
     knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -35,12 +35,26 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: ClusterDomainClaim is a cluster-wide reservation for a particular domain name.
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the ClusterDomainClaim. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - namespace
+              properties:
+                namespace:
+                  description: Namespace is the namespace which is allowed to create a DomainMapping using this ClusterDomainClaim's name.
+                  type: string
   names:
     kind: ClusterDomainClaim
     plural: clusterdomainclaims

--- a/charts/knative-serving-core/crds/cluster-domain-claims.yaml
+++ b/charts/knative-serving-core/crds/cluster-domain-claims.yaml
@@ -20,6 +20,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/configurations.yaml
+++ b/charts/knative-serving-core/crds/configurations.yaml
@@ -22,6 +22,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/podspecable: "true"
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/configurations.yaml
+++ b/charts/knative-serving-core/crds/configurations.yaml
@@ -19,13 +19,12 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
-    knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
+    app.kubernetes.io/version: "1.7.4"
+    knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -108,6 +107,10 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -166,6 +169,17 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -181,7 +195,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -199,6 +213,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -212,6 +227,7 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
                                 description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
@@ -223,7 +239,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -261,10 +277,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -278,13 +299,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -312,7 +338,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -322,7 +347,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -360,10 +385,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -377,13 +407,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -415,24 +450,35 @@ spec:
                                 type: object
                                 properties:
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false.
+                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
-                                  runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -464,10 +510,27 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
                         imagePullSecrets:
                           description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
@@ -478,13 +541,60 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
                         timeoutSeconds:
-                          description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                          description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -528,9 +638,18 @@ spec:
                                   optional:
                                     description: Specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
                                 description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
                                 description: Items for all in one resources secrets, configmaps, and downward API
                                 type: object
@@ -576,6 +695,7 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
                                           description: information about the secret data to project
                                           type: object
@@ -606,6 +726,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           description: information about the serviceAccountToken data to project
                                           type: object
@@ -656,8 +777,6 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
             status:
               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
               type: object
@@ -680,7 +799,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string

--- a/charts/knative-serving-core/crds/domain-mappings.yaml
+++ b/charts/knative-serving-core/crds/domain-mappings.yaml
@@ -17,12 +17,11 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.7.4"
     knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -121,7 +120,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -227,7 +225,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string

--- a/charts/knative-serving-core/crds/domain-mappings.yaml
+++ b/charts/knative-serving-core/crds/domain-mappings.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/image-caching.yaml
+++ b/charts/knative-serving-core/crds/image-caching.yaml
@@ -17,12 +17,11 @@ kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.7.4"
     knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -34,8 +33,6 @@ spec:
     categories:
       - knative-internal
       - caching
-    shortNames:
-      - img
   scope: Namespaced
   versions:
     - name: v1alpha1
@@ -45,12 +42,81 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: Image is a Knative abstraction that encapsulates the interface by which Knative components express a desire to have a particular image cached.
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Image (from the client).
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  description: Image is the name of the container image url to cache across the cluster.
+                  type: string
+                imagePullSecrets:
+                  description: ImagePullSecrets contains the names of the Kubernetes Secrets containing login information used by the Pods which will run this container.
+                  type: array
+                  items:
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    type: object
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    x-kubernetes-map-type: atomic
+                serviceAccountName:
+                  description: 'ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods will run this container.  This is potentially used to authenticate the image pull if the service account has attached pull secrets.  For more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account'
+                  type: string
+            status:
+              description: Status communicates the observed state of the Image (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
       additionalPrinterColumns:
         - name: Image
           type: string

--- a/charts/knative-serving-core/crds/image-caching.yaml
+++ b/charts/knative-serving-core/crds/image-caching.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/ingresses.yaml
+++ b/charts/knative-serving-core/crds/ingresses.yaml
@@ -20,6 +20,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/ingresses.yaml
+++ b/charts/knative-serving-core/crds/ingresses.yaml
@@ -17,12 +17,12 @@ kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.7.4"
     knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -35,12 +35,212 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable URLs, load balance traffic, offer name based virtual hosting, etc. \n This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress which some highlighted modifications."
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the Ingress. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                httpOption:
+                  description: 'HTTPOption is the option of HTTP. It has the following two values: `HTTPOptionEnabled`, `HTTPOptionRedirected`'
+                  type: string
+                rules:
+                  description: A list of host rules used to configure the Ingress.
+                  type: array
+                  items:
+                    description: IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+                    type: object
+                    properties:
+                      hosts:
+                        description: 'Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently a rule value can only apply to the IP in the Spec of the parent . 2. The `:` delimiter is not respected because ports are not allowed. Currently the port of an Ingress is implicitly :80 for http and :443 for https. Both these may change in the future. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue. If multiple matching Hosts were provided, the first rule will take precedent.'
+                        type: array
+                        items:
+                          type: string
+                      http:
+                        description: HTTP represents a rule to apply against incoming requests. If the rule is satisfied, the request is routed to the specified backend.
+                        type: object
+                        required:
+                          - paths
+                        properties:
+                          paths:
+                            description: "A collection of paths that map requests to backends. \n If they are multiple matching paths, the first match takes precedence."
+                            type: array
+                            items:
+                              description: HTTPIngressPath associates a path regex with a backend. Incoming URLs matching the path are forwarded to the backend.
+                              type: object
+                              required:
+                                - splits
+                              properties:
+                                appendHeaders:
+                                  description: "AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. \n NOTE: This differs from K8s Ingress which doesn't allow header appending."
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                headers:
+                                  description: Headers defines header matching rules which is a map from a header name to HeaderMatch which specify a matching condition. When a request matched with all the header matching rules, the request is routed by the corresponding ingress rule. If it is empty, the headers are not used for matching
+                                  type: object
+                                  additionalProperties:
+                                    description: HeaderMatch represents a matching value of Headers in HTTPIngressPath. Currently, only the exact matching is supported.
+                                    type: object
+                                    required:
+                                      - exact
+                                    properties:
+                                      exact:
+                                        type: string
+                                path:
+                                  description: Path represents a literal prefix to which this rule should apply. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
+                                  type: string
+                                rewriteHost:
+                                  description: "RewriteHost rewrites the incoming request's host header. \n This field is currently experimental and not supported by all Ingress implementations."
+                                  type: string
+                                splits:
+                                  description: Splits defines the referenced service endpoints to which the traffic will be forwarded to.
+                                  type: array
+                                  items:
+                                    description: IngressBackendSplit describes all endpoints for a given service and port.
+                                    type: object
+                                    required:
+                                      - serviceName
+                                      - serviceNamespace
+                                      - servicePort
+                                    properties:
+                                      appendHeaders:
+                                        description: "AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. \n NOTE: This differs from K8s Ingress which doesn't allow header appending."
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      percent:
+                                        description: "Specifies the split percentage, a number between 0 and 100.  If only one split is specified, we default to 100. \n NOTE: This differs from K8s Ingress to allow percentage split."
+                                        type: integer
+                                      serviceName:
+                                        description: Specifies the name of the referenced service.
+                                        type: string
+                                      serviceNamespace:
+                                        description: "Specifies the namespace of the referenced service. \n NOTE: This differs from K8s Ingress to allow routing to different namespaces."
+                                        type: string
+                                      servicePort:
+                                        description: Specifies the port of the referenced service.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                      visibility:
+                        description: Visibility signifies whether this rule should `ClusterLocal`. If it's not specified then it defaults to `ExternalIP`.
+                        type: string
+                tls:
+                  description: 'TLS configuration. Currently Ingress only supports a single TLS port: 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.'
+                  type: array
+                  items:
+                    description: IngressTLS describes the transport layer security associated with an Ingress.
+                    type: object
+                    properties:
+                      hosts:
+                        description: Hosts is a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+                        type: array
+                        items:
+                          type: string
+                      secretName:
+                        description: SecretName is the name of the secret used to terminate SSL traffic.
+                        type: string
+                      secretNamespace:
+                        description: SecretNamespace is the namespace of the secret used to terminate SSL traffic. If not set the namespace should be assumed to be the same as the Ingress. If set the secret should have the same namespace as the Ingress otherwise the behaviour is undefined and not supported.
+                        type: string
+            status:
+              description: 'Status is the current state of the Ingress. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateLoadBalancer:
+                  description: PrivateLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: 'LoadBalancerIngressStatus represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                        type: object
+                        properties:
+                          domain:
+                            description: Domain is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: "DomainInternal is set if there is a cluster-local DNS name to access the Ingress. \n NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh."
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
+                publicLoadBalancer:
+                  description: PublicLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: 'LoadBalancerIngressStatus represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                        type: object
+                        properties:
+                          domain:
+                            description: Domain is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: "DomainInternal is set if there is a cluster-local DNS name to access the Ingress. \n NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh."
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
       additionalPrinterColumns:
         - name: Ready
           type: string

--- a/charts/knative-serving-core/crds/networking-certificates.yaml
+++ b/charts/knative-serving-core/crds/networking-certificates.yaml
@@ -17,12 +17,12 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.7.4"
     knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -35,12 +35,99 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: Certificate is responsible for provisioning a SSL certificate for the given hosts. It is a Knative abstraction for various SSL certificate provisioning solutions (such as cert-manager or self-signed SSL certificate).
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the Certificate. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - dnsNames
+                - secretName
+              properties:
+                dnsNames:
+                  description: DNSNames is a list of DNS names the Certificate could support. The wildcard format of DNSNames (e.g. *.default.example.com) is supported.
+                  type: array
+                  items:
+                    type: string
+                secretName:
+                  description: SecretName is the name of the secret resource to store the SSL certificate in.
+                  type: string
+            status:
+              description: 'Status is the current state of the Certificate. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                http01Challenges:
+                  description: HTTP01Challenges is a list of HTTP01 challenges that need to be fulfilled in order to get the TLS certificate..
+                  type: array
+                  items:
+                    description: HTTP01Challenge defines the status of a HTTP01 challenge that a certificate needs to fulfill.
+                    type: object
+                    properties:
+                      serviceName:
+                        description: ServiceName is the name of the service to serve HTTP01 challenge requests.
+                        type: string
+                      serviceNamespace:
+                        description: ServiceNamespace is the namespace of the service to serve HTTP01 challenge requests.
+                        type: string
+                      servicePort:
+                        description: ServicePort is the port of the service to serve HTTP01 challenge requests.
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      url:
+                        description: URL is the URL that the HTTP01 challenge is expected to serve on.
+                        type: string
+                notAfter:
+                  description: The expiration time of the TLS certificate stored in the secret named by this resource in spec.secretName.
+                  type: string
+                  format: date-time
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
       additionalPrinterColumns:
         - name: Ready
           type: string

--- a/charts/knative-serving-core/crds/networking-certificates.yaml
+++ b/charts/knative-serving-core/crds/networking-certificates.yaml
@@ -20,6 +20,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/pod-autoscalers.yaml
+++ b/charts/knative-serving-core/crds/pod-autoscalers.yaml
@@ -19,12 +19,11 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.7.4"
     knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -61,7 +60,7 @@ spec:
           jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
       schema:
         openAPIV3Schema:
-          description: 'PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative components instantiate autoscalers.  This definition is an abstraction that may be backed by multiple definitions.  For more information, see the Knative Pluggability presentation: https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit'
+          description: 'PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative components instantiate autoscalers.  This definition is an abstraction that may be backed by multiple definitions.  For more information, see the Knative Pluggability presentation: https://docs.google.com/presentation/d/19vW9HFZ6Puxt31biNZF3uLRejDmu82rxJIk1cWmxF7w/edit'
           type: object
           properties:
             apiVersion:
@@ -102,6 +101,7 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                  x-kubernetes-map-type: atomic
             status:
               description: Status communicates the observed state of the PodAutoscaler (from the controller).
               type: object
@@ -131,7 +131,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string

--- a/charts/knative-serving-core/crds/pod-autoscalers.yaml
+++ b/charts/knative-serving-core/crds/pod-autoscalers.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/revisions.yaml
+++ b/charts/knative-serving-core/crds/revisions.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/revisions.yaml
+++ b/charts/knative-serving-core/crds/revisions.yaml
@@ -19,12 +19,11 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.7.4"
     knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -87,6 +86,10 @@ spec:
               required:
                 - containers
               properties:
+                affinity:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 automountServiceAccountToken:
                   description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                   type: boolean
@@ -145,6 +148,17 @@ spec:
                                     optional:
                                       description: Specify whether the ConfigMap or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's namespace
                                   type: object
@@ -160,7 +174,7 @@ spec:
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
                                       type: boolean
-                              x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                       envFrom:
                         description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                         type: array
@@ -178,6 +192,7 @@ spec:
                                 optional:
                                   description: Specify whether the ConfigMap must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                             prefix:
                               description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
@@ -191,6 +206,7 @@ spec:
                                 optional:
                                   description: Specify whether the Secret must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                       image:
                         description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                         type: string
@@ -202,7 +218,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -240,10 +256,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -257,13 +278,18 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             type: object
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -291,7 +317,6 @@ spec:
                               description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                               type: string
                               default: TCP
-                          x-kubernetes-preserve-unknown-fields: true
                         x-kubernetes-list-map-keys:
                           - containerPort
                           - protocol
@@ -301,7 +326,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -339,10 +364,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -356,13 +386,18 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             type: object
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -390,28 +425,39 @@ spec:
                                 - type: string
                               x-kubernetes-int-or-string: true
                       securityContext:
-                        description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                         type: object
                         properties:
                           capabilities:
-                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                             type: object
                             properties:
+                              add:
+                                description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities type
+                                  type: string
                               drop:
                                 description: Removed capabilities
                                 type: array
                                 items:
                                   description: Capability represent POSIX capabilities type
                                   type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root filesystem. Default is false.
+                            description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
-                          runAsUser:
-                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
-                        x-kubernetes-preserve-unknown-fields: true
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                            type: integer
+                            format: int64
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                         type: string
@@ -443,10 +489,27 @@ spec:
                       workingDir:
                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                         type: string
-                    x-kubernetes-preserve-unknown-fields: true
+                dnsConfig:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dnsPolicy:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                  type: string
                 enableServiceLinks:
-                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                   type: boolean
+                hostAliases:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                idleTimeoutSeconds:
+                  description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                  type: integer
+                  format: int64
                 imagePullSecrets:
                   description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                   type: array
@@ -457,13 +520,60 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
+                    x-kubernetes-map-type: atomic
+                initContainers:
+                  description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                nodeSelector:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-map-type: atomic
+                priorityClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                responseStartTimeoutSeconds:
+                  description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                  type: integer
+                  format: int64
+                runtimeClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                schedulerName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                securityContext:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 serviceAccountName:
                   description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                   type: string
                 timeoutSeconds:
-                  description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                  description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                   type: integer
                   format: int64
+                tolerations:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                topologySpreadConstraints:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 volumes:
                   description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                   type: array
@@ -507,9 +617,18 @@ spec:
                           optional:
                             description: Specify whether the ConfigMap or its keys must be defined
                             type: boolean
+                        x-kubernetes-map-type: atomic
+                      emptyDir:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
                         description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
+                      persistentVolumeClaim:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       projected:
                         description: Items for all in one resources secrets, configmaps, and downward API
                         type: object
@@ -555,6 +674,7 @@ spec:
                                     optional:
                                       description: Specify whether the ConfigMap or its keys must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 secret:
                                   description: information about the secret data to project
                                   type: object
@@ -585,6 +705,7 @@ spec:
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 serviceAccountToken:
                                   description: information about the serviceAccountToken data to project
                                   type: object
@@ -635,8 +756,6 @@ spec:
                           secretName:
                             description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             type: string
-                    x-kubernetes-preserve-unknown-fields: true
-              x-kubernetes-preserve-unknown-fields: true
             status:
               description: RevisionStatus communicates the observed state of the Revision (from the controller).
               type: object
@@ -663,7 +782,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -693,17 +811,17 @@ spec:
                 desiredReplicas:
                   description: DesiredReplicas reflects the desired amount of pods running this revision.
                   type: integer
-                  format: 
-                int32initContainerStatuses:	
-                  description: 'InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image to their respective digests and their container name. The digests are resolved during the creation of Revision. ContainerStatuses holds the container name and image digests for both serving and non serving containers. ref: http://bit.ly/image-digests'	
-                  type: array	
-                  items:	
-                    description: ContainerStatus holds the information of container name and image digest value	
-                    type: object	
-                    properties:	
-                      imageDigest:	
-                        type: string	
-                      name:	
+                  format: int32
+                initContainerStatuses:
+                  description: 'InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image to their respective digests and their container name. The digests are resolved during the creation of Revision. ContainerStatuses holds the container name and image digests for both serving and non serving containers. ref: http://bit.ly/image-digests'
+                  type: array
+                  items:
+                    description: ContainerStatus holds the information of container name and image digest value
+                    type: object
+                    properties:
+                      imageDigest:
+                        type: string
+                      name:
                         type: string
                 logUrl:
                   description: LogURL specifies the generated logging url for this particular revision based on the revision url template specified in the controller's config.

--- a/charts/knative-serving-core/crds/routes.yaml
+++ b/charts/knative-serving-core/crds/routes.yaml
@@ -22,6 +22,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/routes.yaml
+++ b/charts/knative-serving-core/crds/routes.yaml
@@ -19,13 +19,12 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
-    knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
+    app.kubernetes.io/version: "1.7.4"
+    knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -88,7 +87,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -128,7 +127,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -162,7 +160,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:

--- a/charts/knative-serving-core/crds/serverless-services.yaml
+++ b/charts/knative-serving-core/crds/serverless-services.yaml
@@ -17,12 +17,12 @@ kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.7.4"
     knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -35,12 +35,107 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: 'ServerlessService is a proxy for the K8s service objects containing the endpoints for the revision, whether those are endpoints of the activator or revision pods. See: https://knative.page.link/naxz for details.'
           type: object
-          # this is a work around so we don't need to flush out the
-          # schema for each version at this time
-          #
-          # see issue: https://github.com/knative/serving/issues/912
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the ServerlessService. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - objectRef
+                - protocolType
+              properties:
+                mode:
+                  description: Mode describes the mode of operation of the ServerlessService.
+                  type: string
+                numActivators:
+                  description: NumActivators contains number of Activators that this revision should be assigned. O means — assign all.
+                  type: integer
+                  format: int32
+                objectRef:
+                  description: ObjectRef defines the resource that this ServerlessService is responsible for making "serverless".
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  x-kubernetes-map-type: atomic
+                protocolType:
+                  description: The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision. serving imports networking, so just use string.
+                  type: string
+            status:
+              description: 'Status is the current state of the ServerlessService. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateServiceName:
+                  description: PrivateServiceName holds the name of a core K8s Service resource that load balances over the user service pods backing this Revision.
+                  type: string
+                serviceName:
+                  description: ServiceName holds the name of a core K8s Service resource that load balances over the pods backing this Revision (activator or revision).
+                  type: string
       additionalPrinterColumns:
         - name: Mode
           type: string

--- a/charts/knative-serving-core/crds/serverless-services.yaml
+++ b/charts/knative-serving-core/crds/serverless-services.yaml
@@ -20,6 +20,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/crds/services.yaml
+++ b/charts/knative-serving-core/crds/services.yaml
@@ -19,14 +19,13 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
-    helm.sh/chart: knative-serving-core
-    app.kubernetes.io/version: "1.3.2"
-    serving.knative.dev/release: "v1.3.2"
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: knative-serving
-    knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
+    app.kubernetes.io/version: "1.7.4"
+    knative.dev/crd-install: "true"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: knative-serving-core
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -112,6 +111,10 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -170,6 +173,17 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -185,7 +199,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -203,6 +217,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -216,6 +231,7 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
                                 description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
@@ -227,7 +243,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -265,10 +281,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -282,13 +303,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -316,7 +342,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -326,7 +351,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -364,10 +389,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -381,13 +411,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -419,24 +454,35 @@ spec:
                                 type: object
                                 properties:
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false.
+                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
-                                  runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -468,10 +514,27 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
                         imagePullSecrets:
                           description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
@@ -482,13 +545,60 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
                         timeoutSeconds:
-                          description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                          description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -532,9 +642,18 @@ spec:
                                   optional:
                                     description: Specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
                                 description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
                                 description: Items for all in one resources secrets, configmaps, and downward API
                                 type: object
@@ -580,6 +699,7 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
                                           description: information about the secret data to project
                                           type: object
@@ -610,6 +730,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           description: information about the serviceAccountToken data to project
                                           type: object
@@ -660,8 +781,6 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
                 traffic:
                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.
                   type: array
@@ -676,7 +795,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -716,7 +835,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -756,7 +874,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:

--- a/charts/knative-serving-core/crds/services.yaml
+++ b/charts/knative-serving-core/crds/services.yaml
@@ -23,6 +23,7 @@ metadata:
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
     app.kubernetes.io/version: "1.7.4"
+    serving.knative.dev/release: "v1.7.4"
     knative.dev/crd-install: "true"
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: knative-serving-core

--- a/charts/knative-serving-core/templates/_helpers.tpl
+++ b/charts/knative-serving-core/templates/_helpers.tpl
@@ -7,6 +7,7 @@ Common labels
 helm.sh/chart: {{ .Chart.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+serving.knative.dev/release: {{ .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: knative-serving
@@ -27,6 +28,7 @@ autoscaling hpa labels
 helm.sh/chart: {{ .Chart.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+serving.knative.dev/release: {{ .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: knative-serving

--- a/charts/knative-serving-core/templates/_helpers.tpl
+++ b/charts/knative-serving-core/templates/_helpers.tpl
@@ -7,7 +7,6 @@ Common labels
 helm.sh/chart: {{ .Chart.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-serving.knative.dev/release: {{ .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: knative-serving
@@ -28,7 +27,6 @@ autoscaling hpa labels
 helm.sh/chart: {{ .Chart.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-serving.knative.dev/release: {{ .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: knative-serving

--- a/charts/knative-serving-core/templates/config-maps/autoscaler.yaml
+++ b/charts/knative-serving-core/templates/config-maps/autoscaler.yaml
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/component: autoscaler
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "16af78ce"
+    knative.dev/example-checksum: "47c2487f"
 data:
 {{- if .Values.config.autoscaler }}
   {{- toYaml .Values.config.autoscaler | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/defaults.yaml
+++ b/charts/knative-serving-core/templates/config-maps/defaults.yaml
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "a0feb4c6"
+    knative.dev/example-checksum: "e7973912"
 data:
 {{- if .Values.config.defaults }}
   {{- toYaml .Values.config.defaults | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/features.yaml
+++ b/charts/knative-serving-core/templates/config-maps/features.yaml
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "d9e300ba"
+    knative.dev/example-checksum: "4d5feafc"
 data:
 {{- if .Values.config.features }}
   {{- toYaml .Values.config.features | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/gc.yaml
+++ b/charts/knative-serving-core/templates/config-maps/gc.yaml
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/component: controller
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "45463e45"
+    knative.dev/example-checksum: "aa3813a8"
 data:
 {{- if .Values.config.gc }}
   {{- toYaml .Values.config.gc | nindent 2 }}

--- a/charts/knative-serving-core/templates/config-maps/network.yaml
+++ b/charts/knative-serving-core/templates/config-maps/network.yaml
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/component: networking
     {{- include "knative-serving-core.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "ddc3250f"
+    knative.dev/example-checksum: "73d96d1b"
 data:
 {{- if .Values.config.network }}
   {{- toYaml .Values.config.network | nindent 2 }}

--- a/charts/knative-serving-core/templates/mutating-webhooks/domain-mapping.yaml
+++ b/charts/knative-serving-core/templates/mutating-webhooks/domain-mapping.yaml
@@ -33,11 +33,11 @@ webhooks:
       - apiGroups:
           - serving.knative.dev
         apiVersions:
-          - v1alpha1
-          - v1beta1
+          - "*"
         operations:
           - CREATE
           - UPDATE
         scope: "*"
         resources:
           - domainmappings
+          - domainmappings/status

--- a/charts/knative-serving-core/templates/services/activator.yaml
+++ b/charts/knative-serving-core/templates/services/activator.yaml
@@ -37,4 +37,7 @@ spec:
     - name: http2
       port: 81
       targetPort: 8013
+    - name: https
+      port: 443
+      targetPort: 8112
   type: ClusterIP

--- a/charts/knative-serving-core/templates/validating-webhooks/domain-mapping.yaml
+++ b/charts/knative-serving-core/templates/validating-webhooks/domain-mapping.yaml
@@ -33,8 +33,7 @@ webhooks:
       - apiGroups:
           - serving.knative.dev
         apiVersions:
-          - v1alpha1
-          - v1beta1
+          - "*"
         operations:
           - CREATE
           - UPDATE
@@ -42,3 +41,4 @@ webhooks:
         scope: "*"
         resources:
           - domainmappings
+          - domainmappings/status

--- a/charts/knative-serving-core/values.yaml
+++ b/charts/knative-serving-core/values.yaml
@@ -928,7 +928,7 @@ controller:
     # -- Tag of the controller image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the controller image, either provide tag or SHA (SHA will be given priority)
-    sha: "f81c354e13768a11ecdcb84c512af339a0cef596a418daa932e378c6c9c2c87e"
+    sha: "97125c7b1ee8c188ddb9d39786161f18bc9166d4a81a01ceae320863c9d3c4e6"
   # -- Number of replicas for the controller deployment.
   replicaCount: 1
   # -- Resources requests and limits for controller. This should be set
@@ -949,7 +949,7 @@ domainMapping:
     # -- Tag of the domain mapping image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the domain mapping image, either provide tag or SHA (SHA will be given priority)
-    sha: "ed47da2c95a9bf73dd3b511323023578e15730864852fb0c869f8f64a2bab39f"
+    sha: "ff5c657ea01d3377be33d88bd3756f3fde49d99b1796c7adf5463b4eb20f37af"
   # -- Number of replicas for the domain mapping deployment.
   replicaCount: 1
   # -- Resources requests and limits for domain mapping. This should be set

--- a/charts/knative-serving-core/values.yaml
+++ b/charts/knative-serving-core/values.yaml
@@ -14,22 +14,852 @@ global:
 # -- Please check out the Knative documentation in https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-core.yaml
 config:
   autoscaler: {}
+    # # The Revision ContainerConcurrency field specifies the maximum number
+    # # of requests the Container can handle at once. Container concurrency
+    # # target percentage is how much of that maximum to use in a stable
+    # # state. E.g. if a Revision specifies ContainerConcurrency of 10, then
+    # # the Autoscaler will try to maintain 7 concurrent connections per pod
+    # # on average.
+    # # Note: this limit will be applied to container concurrency set at every
+    # # level (ConfigMap, Revision Spec or Annotation).
+    # # For legacy and backwards compatibility reasons, this value also accepts
+    # # fractional values in (0, 1] interval (i.e. 0.7 ⇒ 70%).
+    # # Thus minimal percentage value must be greater than 1.0, or it will be
+    # # treated as a fraction.
+    # # NOTE: that this value does not affect actual number of concurrent requests
+    # #       the user container may receive, but only the average number of requests
+    # #       that the revision pods will receive.
+    # container-concurrency-target-percentage: "70"
+
+    # # The container concurrency target default is what the Autoscaler will
+    # # try to maintain when concurrency is used as the scaling metric for the
+    # # Revision and the Revision specifies unlimited concurrency.
+    # # When revision explicitly specifies container concurrency, that value
+    # # will be used as a scaling target for autoscaler.
+    # # When specifying unlimited concurrency, the autoscaler will
+    # # horizontally scale the application based on this target concurrency.
+    # # This is what we call "soft limit" in the documentation, i.e. it only
+    # # affects number of pods and does not affect the number of requests
+    # # individual pod processes.
+    # # The value must be a positive number such that the value multiplied
+    # # by container-concurrency-target-percentage is greater than 0.01.
+    # # NOTE: that this value will be adjusted by application of
+    # #       container-concurrency-target-percentage, i.e. by default
+    # #       the system will target on average 70 concurrent requests
+    # #       per revision pod.
+    # # NOTE: Only one metric can be used for autoscaling a Revision.
+    # container-concurrency-target-default: "100"
+
+    # # The requests per second (RPS) target default is what the Autoscaler will
+    # # try to maintain when RPS is used as the scaling metric for a Revision and
+    # # the Revision specifies unlimited RPS. Even when specifying unlimited RPS,
+    # # the autoscaler will horizontally scale the application based on this
+    # # target RPS.
+    # # Must be greater than 1.0.
+    # # NOTE: Only one metric can be used for autoscaling a Revision.
+    # requests-per-second-target-default: "200"
+
+    # # The target burst capacity specifies the size of burst in concurrent
+    # # requests that the system operator expects the system will receive.
+    # # Autoscaler will try to protect the system from queueing by introducing
+    # # Activator in the request path if the current spare capacity of the
+    # # service is less than this setting.
+    # # If this setting is 0, then Activator will be in the request path only
+    # # when the revision is scaled to 0.
+    # # If this setting is > 0 and container-concurrency-target-percentage is
+    # # 100% or 1.0, then activator will always be in the request path.
+    # # -1 denotes unlimited target-burst-capacity and activator will always
+    # # be in the request path.
+    # # Other negative values are invalid.
+    # target-burst-capacity: "211"
+
+    # # When operating in a stable mode, the autoscaler operates on the
+    # # average concurrency over the stable window.
+    # # Stable window must be in whole seconds.
+    # stable-window: "60s"
+
+    # # When observed average concurrency during the panic window reaches
+    # # panic-threshold-percentage the target concurrency, the autoscaler
+    # # enters panic mode. When operating in panic mode, the autoscaler
+    # # scales on the average concurrency over the panic window which is
+    # # panic-window-percentage of the stable-window.
+    # # Must be in the [1, 100] range.
+    # # When computing the panic window it will be rounded to the closest
+    # # whole second, at least 1s.
+    # panic-window-percentage: "10.0"
+
+    # # The percentage of the container concurrency target at which to
+    # # enter panic mode when reached within the panic window.
+    # panic-threshold-percentage: "200.0"
+
+    # # Max scale up rate limits the rate at which the autoscaler will
+    # # increase pod count. It is the maximum ratio of desired pods versus
+    # # observed pods.
+    # # Cannot be less or equal to 1.
+    # # I.e with value of 2.0 the number of pods can at most go N to 2N
+    # # over single Autoscaler period (2s), but at least N to
+    # # N+1, if Autoscaler needs to scale up.
+    # max-scale-up-rate: "1000.0"
+
+    # # Max scale down rate limits the rate at which the autoscaler will
+    # # decrease pod count. It is the maximum ratio of observed pods versus
+    # # desired pods.
+    # # Cannot be less or equal to 1.
+    # # I.e. with value of 2.0 the number of pods can at most go N to N/2
+    # # over single Autoscaler evaluation period (2s), but at
+    # # least N to N-1, if Autoscaler needs to scale down.
+    # max-scale-down-rate: "2.0"
+
+    # # Scale to zero feature flag.
+    # enable-scale-to-zero: "true"
+
+    # # Scale to zero grace period is the time an inactive revision is left
+    # # running before it is scaled to zero (must be positive, but recommended
+    # # at least a few seconds if running with mesh networking).
+    # # This is the upper limit and is provided not to enforce timeout after
+    # # the revision stopped receiving requests for stable window, but to
+    # # ensure network reprogramming to put activator in the path has completed.
+    # # If the system determines that a shorter period is satisfactory,
+    # # then the system will only wait that amount of time before scaling to 0.
+    # # NOTE: this period might actually be 0, if activator has been
+    # # in the request path sufficiently long.
+    # # If there is necessity for the last pod to linger longer use
+    # # scale-to-zero-pod-retention-period flag.
+    # scale-to-zero-grace-period: "30s"
+
+    # # Scale to zero pod retention period defines the minimum amount
+    # # of time the last pod will remain after Autoscaler has decided to
+    # # scale to zero.
+    # # This flag is for the situations where the pod startup is very expensive
+    # # and the traffic is bursty (requiring smaller windows for fast action),
+    # # but patchy.
+    # # The larger of this flag and `scale-to-zero-grace-period` will effectively
+    # # determine how the last pod will hang around.
+    # scale-to-zero-pod-retention-period: "0s"
+
+    # # pod-autoscaler-class specifies the default pod autoscaler class
+    # # that should be used if none is specified. If omitted,
+    # # the Knative Pod Autoscaler (KPA) is used by default.
+    # pod-autoscaler-class: "kpa.autoscaling.knative.dev"
+
+    # # The capacity of a single activator task.
+    # # The `unit` is one concurrent request proxied by the activator.
+    # # activator-capacity must be at least 1.
+    # # This value is used for computation of the Activator subset size.
+    # # See the algorithm here: http://bit.ly/38XiCZ3.
+    # # TODO(vagababov): tune after actual benchmarking.
+    # activator-capacity: "100.0"
+
+    # # initial-scale is the cluster-wide default value for the initial target
+    # # scale of a revision after creation, unless overridden by the
+    # # "autoscaling.knative.dev/initialScale" annotation.
+    # # This value must be greater than 0 unless allow-zero-initial-scale is true.
+    # initial-scale: "1"
+
+    # # allow-zero-initial-scale controls whether either the cluster-wide initial-scale flag,
+    # # or the "autoscaling.knative.dev/initialScale" annotation, can be set to 0.
+    # allow-zero-initial-scale: "false"
+
+    # # min-scale is the cluster-wide default value for the min scale of a revision,
+    # # unless overridden by the "autoscaling.knative.dev/minScale" annotation.
+    # min-scale: "0"
+
+    # # max-scale is the cluster-wide default value for the max scale of a revision,
+    # # unless overridden by the "autoscaling.knative.dev/maxScale" annotation.
+    # # If set to 0, the revision has no maximum scale.
+    # max-scale: "0"
+
+    # # scale-down-delay is the amount of time that must pass at reduced
+    # # concurrency before a scale down decision is applied. This can be useful,
+    # # for example, to maintain replica count and avoid a cold start penalty if
+    # # more requests come in within the scale down delay period.
+    # # The default, 0s, imposes no delay at all.
+    # scale-down-delay: "0s"
+
+    # # max-scale-limit sets the maximum permitted value for the max scale of a revision.
+    # # When this is set to a positive value, a revision with a maxScale above that value
+    # # (including a maxScale of "0" = unlimited) is disallowed.
+    # # A value of zero (the default) allows any limit, including unlimited.
+    # max-scale-limit: "0"
   defaults: {}
+    # # revision-timeout-seconds contains the default number of
+    # # seconds to use for the revision's per-request timeout, if
+    # # none is specified.
+    # revision-timeout-seconds: "300"  # 5 minutes
+
+    # # max-revision-timeout-seconds contains the maximum number of
+    # # seconds that can be used for revision-timeout-seconds.
+    # # This value must be greater than or equal to revision-timeout-seconds.
+    # # If omitted, the system default is used (600 seconds).
+    # #
+    # # If this value is increased, the activator's terminationGraceTimeSeconds
+    # # should also be increased to prevent in-flight requests being disrupted.
+    # max-revision-timeout-seconds: "600"  # 10 minutes
+
+    # # revision-response-start-timeout-seconds contains the default number of
+    # # seconds a request will be allowed to stay open while waiting to
+    # # receive any bytes from the user's application, if none is specified.
+    # #
+    # # This defaults to 'revision-timeout-seconds'
+    # revision-response-start-timeout-seconds: "300"
+
+    # # revision-idle-timeout-seconds contains the default number of
+    # # seconds a request will be allowed to stay open while not receiving any
+    # # bytes from the user's application, if none is specified.
+    # revision-idle-timeout-seconds: "0"  # infinite
+
+    # # revision-cpu-request contains the cpu allocation to assign
+    # # to revisions by default.  If omitted, no value is specified
+    # # and the system default is used.
+    # # Below is an example of setting revision-cpu-request.
+    # # By default, it is not set by Knative.
+    # revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
+
+    # # revision-memory-request contains the memory allocation to assign
+    # # to revisions by default.  If omitted, no value is specified
+    # # and the system default is used.
+    # # Below is an example of setting revision-memory-request.
+    # # By default, it is not set by Knative.
+    # revision-memory-request: "100M"  # 100 megabytes of memory
+
+    # # revision-ephemeral-storage-request contains the ephemeral storage
+    # # allocation to assign to revisions by default.  If omitted, no value is
+    # # specified and the system default is used.
+    # revision-ephemeral-storage-request: "500M"  # 500 megabytes of storage
+
+    # # revision-cpu-limit contains the cpu allocation to limit
+    # # revisions to by default.  If omitted, no value is specified
+    # # and the system default is used.
+    # # Below is an example of setting revision-cpu-limit.
+    # # By default, it is not set by Knative.
+    # revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
+
+    # # revision-memory-limit contains the memory allocation to limit
+    # # revisions to by default.  If omitted, no value is specified
+    # # and the system default is used.
+    # # Below is an example of setting revision-memory-limit.
+    # # By default, it is not set by Knative.
+    # revision-memory-limit: "200M"  # 200 megabytes of memory
+
+    # # revision-ephemeral-storage-limit contains the ephemeral storage
+    # # allocation to limit revisions to by default.  If omitted, no value is
+    # # specified and the system default is used.
+    # revision-ephemeral-storage-limit: "750M"  # 750 megabytes of storage
+
+    # # container-name-template contains a template for the default
+    # # container name, if none is specified.  This field supports
+    # # Go templating and is supplied with the ObjectMeta of the
+    # # enclosing Service or Configuration, so values such as
+    # # {{.Name}} are also valid.
+    # container-name-template: "user-container"
+
+    # # init-container-name-template contains a template for the default
+    # # init container name, if none is specified.  This field supports
+    # # Go templating and is supplied with the ObjectMeta of the
+    # # enclosing Service or Configuration, so values such as
+    # # {{.Name}} are also valid.
+    # init-container-name-template: "init-container"
+
+    # # container-concurrency specifies the maximum number
+    # # of requests the Container can handle at once, and requests
+    # # above this threshold are queued.  Setting a value of zero
+    # # disables this throttling and lets through as many requests as
+    # # the pod receives.
+    # container-concurrency: "0"
+
+    # # The container concurrency max limit is an operator setting ensuring that
+    # # the individual revisions cannot have arbitrary large concurrency
+    # # values, or autoscaling targets. `container-concurrency` default setting
+    # # must be at or below this value.
+    # #
+    # # Must be greater than 1.
+    # #
+    # # Note: even with this set, a user can choose a containerConcurrency
+    # # of 0 (i.e. unbounded) unless allow-container-concurrency-zero is
+    # # set to "false".
+    # container-concurrency-max-limit: "1000"
+
+    # # allow-container-concurrency-zero controls whether users can
+    # # specify 0 (i.e. unbounded) for containerConcurrency.
+    # allow-container-concurrency-zero: "true"
+
+    # # enable-service-links specifies the default value used for the
+    # # enableServiceLinks field of the PodSpec, when it is omitted by the user.
+    # # See: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service
+    # #
+    # # This is a tri-state flag with possible values of (true|false|default).
+    # #
+    # # In environments with large number of services it is suggested
+    # # to set this value to `false`.
+    # # See https://github.com/knative/serving/issues/8498.
+    # enable-service-links: "false"
   deployment:
-    queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b
+    queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:fec35c5d66dad3d520e39de7f4f75ec6057962401f85761c143efc902f34efe7
+    #  # List of repositories for which tag to digest resolving should be skipped
+    # registries-skipping-tag-resolving: "kind.local,ko.local,dev.local"
+
+    # # Maximum time allowed for an image's digests to be resolved.
+    # digest-resolution-timeout: "10s"
+
+    # # Duration we wait for the deployment to be ready before considering it failed.
+    # progress-deadline: "600s"
+
+    # # Sets the queue proxy's CPU request.
+    # # If omitted, a default value (currently "25m"), is used.
+    # queue-sidecar-cpu-request: "25m"
+
+    # # Sets the queue proxy's CPU limit.
+    # # If omitted, no value is specified and the system default is used.
+    # queue-sidecar-cpu-limit: "1000m"
+
+    # # Sets the queue proxy's memory request.
+    # # If omitted, no value is specified and the system default is used.
+    # queue-sidecar-memory-request: "400Mi"
+
+    # # Sets the queue proxy's memory limit.
+    # # If omitted, no value is specified and the system default is used.
+    # queue-sidecar-memory-limit: "800Mi"
+
+    # # Sets the queue proxy's ephemeral storage request.
+    # # If omitted, no value is specified and the system default is used.
+    # queue-sidecar-ephemeral-storage-request: "512Mi"
+
+    # # Sets the queue proxy's ephemeral storage limit.
+    # # If omitted, no value is specified and the system default is used.
+    # queue-sidecar-ephemeral-storage-limit: "1024Mi"
+
+    # # The freezer service endpoint that queue-proxy calls when its traffic drops to zero or
+    # # scales up from zero.
+    # #
+    # # Freezer service is available at: https://github.com/knative-sandbox/container-freezer
+    # # or users may write their own service.
+    # #
+    # # The value will need to include both the host and the port that will be accessed.
+    # # For the host, $HOST_IP can be passed, and the appropriate host IP value will be swapped
+    # # in at runtime, which will enable the freezer daemonset to be reachable via the node IP.
+    # #
+    # # As an example:
+    # #     concurrency-state-endpoint: "http://$HOST_IP:9696"
+    # #
+    # # If not set, queue proxy takes no action (this is the default behavior).
+    # #
+    # # When enabled, a serviceAccountToken will be mounted to queue-proxy using
+    # # a projected volume. This requires the Service Account Token Volume Projection feature
+    # # to be enabled. For details, see this link:
+    # # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
+    # #
+    # # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
+    # concurrency-state-endpoint: ""
   domain: {}
+    # Default value for domain.
+    # Although it will match all routes, it is the least-specific rule so it
+    # will only be used if no other domain matches.
+    # example.com: |
+
+    # # These are example settings of domain.
+    # # example.org will be used for routes having app=nonprofit.
+    # example.org: |
+    #   selector:
+    #     app: nonprofit
+
+    # # Routes having the cluster domain suffix (by default 'svc.cluster.local')
+    # # will not be exposed through Ingress. You can define your own label
+    # # selector to assign that domain suffix to your Route here, or you can set
+    # # the label
+    # #    "networking.knative.dev/visibility=cluster-local"
+    # # to achieve the same effect.  This shows how to make routes having
+    # # the label app=secret only exposed to the local cluster.
+    # svc.cluster.local: |
+    #   selector:
+    #     app: secret
   features: {}
+    # # Indicates whether multi container support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#multi-containers
+    # multi-container: "enabled"
+
+    # # Indicates whether Kubernetes affinity support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-node-affinity
+    # kubernetes.podspec-affinity: "disabled"
+
+    # # Indicates whether Kubernetes topologySpreadConstraints support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-topology-spread-constraints
+    # kubernetes.podspec-topologyspreadconstraints: "disabled"
+
+    # # Indicates whether Kubernetes hostAliases support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-host-aliases
+    # kubernetes.podspec-hostaliases: "disabled"
+
+    # # Indicates whether Kubernetes nodeSelector support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-node-selector
+    # kubernetes.podspec-nodeselector: "disabled"
+
+    # # Indicates whether Kubernetes tolerations support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-toleration
+    # kubernetes.podspec-tolerations: "disabled"
+
+    # # Indicates whether Kubernetes FieldRef support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-fieldref
+    # kubernetes.podspec-fieldref: "disabled"
+
+    # # Indicates whether Kubernetes RuntimeClassName support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-runtime-class
+    # kubernetes.podspec-runtimeclassname: "disabled"
+
+    # # Indicates whether Kubernetes DNSPolicy support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dnspolicy
+    # kubernetes.podspec-dnspolicy: "disabled"
+
+    # # Indicates whether Kubernetes DNSConfig support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dnsconfig
+    # kubernetes.podspec-dnsconfig: "disabled"
+
+    # # This feature allows end-users to set a subset of fields on the Pod's SecurityContext
+    # #
+    # # When set to "enabled" or "allowed" it allows the following
+    # # PodSecurityContext properties:
+    # # - FSGroup
+    # # - RunAsGroup
+    # # - RunAsNonRoot
+    # # - SupplementalGroups
+    # # - RunAsUser
+    # #
+    # # This feature flag should be used with caution as the PodSecurityContext
+    # # properties may have a side-effect on non-user sidecar containers that come
+    # # from Knative or your service mesh
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-security-context
+    # kubernetes.podspec-securitycontext: "disabled"
+
+    # # Indicates whether Kubernetes PriorityClassName support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-priority-class-name
+    # kubernetes.podspec-priorityclassname: "disabled"
+
+    # # Indicates whether Kubernetes SchedulerName support is enabled
+    # #
+    # # WARNING: Cannot safely be disabled once enabled.
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-scheduler-name
+    # kubernetes.podspec-schedulername: "disabled"
+
+    # # This feature flag allows end-users to add a subset of capabilities on the Pod's SecurityContext.
+    # #
+    # # When set to "enabled" or "allowed" it allows capabilities to be added to the container.
+    # # For a list of possible capabilities, see https://man7.org/linux/man-pages/man7/capabilities.7.html
+    # kubernetes.containerspec-addcapabilities: "disabled"
+
+    # # This feature validates PodSpecs from the validating webhook
+    # # against the K8s API Server.
+    # #
+    # # When "enabled", the server will always run the extra validation.
+    # # When "allowed", the server will not run the dry-run validation by default.
+    # #   However, clients may enable the behavior on an individual Service by
+    # #   attaching the following metadata annotation: "features.knative.dev/podspec-dryrun":"enabled".
+    # # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dry-run
+    # kubernetes.podspec-dryrun: "allowed"
+
+    # # Controls whether tag header based routing feature are enabled or not.
+    # # 1. Enabled: enabling tag header based routing
+    # # 2. Disabled: disabling tag header based routing
+    # # See: https://knative.dev/docs/serving/feature-flags/#tag-header-based-routing
+    # tag-header-based-routing: "disabled"
+
+    # # Controls whether http2 auto-detection should be enabled or not.
+    # # 1. Enabled: http2 connection will be attempted via upgrade.
+    # # 2. Disabled: http2 connection will only be attempted when port name is set to "h2c".
+    # autodetect-http2: "disabled"
+
+    # # Controls whether volume support for EmptyDir is enabled or not.
+    # # 1. Enabled: enabling EmptyDir volume support
+    # # 2. Disabled: disabling EmptyDir volume support
+    # kubernetes.podspec-volumes-emptydir: "disabled"
+
+    # # Controls whether init containers support is enabled or not.
+    # # 1. Enabled: enabling init containers support
+    # # 2. Disabled: disabling init containers support
+    # kubernetes.podspec-init-containers: "disabled"
+
+    # # Controls whether persistent volume claim support is enabled or not.
+    # # 1. Enabled: enabling persistent volume claim support
+    # # 2. Disabled: disabling persistent volume claim support
+    # kubernetes.podspec-persistent-volume-claim: "disabled"
+
+    # # Controls whether write access for persistent volumes is enabled or not.
+    # # 1. Enabled: enabling write access for persistent volumes
+    # # 2. Disabled: disabling write access for persistent volumes
+    # kubernetes.podspec-persistent-volume-write: "disabled"
+
+    # # Controls if the queue proxy podInfo feature is enabled, allowed or disabled
+    # #
+    # # This feature should be enabled/allowed when using queue proxy Options (Extensions)
+    # # Enabling will mount a podInfo volume to the queue proxy container.
+    # # The volume will contains an 'annotations' file (from the pod's annotation field).
+    # # The annotations in this file include the Service annotations set by the client creating the service.
+    # # If mounted, the annotations can be accessed by queue proxy extensions at /etc/podinfo/annnotations
+    # #
+    # # 1. "enabled": always mount a podInfo volume
+    # # 2. "disabled": never mount a podInfo volume
+    # # 3. "allowed": by default, do not mount a podInfo volume
+    # #   However, a client may mount the podInfo volume on an individual Service by attaching
+    # #   the following metadata annotation to the Service: "features.knative.dev/queueproxy-podinfo":"enabled".
+    # #
+    # # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
+    # queueproxy.mount-podinfo: "disabled"
   gc: {}
+    # # ---------------------------------------
+    # # Garbage Collector Settings
+    # # ---------------------------------------
+    # #
+    # # Active
+    # #   * Revisions which are referenced by a Route are considered active.
+    # #   * Individual revisions may be marked with the annotation
+    # #      "serving.knative.dev/no-gc":"true" to be permanently considered active.
+    # #   * Active revisions are not considered for GC.
+    # # Retention
+    # #   * Revisions are retained if they are any of the following:
+    # #       1. Active
+    # #       2. Were created within "retain-since-create-time"
+    # #       3. Were last referenced by a route within
+    # #           "retain-since-last-active-time"
+    # #       4. There are fewer than "min-non-active-revisions"
+    # #     If none of these conditions are met, or if the count of revisions exceed
+    # #      "max-non-active-revisions", they will be deleted by GC.
+    # #     The special value "disabled" may be used to turn off these limits.
+    # #
+    # # Example config to immediately collect any inactive revision:
+    # #    min-non-active-revisions: "0"
+    # #    max-non-active-revisions: "0"
+    # #    retain-since-create-time: "disabled"
+    # #    retain-since-last-active-time: "disabled"
+    # #
+    # # Example config to always keep around the last ten non-active revisions:
+    # #     retain-since-create-time: "disabled"
+    # #     retain-since-last-active-time: "disabled"
+    # #     max-non-active-revisions: "10"
+    # #
+    # # Example config to disable all garbage collection:
+    # #     retain-since-create-time: "disabled"
+    # #     retain-since-last-active-time: "disabled"
+    # #     max-non-active-revisions: "disabled"
+    # #
+    # # Example config to keep recently deployed or active revisions,
+    # # always maintain the last two in case of rollback, and prevent
+    # # burst activity from exploding the count of old revisions:
+    # #      retain-since-create-time: "48h"
+    # #      retain-since-last-active-time: "15h"
+    # #      min-non-active-revisions: "2"
+    # #      max-non-active-revisions: "1000"
+
+    # # Duration since creation before considering a revision for GC or "disabled".
+    # retain-since-create-time: "48h"
+
+    # # Duration since active before considering a revision for GC or "disabled".
+    # retain-since-last-active-time: "15h"
+
+    # # Minimum number of non-active revisions to retain.
+    # min-non-active-revisions: "20"
+
+    # # Maximum number of non-active revisions to retain
+    # # or "disabled" to disable any maximum limit.
+    # max-non-active-revisions: "1000"
   leaderElection:
+    # lease-duration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
     lease-duration: "60s"
+    # renew-deadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
     renew-deadline: "40s"
+    # retry-period is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retry-period: "10s"
-  buckets: "1"
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"
   logging:
     logging.request-log-template: ""
+    #  # Common configuration for all Knative codebase
+    # zap-logger-config: |
+    #   {
+    #     "level": "info",
+    #     "development": false,
+    #     "outputPaths": ["stdout"],
+    #     "errorOutputPaths": ["stderr"],
+    #     "encoding": "json",
+    #     "encoderConfig": {
+    #       "timeKey": "timestamp",
+    #       "levelKey": "severity",
+    #       "nameKey": "logger",
+    #       "callerKey": "caller",
+    #       "messageKey": "message",
+    #       "stacktraceKey": "stacktrace",
+    #       "lineEnding": "",
+    #       "levelEncoder": "",
+    #       "timeEncoder": "iso8601",
+    #       "durationEncoder": "",
+    #       "callerEncoder": ""
+    #     }
+    #   }
+
+    # # Log level overrides
+    # # For all components except the queue proxy,
+    # # changes are picked up immediately.
+    # # For queue proxy, changes require recreation of the pods.
+    # loglevel.controller: "info"
+    # loglevel.autoscaler: "info"
+    # loglevel.queueproxy: "info"
+    # loglevel.webhook: "info"
+    # loglevel.activator: "info"
+    # loglevel.hpaautoscaler: "info"
+    # loglevel.net-certmanager-controller: "info"
+    # loglevel.net-istio-controller: "info"
+    # loglevel.net-contour-controller: "info"
   network: {}
+    # # ingress-class specifies the default ingress class
+    # # to use when not dictated by Route annotation.
+    # #
+    # # If not specified, will use the Istio ingress.
+    # #
+    # # Note that changing the Ingress class of an existing Route
+    # # will result in undefined behavior.  Therefore it is best to only
+    # # update this value during the setup of Knative, to avoid getting
+    # # undefined behavior.
+    # ingress-class: "istio.ingress.networking.knative.dev"
+
+    # # certificate-class specifies the default Certificate class
+    # # to use when not dictated by Route annotation.
+    # #
+    # # If not specified, will use the Cert-Manager Certificate.
+    # #
+    # # Note that changing the Certificate class of an existing Route
+    # # will result in undefined behavior.  Therefore it is best to only
+    # # update this value during the setup of Knative, to avoid getting
+    # # undefined behavior.
+    # certificate-class: "cert-manager.certificate.networking.knative.dev"
+
+    # # namespace-wildcard-cert-selector specifies a LabelSelector which
+    # # determines which namespaces should have a wildcard certificate
+    # # provisioned.
+    # #
+    # # Use an empty value to disable the feature (this is the default):
+    # #   namespace-wildcard-cert-selector: ""
+    # #
+    # # Use an empty object to enable for all namespaces
+    # #   namespace-wildcard-cert-selector: {}
+    # #
+    # # Useful labels include the "kubernetes.io/metadata.name" label to
+    # # avoid provisioning a certifcate for the "kube-system" namespaces.
+    # # Use the following selector to match pre-1.0 behavior of using
+    # # "networking.knative.dev/disableWildcardCert" to exclude namespaces:
+    # #
+    # # matchExpressions:
+    # # - key: "networking.knative.dev/disableWildcardCert"
+    # #   operator: "NotIn"
+    # #   values: ["true"]
+    # namespace-wildcard-cert-selector: ""
+
+    # # domain-template specifies the golang text template string to use
+    # # when constructing the Knative service's DNS name. The default
+    # # value is "{{.Name}}.{{.Namespace}}.{{.Domain}}".
+    # #
+    # # Valid variables defined in the template include Name, Namespace, Domain,
+    # # Labels, and Annotations. Name will be the result of the tagTemplate
+    # # below, if a tag is specified for the route.
+    # #
+    # # Changing this value might be necessary when the extra levels in
+    # # the domain name generated is problematic for wildcard certificates
+    # # that only support a single level of domain name added to the
+    # # certificate's domain. In those cases you might consider using a value
+    # # of "{{.Name}}-{{.Namespace}}.{{.Domain}}", or removing the Namespace
+    # # entirely from the template. When choosing a new value be thoughtful
+    # # of the potential for conflicts - for example, when users choose to use
+    # # characters such as `-` in their service, or namespace, names.
+    # # {{.Annotations}} or {{.Labels}} can be used for any customization in the
+    # # go template if needed.
+    # # We strongly recommend keeping namespace part of the template to avoid
+    # # domain name clashes:
+    # # eg. '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
+    # # and you have an annotation {"sub":"foo"}, then the generated template
+    # # would be {Name}-{Namespace}.foo.{Domain}
+    # domain-template: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+
+    # # tagTemplate specifies the golang text template string to use
+    # # when constructing the DNS name for "tags" within the traffic blocks
+    # # of Routes and Configuration.  This is used in conjunction with the
+    # # domainTemplate above to determine the full URL for the tag.
+    # tag-template: "{{.Tag}}-{{.Name}}"
+
+    # # Controls whether TLS certificates are automatically provisioned and
+    # # installed in the Knative ingress to terminate external TLS connection.
+    # # 1. Enabled: enabling auto-TLS feature.
+    # # 2. Disabled: disabling auto-TLS feature.
+    # auto-tls: "Disabled"
+
+    # # Controls the behavior of the HTTP endpoint for the Knative ingress.
+    # # It requires autoTLS to be enabled.
+    # # 1. Enabled: The Knative ingress will be able to serve HTTP connection.
+    # # 2. Redirected: The Knative ingress will send a 301 redirect for all
+    # # http connections, asking the clients to use HTTPS.
+    # #
+    # # "Disabled" option is deprecated.
+    # http-protocol: "Enabled"
+
+    # # rollout-duration contains the minimal duration in seconds over which the
+    # # Configuration traffic targets are rolled out to the newest revision.
+    # rollout-duration: "0"
+
+    # # autocreate-cluster-domain-claims controls whether ClusterDomainClaims should
+    # # be automatically created (and deleted) as needed when DomainMappings are
+    # # reconciled.
+    # #
+    # # If this is "false" (the default), the cluster administrator is
+    # # responsible for creating ClusterDomainClaims and delegating them to
+    # # namespaces via their spec.Namespace field. This setting should be used in
+    # # multitenant environments which need to control which namespace can use a
+    # # particular domain name in a domain mapping.
+    # #
+    # # If this is "true", users are able to associate arbitrary names with their
+    # # services via the DomainMapping feature.
+    # autocreate-cluster-domain-claims: "false"
+
+    # # If true, networking plugins can add additional information to deployed
+    # # applications to make their pods directly accessible via their IPs even if mesh is
+    # # enabled and thus direct-addressability is usually not possible.
+    # # Consumers like Knative Serving can use this setting to adjust their behavior
+    # # accordingly, i.e. to drop fallback solutions for non-pod-addressable systems.
+    # #
+    # # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    # #       for now. Use with caution.
+    # enable-mesh-pod-addressability: "false"
+
+    # # mesh-compatibility-mode indicates whether consumers of network plugins
+    # # should directly contact Pod IPs (most efficient), or should use the
+    # # Cluster IP (less efficient, needed when mesh is enabled unless
+    # # `enable-mesh-pod-addressability`, above, is set).
+    # # Permitted values are:
+    # #  - "auto" (default): automatically determine which mesh mode to use by trying Pod IP and falling back to Cluster IP as needed.
+    # #  - "enabled": always use Cluster IP and do not attempt to use Pod IPs.
+    # #  - "disabled": always use Pod IPs and do not fall back to Cluster IP on failure.
+    # mesh-compatibility-mode: "auto"
+
+    # # Defines the scheme used for external URLs if autoTLS is not enabled.
+    # # This can be used for making Knative report all URLs as "HTTPS" for example, if you're
+    # # fronting Knative with an external loadbalancer that deals with TLS termination and
+    # # Knative doesn't know about that otherwise.
+    # default-external-scheme: "http"
+
+    # # internal-encryption indicates whether internal traffic is encrypted or not.
+    # # If this is "true", the following traffic are encrypted:
+    # #  - ingress to activator
+    # #  - ingress to queue-proxy
+    # #  - activator to queue-proxy
+    # #
+    # # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    # #       for now. Use with caution.
+    # internal-encryption: "false"
   observability: {}
+    # # logging.enable-var-log-collection defaults to false.
+    # # The fluentd daemon set will be set up to collect /var/log if
+    # # this flag is true.
+    # logging.enable-var-log-collection: "false"
+
+    # # logging.revision-url-template provides a template to use for producing the
+    # # logging URL that is injected into the status of each Revision.
+    # logging.revision-url-template: "http://logging.example.com/?revisionUID=${REVISION_UID}"
+
+    # # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+    # # requests.
+    # # NB: after 0.18 release logging.enable-request-log must be explicitly set to true
+    # # in order for request logging to be enabled.
+    # #
+    # # The value determines the shape of the request logs and it must be a valid go text/template.
+    # # It is important to keep this as a single line. Multiple lines are parsed as separate entities
+    # # by most collection agents and will split the request logs into multiple records.
+    # #
+    # # The following fields and functions are available to the template:
+    # #
+    # # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
+    # # representing an HTTP request received by the server.
+    # #
+    # # Response:
+    # # struct {
+    # #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+    # #   Size    int       // An int representing the size of the response.
+    # #   Latency float64   // A float64 representing the latency of the response in seconds.
+    # # }
+    # #
+    # # Revision:
+    # # struct {
+    # #   Name          string  // Knative revision name
+    # #   Namespace     string  // Knative revision namespace
+    # #   Service       string  // Knative service name
+    # #   Configuration string  // Knative configuration name
+    # #   PodName       string  // Name of the pod hosting the revision
+    # #   PodIP         string  // IP of the pod hosting the revision
+    # # }
+    # #
+    # logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+
+    # # If true, the request logging will be enabled.
+    # # NB: up to and including Knative version 0.18 if logging.request-log-template is non-empty, this value
+    # # will be ignored.
+    # logging.enable-request-log: "false"
+
+    # # If true, this enables queue proxy writing request logs for probe requests to stdout.
+    # # It uses the same template for user requests, i.e. logging.request-log-template.
+    # logging.enable-probe-request-log: "false"
+
+    # # metrics.backend-destination field specifies the system metrics destination.
+    # # It supports either prometheus (the default) or opencensus.
+    # metrics.backend-destination: prometheus
+
+    # # metrics.request-metrics-backend-destination specifies the request metrics
+    # # destination. It enables queue proxy to send request metrics.
+    # # Currently supported values: prometheus (the default), opencensus.
+    # metrics.request-metrics-backend-destination: prometheus
+
+    # # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
+    # # The HTTP context root for profiling is then /debug/pprof/.
+    # profiling.enable: "false"
   tracing: {}
+    # # This may be "zipkin" or "none" (default)
+    # backend: "none"
+
+    # # URL to zipkin collector where traces are sent.
+    # # This must be specified when backend is "zipkin"
+    # zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+    # # Enable zipkin debug mode. This allows all spans to be sent to the server
+    # # bypassing sampling.
+    # debug: "false"
+
+    # # Percentage (0-1) of requests to trace
+    # sample-rate: "0.1"
 
 activator:
   autoscaling:
@@ -47,7 +877,7 @@ activator:
     # -- Tag of the activator image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the activator image, either provide tag or SHA (SHA will be given priority)
-    sha: "01270196a1eba7e5fd5fe34b877c82a7e8c93861de535a82342717d28f81d671"
+    sha: "2a71f86db077e2af4dc02cd8662c545b8206c6d5c853056225967c719251cc20"
   # -- Number of replicas for the activator deployment.
   replicaCount: 1
   # -- Resources requests and limits for activator. This should be set
@@ -68,7 +898,7 @@ autoscaler:
     # -- Tag of the autoscaler image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority)
-    sha: "c5a03a236bfe2abdc7d40203d787668c8accaaf39062a86e68b4d403077835e2"
+    sha: "cbc663928cc3e3dc60c1d6cdd054d203895c4ee0ebe2b19d86804bd708f3fa2e"
   # -- Number of replicas for the autoscaler deployment.
   replicaCount: 1
   # -- Resources requests and limits for autoscaler. This should be set
@@ -98,7 +928,7 @@ controller:
     # -- Tag of the controller image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the controller image, either provide tag or SHA (SHA will be given priority)
-    sha: "cc33e6392485e9d015886d4443324b9a41c17f6ce98b31ef4b19e47325a9a7e8"
+    sha: "f81c354e13768a11ecdcb84c512af339a0cef596a418daa932e378c6c9c2c87e"
   # -- Number of replicas for the controller deployment.
   replicaCount: 1
   # -- Resources requests and limits for controller. This should be set
@@ -119,7 +949,7 @@ domainMapping:
     # -- Tag of the domain mapping image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the domain mapping image, either provide tag or SHA (SHA will be given priority)
-    sha: "00a26f25ef119952b0ecf890f9f9dcb877b5f5d496f43c44756b93343d71b66e"
+    sha: "ed47da2c95a9bf73dd3b511323023578e15730864852fb0c869f8f64a2bab39f"
   # -- Number of replicas for the domain mapping deployment.
   replicaCount: 1
   # -- Resources requests and limits for domain mapping. This should be set
@@ -140,7 +970,7 @@ domainMappingWebhook:
     # -- Tag of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the domain mapping webhook image, either provide tag or SHA (SHA will be given priority)
-    sha: "f8f09d3a509b0c25d50be7532d4337a30df4ec5f51b9ed23ad9f21b3940c16ca"
+    sha: "ed47da2c95a9bf73dd3b511323023578e15730864852fb0c869f8f64a2bab39f"
   # -- Number of replicas for the domain mapping webhook deployment.
   replicaCount: 1
   # -- Resources requests and limits for domain mapping webhook. This should be set
@@ -170,7 +1000,7 @@ webhook:
     # -- Tag of the webhook image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the webhook image, either provide tag or SHA (SHA will be given priority)
-    sha: "b001a58cb7eac7fbae4d83d8a111fa0f6726d36e86844d5b1dc3c9b8fdd5710a"
+    sha: "1dc88f22b885d56efc88aae8f0b3160d9bd9632bd0256847eed774e68b3a769b"
   # -- Number of replicas for the webhook deployment.
   replicaCount: 1
   # -- Resources requests and limits for webhook. This should be set
@@ -191,7 +1021,7 @@ queueProxy:
     # -- Tag of the queue proxy image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the queue proxy image, either provide tag or SHA (SHA will be given priority)
-    sha: "2249dc873059c0dfc0783bce5f614a0d8ada3d4499d63aa1dffd19f2788ba64b"
+    sha: "fec35c5d66dad3d520e39de7f4f75ec6057962401f85761c143efc902f34efe7"
 
 monitoring:
   enabled: false
@@ -213,7 +1043,7 @@ autoscalerHpa:
     # -- Tag of the autoscaler image, either provide tag or SHA (SHA will be given priority)
     tag: ""
     # -- SHA256 of the autoscaler image, either provide tag or SHA (SHA will be given priority)
-    sha: "256373054915e035d3f5df214ca80eea7a235526c93348933f42acf0437bb1a2"
+    sha: "f81c354e13768a11ecdcb84c512af339a0cef596a418daa932e378c6c9c2c87e"
   # -- Number of replicas for the autoscaler deployment.
   replicaCount: 1
   # -- Resources requests and limits for autoscaler. This should be set


### PR DESCRIPTION
# Motivation

Current knative version that we are currently using (1.3.3) suffers from issue in readiness probe after restart (https://github.com/knative/serving/issues/12571). The fix to the issue is in 1.7.X. 
Note: current knative serving version is 1.8.0, however there are breaking change that will take longer to analyse so we settle with 1.7.X 

# Modification

Update chart based on knative release 1.7.4

# Checklist
- [X] Chart version bumped
- [X] README.md updated
