### PR TITLE
feat: Add annotations for Observation Service pods

### DIFF
--- a/charts/observation-service/Chart.yaml
+++ b/charts/observation-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: observation-service
 description: Observation Service - Logging system for collecting ground truth observation result from ML prediction
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.0
 maintainers:
 - email: caraml-dev@caraml.dev

--- a/charts/observation-service/README.md
+++ b/charts/observation-service/README.md
@@ -1,7 +1,7 @@
 # observation-service
 
 ---
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Observation Service - Logging system for collecting ground truth observation result from ML prediction
@@ -32,6 +32,7 @@ The following table lists the configurable parameters of the Observation Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| fluentd.annotations | object | `{}` |  |
 | fluentd.autoscaling | object | `{"enabled":false,"maxReplicas":2,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | HPA scaling configuration for Observation Service fluentd |
 | fluentd.autoscaling.enabled | bool | `false` | Toggle to enable HPA scaling |
 | fluentd.autoscaling.maxReplicas | int | `2` | Maximum replicas for HPA scaling |
@@ -52,6 +53,7 @@ The following table lists the configurable parameters of the Observation Service
 | fluentd.service | object | `{"externalPort":24224,"internalPort":9880,"multiPort":{"enabled":true},"multiPorts":[{"name":"tcp-input","port":24224,"targetPort":24224},{"name":"http-input","port":9880,"targetPort":9880}],"type":"ClusterIP"}` | Kubernetes Service for fluentd StatefulSet |
 | global.extraPodLabels | object | `{}` | Extra pod labels in a map[string]string format, most likely to be used for the costing labels. |
 | observationService.affinity | object | `{}` | Assign custom affinity rules to constrain pods to nodes. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| observationService.annotations | object | `{}` |  |
 | observationService.apiConfig | object | `{}` | Observation Service server configuration. |
 | observationService.autoscaling | object | `{"enabled":false,"maxReplicas":2,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | HPA scaling configuration for Observation Service |
 | observationService.autoscaling.enabled | bool | `false` | Toggle to enable HPA scaling |

--- a/charts/observation-service/templates/deployment.yaml
+++ b/charts/observation-service/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
         {{- if .Values.global.extraPodLabels }}
           {{- toYaml .Values.global.extraPodLabels | nindent 8 }}
         {{- end }}
+      {{- with .Values.observationService.annotations }}
+      annotations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
         - name: api

--- a/charts/observation-service/templates/fluentd-statefulset.yaml
+++ b/charts/observation-service/templates/fluentd-statefulset.yaml
@@ -27,6 +27,10 @@ spec:
         {{- if .Values.global.extraPodLabels }}
           {{- toYaml .Values.global.extraPodLabels | nindent 8 }}
         {{- end }}
+      {{- with .Values.fluentd.annotations }}
+      annotations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
         - name: logger

--- a/charts/observation-service/values.yaml
+++ b/charts/observation-service/values.yaml
@@ -13,6 +13,9 @@ observationService:
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
 
+  # Annotations to add to Observation Service
+  annotations: {}
+
   replicaCount: 1
 
   # -- Observation Service server configuration.
@@ -107,6 +110,9 @@ fluentd:
     tag: v0.1.0
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
+
+  # Annotations to add to Observation Service fluentd
+  annotations: {}
 
   replicaCount: 1
 


### PR DESCRIPTION
# Motivation

The current Observation Service helm chart does not support adding `annotations` to pods, which are required for Prometheus metrics scrapping.

# Modification

Add annotations to Observation Service Deployment and Observation Service Fluentd StatefulSet manifests.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
