### PR TITLE
fix: Add missing release label for Observation Service helm chart

### DIFF
--- a/charts/observation-service/Chart.yaml
+++ b/charts/observation-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: observation-service
 description: Observation Service - Logging system for collecting ground truth observation result from ML prediction
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.1.0
 maintainers:
 - email: caraml-dev@caraml.dev

--- a/charts/observation-service/README.md
+++ b/charts/observation-service/README.md
@@ -1,7 +1,7 @@
 # observation-service
 
 ---
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Observation Service - Logging system for collecting ground truth observation result from ML prediction

--- a/charts/observation-service/templates/_helpers.tpl
+++ b/charts/observation-service/templates/_helpers.tpl
@@ -43,6 +43,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "observation-service.labels" -}}
+release: {{ .Release.Name }}
 app.kubernetes.io/name: {{ template "observation-service.name" . }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote}}
 {{- if .Chart.AppVersion }}


### PR DESCRIPTION
# Motivation

In order to scrape metrics using ServiceMonitor, it expects `app` and `release` labels to be added to Observation Service's Service CR. This PR ensures the missing `release` label is added.

# Modification

Update helper template for Observation Service helm chart.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
