### PR TITLE
fix: timber fluentd - remove component suffix

### DIFF
--- a/charts/timber-fluentd/Chart.yaml
+++ b/charts/timber-fluentd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: timber-fluentd
 description: Fluentd service - Fluentd service that supports UPI logs parsing
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 maintainers:
 - email: caraml-dev@caraml.dev

--- a/charts/timber-fluentd/README.md
+++ b/charts/timber-fluentd/README.md
@@ -1,7 +1,7 @@
 # timber-fluentd
 
 ---
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Fluentd service - Fluentd service that supports UPI logs parsing

--- a/charts/timber-fluentd/templates/configmap.yaml
+++ b/charts/timber-fluentd/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "timber-fluentd.fullname" . }}-config
+  name: {{ include "timber-fluentd.fullname" . }}
   labels:
     {{- include "timber-fluentd.labels" . | nindent 4 }}
 data:

--- a/charts/timber-fluentd/templates/secret.yaml
+++ b/charts/timber-fluentd/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "timber-fluentd.fullname" . }}-secret
+  name: {{ include "timber-fluentd.fullname" . }}
   labels:
     {{- include "timber-fluentd.labels" . | nindent 4 }}
 data:

--- a/charts/timber-fluentd/templates/statefulset.yaml
+++ b/charts/timber-fluentd/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "timber-fluentd.fullname" . }}-fluentd
+  name: {{ include "timber-fluentd.fullname" . }}
   labels:
     {{- include "timber-fluentd.labels" . | nindent 4 }}
 spec:
@@ -11,13 +11,13 @@ spec:
   minReadySeconds: 5
   selector:
     matchLabels:
-      app: {{ include "timber-fluentd.fullname" . }}-fluentd
+      app: {{ include "timber-fluentd.fullname" . }}
       release: {{ .Release.Name }}
-  serviceName: {{ include "timber-fluentd.fullname" . }}-fluentd
+  serviceName: {{ include "timber-fluentd.fullname" . }}
   template:
     metadata:
       labels:
-        app: {{ include "timber-fluentd.fullname" . }}-fluentd
+        app: {{ include "timber-fluentd.fullname" . }}
         release: {{ .Release.Name }}
         {{- include "timber-fluentd.labels" . | nindent 8 }}
         {{- if .Values.global.extraPodLabels }}
@@ -62,7 +62,7 @@ spec:
       {{- if .Values.fluentdConfig }}
       - name: fluentd-conf
         configMap:
-          name: {{ include "timber-fluentd.fullname" . }}-config
+          name: {{ include "timber-fluentd.fullname" . }}
           defaultMode: 0777
       {{- end }}
       {{- if .Values.gcpServiceAccount.credentials }}
@@ -76,7 +76,7 @@ spec:
       {{- if .Values.gcpServiceAccount.credentialsData }}
       - name: gcp-service-account
         secret:
-          secretName: {{ include "timber-fluentd.fullname" . }}-secret
+          secretName: {{ include "timber-fluentd.fullname" . }}
       {{- end }}
   {{- if .Values.pvcConfig }}
   volumeClaimTemplates:

--- a/charts/timber-fluentd/tests/fluentd_test.yaml
+++ b/charts/timber-fluentd/tests/fluentd_test.yaml
@@ -55,7 +55,7 @@ tests:
           content:
            name: gcp-service-account
            secret:
-            secretName: my-release-timber-fluentd-secret
+            secretName: my-release-timber-fluentd
       - matchRegex: # secret created from secret.yaml
           path: data.[service-account.json]
           pattern: dummy-account


### PR DESCRIPTION
# Motivation
Remove unnecessary suffix for fluentd chart. When installing as a subchart the statefulset can be suffix `fluentd` by the fullname twice which is unnecessary. 

# Modification
Removing suffix for metadata names
# Checklist
- [x] Chart version bumped
- [x] README.md updated
