### PR TITLE
feat: Make Observation Service ServiceMonitor endpoint path configurable

### DIFF
--- a/charts/observation-service/Chart.yaml
+++ b/charts/observation-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: observation-service
 description: Observation Service - Logging system for collecting ground truth observation result from ML prediction
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.1.0
 maintainers:
 - email: caraml-dev@caraml.dev

--- a/charts/observation-service/README.md
+++ b/charts/observation-service/README.md
@@ -1,7 +1,7 @@
 # observation-service
 
 ---
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Observation Service - Logging system for collecting ground truth observation result from ML prediction
@@ -74,7 +74,7 @@ The following table lists the configurable parameters of the Observation Service
 | observationService.livenessProbe.periodSeconds | int | `10` |  |
 | observationService.livenessProbe.successThreshold | int | `1` |  |
 | observationService.livenessProbe.timeoutSeconds | int | `5` |  |
-| observationService.monitoring | object | `{"enabled":false}` | Service Monitor configuration for Observation Service |
+| observationService.monitoring | object | `{"baseURL":"/v1/metrics","enabled":false}` | Service Monitor configuration for Observation Service |
 | observationService.nodeSelector | object | `{}` | Define which nodes the pods are scheduled on. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | observationService.readinessProbe.initialDelaySeconds | int | `60` | Readiness probe delay and thresholds |
 | observationService.readinessProbe.path | string | `"/v1/internal/health/ready"` | HTTP path for readiness check |

--- a/charts/observation-service/templates/service-monitor.yaml
+++ b/charts/observation-service/templates/service-monitor.yaml
@@ -13,4 +13,5 @@ spec:
       release: {{ .Release.Name }}
   endpoints:
     - targetPort: {{ .Values.observationService.service.internalPort }}
+      path: {{ .Values.observationService.monitoring.baseURL }}
 {{- end }}

--- a/charts/observation-service/values.yaml
+++ b/charts/observation-service/values.yaml
@@ -94,7 +94,7 @@ observationService:
   # -- Service Monitor configuration for Observation Service
   monitoring:
     enabled: false
-    # baseURL: ""
+    baseURL: /v1/metrics
     # jobBaseURL: ""
 
 fluentd:


### PR DESCRIPTION
# Motivation

Observation Service expects `/v1/metrics` path instead of the default `/metrics` path as described in the [documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint). This PR makes the path configurable.

# Modification

Support `path` configuration for ServiceMonitor CR.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
