### PR TITLE
feat: add timber obs service using timber fluentd subchart

### DIFF
--- a/charts/timber-observation-service/.helmignore
+++ b/charts/timber-observation-service/.helmignore
@@ -1,0 +1,1 @@
+../../.helmignore

--- a/charts/timber-observation-service/Chart.yaml
+++ b/charts/timber-observation-service/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: timber-observation-service
+description: Observation Service - Logging system for collecting ground truth observation result from ML prediction
+version: 0.2.0
+appVersion: 0.2.0
+dependencies:
+- alias: fluentd
+  condition: fluentd.enabled
+  name: timber-fluentd
+  repository: https://caraml-dev.github.io/helm-charts
+  version: 0.1.1
+maintainers:
+- email: caraml-dev@caraml.dev
+  name: caraml-dev

--- a/charts/timber-observation-service/Chart.yaml
+++ b/charts/timber-observation-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timber-observation-service
 description: Observation Service - Logging system for collecting ground truth observation result from ML prediction
 version: 0.2.0
-appVersion: 0.2.0
+appVersion: 0.1.0
 dependencies:
 - alias: fluentd
   condition: fluentd.enabled

--- a/charts/timber-observation-service/README.md
+++ b/charts/timber-observation-service/README.md
@@ -1,0 +1,75 @@
+# timber-observation-service
+
+---
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
+![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+
+Observation Service - Logging system for collecting ground truth observation result from ML prediction
+
+## Introduction
+
+This Helm chart installs [Timber-Observation-Service](https://github.com/caraml-dev/observation-service) and all its dependencies in a Kubernetes cluster.
+It installs fluentd service optionally as a subchart.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| caraml-dev | <caraml-dev@caraml.dev> |  |
+
+## Prerequisites
+
+To use the charts here, [Helm](https://helm.sh/) must be configured for your
+Kubernetes cluster. Setting up Kubernetes and Helm is outside the scope of
+this README. Please refer to the Kubernetes and Helm documentation.
+
+- **Helm 3.0+** – This chart was tested with Helm v3.7.1, but it is also expected to work with earlier Helm versions
+- **Kubernetes 1.18+** – This chart was tested with GKE v1.20.x and with [k3d](https://github.com/rancher/k3d) v1.21.x,
+but it's possible it works with earlier k8s versions too
+
+## Configuration
+
+The following table lists the configurable parameters of the Observation Service chart and their default values.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| fluentd.enabled | bool | `false` | Flag to toggle deployment of Observation Service fluentd |
+| fluentd.extraEnvs | string | `nil` | List of extra environment variables to add to Observation Service fluentd container |
+| fluentd.fluentdConfig | string | `""` | Fluentd.conf |
+| fluentd.nameOverride | string | `"timber-observation-service-fluentd"` |  |
+| global.extraPodLabels | object | `{}` | Extra pod labels in a map[string]string format, most likely to be used for the costing labels. |
+| observationService.affinity | object | `{}` | Assign custom affinity rules to constrain pods to nodes. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| observationService.annotations | object | `{}` | Annotations to add to Observation Service pod |
+| observationService.apiConfig | object | `{}` | Observation Service server configuration. |
+| observationService.autoscaling | object | `{"enabled":false,"maxReplicas":2,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | HPA scaling configuration for Observation Service |
+| observationService.autoscaling.enabled | bool | `false` | Toggle to enable HPA scaling |
+| observationService.autoscaling.maxReplicas | int | `2` | Maximum replicas for HPA scaling |
+| observationService.autoscaling.minReplicas | int | `1` | Minimum replicas for HPA scaling |
+| observationService.autoscaling.targetCPUUtilizationPercentage | int | `80` | CPU utilization percentage threshold to activate HPA scaling |
+| observationService.extraEnvs | list | `[]` | List of extra environment variables to add to Observation Service server container |
+| observationService.extraLabels | object | `{}` | List of extra labels to add to Observation Service K8s resources |
+| observationService.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
+| observationService.image.registry | string | `"ghcr.io"` | Docker registry for Observation Service image |
+| observationService.image.repository | string | `"caraml-dev/timber/observation-service"` | Docker image repository for Observation Service |
+| observationService.image.tag | string | `"v0.0.0-build.15-b8afdb5"` | Docker image tag for Observation Service |
+| observationService.ingress.class | string | `""` | Ingress class annotation to add to this Ingress rule, useful when there are multiple ingress controllers installed |
+| observationService.ingress.enabled | bool | `false` | Enable ingress to provision Ingress resource for external access to Observation Service |
+| observationService.ingress.host | string | `""` | Set host value to enable name based virtual hosting. This allows routing HTTP traffic to multiple host names at the same IP address. If no host is specified, the ingress rule applies to all inbound HTTP traffic through the IP address specified. https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting |
+| observationService.livenessProbe.initialDelaySeconds | int | `60` | Liveness probe delay and thresholds |
+| observationService.livenessProbe.path | string | `"/v1/internal/health/live"` | HTTP path for liveness check |
+| observationService.livenessProbe.periodSeconds | int | `10` |  |
+| observationService.livenessProbe.successThreshold | int | `1` |  |
+| observationService.livenessProbe.timeoutSeconds | int | `5` |  |
+| observationService.monitoring | object | `{"baseURL":"/v1/metrics","enabled":false}` | Service Monitor configuration for Observation Service |
+| observationService.nodeSelector | object | `{}` | Define which nodes the pods are scheduled on. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| observationService.readinessProbe.initialDelaySeconds | int | `60` | Readiness probe delay and thresholds |
+| observationService.readinessProbe.path | string | `"/v1/internal/health/ready"` | HTTP path for readiness check |
+| observationService.readinessProbe.periodSeconds | int | `10` |  |
+| observationService.readinessProbe.successThreshold | int | `1` |  |
+| observationService.readinessProbe.timeoutSeconds | int | `5` |  |
+| observationService.replicaCount | int | `1` |  |
+| observationService.resources | object | `{}` | Resources requests and limits for Observation Service. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| observationService.service.externalPort | int | `9001` | Observation Service Kubernetes service port number |
+| observationService.service.internalPort | int | `9001` | Observation Service container port number |
+| observationService.service.type | string | `"ClusterIP"` |  |
+| observationService.tolerations | list | `[]` | If specified, the pod's tolerations. ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |

--- a/charts/timber-observation-service/README.md
+++ b/charts/timber-observation-service/README.md
@@ -2,7 +2,7 @@
 
 ---
 ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
-![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Observation Service - Logging system for collecting ground truth observation result from ML prediction
 
@@ -30,6 +30,8 @@ but it's possible it works with earlier k8s versions too
 ## Configuration
 
 The following table lists the configurable parameters of the Observation Service chart and their default values.
+
+For more configurable of fluentd, check out [Timber-Fluentd](https://github.com/caraml-dev/timber-fluentd)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|

--- a/charts/timber-observation-service/README.md.gotmpl
+++ b/charts/timber-observation-service/README.md.gotmpl
@@ -1,0 +1,33 @@
+{{ template "chart.header" . }}
+---
+{{ template "chart.versionBadge" . }}
+{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+## Introduction
+
+This Helm chart installs [Timber-Observation-Service](https://github.com/caraml-dev/observation-service) and all its dependencies in a Kubernetes cluster.
+It installs fluentd service optionally as a subchart.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| caraml-dev | <caraml-dev@caraml.dev> |  |
+
+## Prerequisites
+
+To use the charts here, [Helm](https://helm.sh/) must be configured for your
+Kubernetes cluster. Setting up Kubernetes and Helm is outside the scope of
+this README. Please refer to the Kubernetes and Helm documentation.
+
+- **Helm 3.0+** – This chart was tested with Helm v3.7.1, but it is also expected to work with earlier Helm versions
+- **Kubernetes 1.18+** – This chart was tested with GKE v1.20.x and with [k3d](https://github.com/rancher/k3d) v1.21.x,
+but it's possible it works with earlier k8s versions too
+
+## Configuration
+
+The following table lists the configurable parameters of the Observation Service chart and their default values.
+
+{{ template "chart.valuesTable" . }}

--- a/charts/timber-observation-service/README.md.gotmpl
+++ b/charts/timber-observation-service/README.md.gotmpl
@@ -30,4 +30,6 @@ but it's possible it works with earlier k8s versions too
 
 The following table lists the configurable parameters of the Observation Service chart and their default values.
 
+For more configurable of fluentd, check out [Timber-Fluentd](https://github.com/caraml-dev/timber-fluentd)
+
 {{ template "chart.valuesTable" . }}

--- a/charts/timber-observation-service/templates/_helpers.tpl
+++ b/charts/timber-observation-service/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+
+{{- define "observation-service.resource-prefix-with-release-name" -}}
+    {{- if .Values.fullnameOverride -}}
+        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- $name := default .Chart.Name .Values.nameOverride -}}
+        {{- if contains $name .Release.Name -}}
+            {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+        {{- else -}}
+            {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "observation-service.resource-prefix" -}}
+    {{- if .Values.nameOverride -}}
+        {{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- $deployedChart := .Chart.Name -}}
+        {{ printf "%s"  $deployedChart | trunc 63 | trimSuffix "-" }}
+    {{- end -}}
+{{- end -}}
+
+{{- define "observation-service.name" -}}
+    {{- printf "%s" (include "observation-service.resource-prefix" .) -}}
+{{- end }}
+
+{{- define "observation-service.fullname" -}}
+    {{- printf "%s" (include "observation-service.resource-prefix-with-release-name" .) -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "observation-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "observation-service.labels" -}}
+release: {{ .Release.Name }}
+app.kubernetes.io/name: {{ template "observation-service.name" . }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote}}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: caraml
+{{ if .Values.observationService.extraLabels -}}
+    {{ toYaml .Values.observationService.extraLabels -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "observation-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "observation-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/timber-observation-service/templates/deployment.yaml
+++ b/charts/timber-observation-service/templates/deployment.yaml
@@ -21,7 +21,6 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}
-        release: {{ .Release.Name }}
         {{- include "observation-service.labels" . | nindent 8 }}
         {{- if .Values.global.extraPodLabels }}
           {{- toYaml .Values.global.extraPodLabels | nindent 8 }}
@@ -35,14 +34,16 @@ spec:
         - name: api
           image: "{{ .Values.observationService.image.registry }}/{{ .Values.observationService.image.repository }}:{{ .Values.observationService.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.observationService.image.pullPolicy }}
+          {{- if or .Values.fluentd.gcpServiceAccount .Values.observationService.extraEnvs}}
           env:
-            {{ if .Values.fluentd.gcpServiceAccount}}
+            {{- if .Values.fluentd.gcpServiceAccount}}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcp_service_account/service-account.json
             {{- end }}
             {{- with .Values.observationService.extraEnvs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.observationService.service.internalPort }}

--- a/charts/timber-observation-service/templates/deployment.yaml
+++ b/charts/timber-observation-service/templates/deployment.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "observation-service.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observation-service.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.observationService.autoscaling.enabled }}
+  replicas: {{ .Values.observationService.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+      release: {{ .Release.Name }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+        release: {{ .Release.Name }}
+        {{- include "observation-service.labels" . | nindent 8 }}
+        {{- if .Values.global.extraPodLabels }}
+          {{- toYaml .Values.global.extraPodLabels | nindent 8 }}
+        {{- end }}
+        {{- with .Values.observationService.annotations }}
+        annotations:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.observationService.image.registry }}/{{ .Values.observationService.image.repository }}:{{ .Values.observationService.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.observationService.image.pullPolicy }}
+          env:
+            {{ if .Values.fluentd.gcpServiceAccount}}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/gcp_service_account/service-account.json
+            {{- end }}
+            {{- with .Values.observationService.extraEnvs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.observationService.service.internalPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.observationService.livenessProbe.path }}
+              port: {{ .Values.observationService.service.internalPort }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.observationService.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.observationService.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.observationService.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.observationService.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.observationService.readinessProbe.path }}
+              port: {{ .Values.observationService.service.internalPort }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.observationService.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.observationService.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.observationService.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.observationService.readinessProbe.timeoutSeconds }}
+          resources:
+            {{- toYaml .Values.observationService.resources | nindent 12 }}
+          # Give time for running pods to terminate existing connection before letting
+          # Kubernetes terminate the pods.
+          # https://blog.sebastian-daschner.com/entries/zero-downtime-updates-kubernetes
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/bash", "-c", "sleep 15"]
+          args:
+          - serve
+          - --config=/etc/observation-service/config.yaml
+          {{- with .Values.observationService.extraArgs }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.fluentd.gcpServiceAccount }}
+          - mountPath: /etc/gcp_service_account
+            name: gcp-service-account
+            readOnly: true
+          {{- end }}
+          - name: config
+            mountPath: /etc/observation-service
+      volumes:
+      {{- if .Values.fluentd.gcpServiceAccount.credentials }}
+      - name: gcp-service-account
+        secret:
+          secretName: {{ .Values.gcpServiceAccount.credentials.name }}
+          items:
+            - key: {{ .Values.gcpServiceAccount.credentials.key }}
+              path: service-account.json
+      {{- end }}
+      {{- if .Values.fluentd.gcpServiceAccount.credentialsData }}
+      - name: gcp-service-account
+        secret:
+          secretName: {{ template "timber-fluentd.fullname" .Subcharts.fluentd }}
+      {{- end }}
+      - name: config
+        secret:
+          secretName: {{ template "observation-service.fullname" . }}
+      {{- if .Values.observationService.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.observationService.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.observationService.affinity }}
+      affinity:
+        {{- toYaml .Values.observationService.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.observationService.tolerations }}
+      tolerations:
+        {{- toYaml .Values.observationService.tolerations | nindent 8 }}
+      {{- end }}

--- a/charts/timber-observation-service/templates/hpa.yaml
+++ b/charts/timber-observation-service/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.observationService.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "observation-service.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observation-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "observation-service.fullname" . }}
+  minReplicas: {{ .Values.observationService.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.observationService.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/timber-observation-service/templates/secrets.yaml
+++ b/charts/timber-observation-service/templates/secrets.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "observation-service.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observation-service.labels" . | nindent 4 }}
+stringData:
+  config.yaml: |
+    {{- toYaml .Values.observationService.apiConfig | nindent 4 -}}

--- a/charts/timber-observation-service/templates/service-monitor.yaml
+++ b/charts/timber-observation-service/templates/service-monitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.observationService.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "observation-service.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "observation-service.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "observation-service.name" .}}
+      release: {{ .Release.Name }}
+  endpoints:
+    - port: http
+      path: {{ .Values.observationService.monitoring.baseURL }}
+{{- end }}

--- a/charts/timber-observation-service/templates/service.yaml
+++ b/charts/timber-observation-service/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "observation-service.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+    {{- include "observation-service.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.observationService.service.externalPort }}
+      targetPort: {{ .Values.observationService.service.internalPort }}
+      protocol: TCP
+  selector:
+    app: {{ .Release.Name }}
+    release: {{ .Release.Name }}

--- a/charts/timber-observation-service/tests/observation_service_deployment_test.yaml
+++ b/charts/timber-observation-service/tests/observation_service_deployment_test.yaml
@@ -1,0 +1,35 @@
+suite: Unit tests for Observation Service Deployment
+templates:
+  - deployment.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+  revision: 1
+  isUpgrade: true
+tests:
+  - it: should set Fluentd GCP secret if Fluentd is configured for BQ sink writing
+    set:
+      global: {}
+      fluentd:
+        enabled: true
+        gcpServiceAccount:
+          credentialsData: "dummy"
+      timber-fluentd:
+        fullname: a
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-timber-observation-service
+      - contains: # check GCP service account volume
+          path: spec.template.spec.volumes
+          content:
+           name: gcp-service-account
+           secret:
+            secretName:  my-release-timber-observation-service-fluentd
+      - contains: # check env var added
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcp_service_account/service-account.json

--- a/charts/timber-observation-service/values.yaml
+++ b/charts/timber-observation-service/values.yaml
@@ -1,0 +1,264 @@
+global:
+  # -- Extra pod labels in a map[string]string format, most likely to be used for the costing labels.
+  extraPodLabels: {}
+
+observationService:
+  image:
+    # -- Docker registry for Observation Service image
+    registry: ghcr.io
+    # -- Docker image repository for Observation Service
+    repository: caraml-dev/timber/observation-service
+    # -- Docker image tag for Observation Service
+    tag: v0.0.0-build.15-b8afdb5
+    # -- Docker image pull policy
+    pullPolicy: IfNotPresent
+
+  # -- Annotations to add to Observation Service pod
+  annotations: {}
+
+  replicaCount: 1
+
+  # -- Observation Service server configuration.
+  apiConfig: {}
+    # Default configuration base on caraml-dev/timber/observation-service: v0.0.0-build.15-b8afdb5
+    # DeploymentConfig:
+    #   EnvironmentType: local
+    #   ProjectName: ""
+    #   ServiceName: ""
+    #   LogLevel: "INFO"
+    #   MaxGoRoutines: 1000
+    # NewRelicConfig:
+    #   Enabled: false
+    #   License: string
+    #   Labels: {}
+    #   IgnoreStatusCodes: []
+    # SentryConfig:
+    #   Enabled: false
+    #   DSN: ""
+    #   Labels: {}
+    # LogConsumerConfig:
+    #   Kind: ""
+    #   KafkaConfig:
+    #     Brokers: ""
+    #     Topic: ""
+    #     MaxMessageBytes: 1048588
+    #     CompressionType: "none"
+    #     ConnectTimeoutMS: 1000
+    #     PollInterval: 1000
+    #     AutoOffsetReset: "latest"
+    # LogProducerConfig:
+    #   Kind: ""
+    #   QueueLength: 100
+    #   FlushIntervalSeconds: 1
+    #   KafkaConfig:
+    #     Brokers: ""
+    #     Topic: ""
+    #     MaxMessageBytes: 1048588
+    #     CompressionType: "none"
+    #     ConnectTimeoutMS: 1000
+    #     PollInterval: 1000
+    #     AutoOffsetReset: "latest"
+    #   FluentdConfig:
+    #     Kind: ""
+    #     Host: "localhost"
+    #     Port: 24224
+    #     Tag: "observation-service"
+    #     BQConfig:
+    #       Project: ""
+    #       Dataset: ""
+    #       Table: ""
+    #   MonitoringConfig:
+    #     Kind: ""
+
+    # E.g. using BQ FLuentd
+    # DeploymentConfig:
+    #   EnvironmentType: dev
+    # logConsumerConfig:
+    #   Kind: kafka
+    #   KafkaConfig:
+    #     Brokers: kafka.default.svc.cluster.local
+    #     Topic: test-topic
+    # LogProducerConfig:
+    #   FlushIntervalSeconds: 10
+    #   Kind: fluentd
+    #   FluentdConfig:
+    #     Host: observation-service-fluentd
+    #     Port: 24224
+    #     Kind: bq
+    #     Tag: observation-service.log
+    #     BQConfig:
+    #       Project: project
+    #       Dataset: dataset
+    #       Table: table
+
+  # -- Resources requests and limits for Observation Service. This should be set
+  # according to your cluster capacity and service level objectives.
+  # Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources: {}
+
+  livenessProbe:
+    # -- HTTP path for liveness check
+    path: "/v1/internal/health/live"
+    # -- Liveness probe delay and thresholds
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+
+  readinessProbe:
+    # -- HTTP path for readiness check
+    path: "/v1/internal/health/ready"
+    # -- Readiness probe delay and thresholds
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+
+  service:
+    type: ClusterIP
+    # -- Observation Service Kubernetes service port number
+    externalPort: 9001
+    # -- Observation Service container port number
+    internalPort: 9001
+
+  ingress:
+    # -- Enable ingress to provision Ingress resource for external access to Observation Service
+    enabled: false
+    # -- Set host value to enable name based virtual hosting. This allows routing
+    # HTTP traffic to multiple host names at the same IP address. If no host is
+    # specified, the ingress rule applies to all inbound HTTP traffic through
+    # the IP address specified.
+    # https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting
+    host: ""
+    # -- Ingress class annotation to add to this Ingress rule,
+    # useful when there are multiple ingress controllers installed
+    class: ""
+
+  # -- List of extra environment variables to add to Observation Service server container
+  extraEnvs: []
+
+  # -- List of extra labels to add to Observation Service K8s resources
+  extraLabels: {}
+
+  # -- Define which nodes the pods are scheduled on.
+  # ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
+  # -- If specified, the pod's tolerations.
+  # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+  # -- Assign custom affinity rules to constrain pods to nodes.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  affinity: {}
+
+  # -- HPA scaling configuration for Observation Service
+  autoscaling:
+    # -- Toggle to enable HPA scaling
+    enabled: false
+    # -- Minimum replicas for HPA scaling
+    minReplicas: 1
+    # -- Maximum replicas for HPA scaling
+    maxReplicas: 2
+    # -- CPU utilization percentage threshold to activate HPA scaling
+    targetCPUUtilizationPercentage: 80
+
+  # -- Service Monitor configuration for Observation Service
+  monitoring:
+    enabled: false
+    baseURL: /v1/metrics
+    # jobBaseURL: ""
+
+# Fluentd configuration
+# ref: https://github.com/caraml-dev/helm-charts/tree/main/charts/timber-fluentd
+fluentd:
+  # -- Flag to toggle deployment of Observation Service fluentd
+  enabled: false
+
+  nameOverride: timber-observation-service-fluentd
+
+  # -- List of extra environment variables to add to Observation Service fluentd container
+  extraEnvs:
+    # E.g. Sample for fluentd env to work with fluentd.conf with bq
+    # - name: FLUENTD_WORKER_COUNT
+    #   value: "1"
+    # - name: FLUENTD_LOG_LEVEL
+    #   value: debug
+    # - name: FLUENTD_BUFFER_LIMIT
+    #   value: 1g
+    # - name: FLUENTD_FLUSH_INTERVAL_SECONDS
+    #   value: "30"
+    # - name: FLUENTD_LOG_PATH
+    #   value: /fluentd/cache/log
+    # - name: FLUENTD_TAG
+    #   value: observation-service.log
+    # - name: FLUENTD_GCP_JSON_KEY_PATH
+    #   value: /etc/gcp_service_account/service-account.json
+    # - name: FLUENTD_GCP_PROJECT
+    #   value: project
+    # - name: FLUENTD_BQ_DATASET
+    #   value: dataset
+    # - name: FLUENTD_BQ_TABLE
+    #   value: table
+
+  # -- Fluentd.conf
+  fluentdConfig: ""
+  # E.g. sample fluentd.conf deployment for Fluentd producer to BQ sink
+  # |-
+  #   # Set fluentd log level to error
+  #   <system>
+  #     log_level "#{ENV['FLUENTD_LOG_LEVEL']}"
+  #     workers "#{ENV['FLUENTD_WORKER_COUNT']}"
+  #   </system>
+
+  #   # Accept HTTP input
+  #   <source>
+  #     @type http
+  #     port 9880
+  #     bind 0.0.0.0
+  #     body_size_limit 32m
+  #     keepalive_timeout 10s
+  #   </source>
+
+  #   # Accept events on tcp socket
+  #   <source>
+  #     @type forward
+  #     port 24224
+  #     bind 0.0.0.0
+  #   </source>
+
+  #   # Buffer and output to multiple sinks
+  #   <match "#{ENV['FLUENTD_TAG']}">
+  #     @type copy
+  #     <store>
+  #       @type stdout
+  #     </store>
+  #     <store>
+  #       @type bigquery_load
+
+  #       <buffer>
+  #         @type file
+
+  #         path "#{ENV['FLUENTD_LOG_PATH']}"
+  #         timekey_use_utc
+          
+  #         flush_at_shutdown true
+  #         flush_mode interval
+  #         flush_interval "#{ENV['FLUENTD_FLUSH_INTERVAL_SECONDS']}"
+  #         retry_max_times 3
+
+  #         chunk_limit_size 1g
+  #         compress gzip
+  #         total_limit_size "#{ENV['FLUENTD_BUFFER_LIMIT']}"
+
+  #         delayed_commit_timeout 150
+  #         disable_chunk_backup true
+  #       </buffer>
+
+  #       # Authenticate with BigQuery using a json key
+  #       auth_method json_key
+  #       json_key "#{ENV['FLUENTD_GCP_JSON_KEY_PATH']}"
+  #       project "#{ENV['FLUENTD_GCP_PROJECT']}"
+  #       dataset "#{ENV['FLUENTD_BQ_DATASET']}"
+  #       table "#{ENV['FLUENTD_BQ_TABLE']}"
+  #       fetch_schema true
+  #     </store>
+  #   </match>

--- a/charts/timber-observation-service/values.yaml
+++ b/charts/timber-observation-service/values.yaml
@@ -239,7 +239,7 @@ fluentd:
 
   #         path "#{ENV['FLUENTD_LOG_PATH']}"
   #         timekey_use_utc
-          
+
   #         flush_at_shutdown true
   #         flush_mode interval
   #         flush_interval "#{ENV['FLUENTD_FLUSH_INTERVAL_SECONDS']}"
@@ -262,3 +262,4 @@ fluentd:
   #       fetch_schema true
   #     </store>
   #   </match>
+  

--- a/charts/timber-observation-service/values.yaml
+++ b/charts/timber-observation-service/values.yaml
@@ -262,4 +262,3 @@ fluentd:
   #       fetch_schema true
   #     </store>
   #   </match>
-  


### PR DESCRIPTION
# Motivation
As a follow up PR to https://github.com/caraml-dev/helm-charts/pull/164, this PR adds the new timber-observation-service which will use new timber-fluentd. 

Changes up to https://github.com/caraml-dev/helm-charts/pull/169 is ported over. 

On top of breaking up the observation-service, several minor enhancements are added.

Deletion of the old observation-service will be carried out later, once the consumers has migrated to this new chart.

Current version of obs-service is `0.1.4` and appVersion is `0.1.0`, releasing this chart as `0.2.0` while maintaining the same appVersion as the underlying obs-service image is not changed.

# Modification
- Porting of existing observation-service 
- Added example to various configuration in `values.yaml` on fluentd configuration
- Removal of `observationService.extraLabels` across some components and added in `templates/_helpers.tpl` as `"observation-service.labels"` so that it will be applied consistently across
- Removal of suffix of components metadata name and use `"observation-service.fullname"` consistently, as it might clash with deployed fluentd components name unnecessarily 

`templates/deployment.yaml`
- Added support of service account via provided secrets or kubernatesServiceAccount (similar to timber-fluentd implementation)
- Added env var in `GOOGLE_APPLICATION_CREDENTIALS` so that users are not required to pass this in, once the fluentd gcp creds are provided 
- Referrence subchart template via subchart fullname, as the previous name will have possible collision depending on the `fluentd.nameOverride`
```
 - name: gcp-service-account
    secret:
      secretName: {{ template "timber-fluentd.fullname" .Subcharts.fluentd }}
```
# Testing
- local minikube helm install + binami kafka
- gcp bq

Observation service with fluentd bq (kafka -> Obs service -> fluentd -> bq)
similar config as per values.yaml example
![Screenshot 2023-02-01 at 6 08 59 PM](https://user-images.githubusercontent.com/30390872/216018766-dcc64dc4-949e-4281-bbdd-612d1f707df0.png)
![Screenshot 2023-02-01 at 5 34 34 PM](https://user-images.githubusercontent.com/30390872/216019265-8e782cb7-5e2f-4df3-a3f7-fb9a8e6a678b.png)

Logwriter (kafka source -> upi parser -> bq)
![Screenshot 2023-02-01 at 6 10 04 PM](https://user-images.githubusercontent.com/30390872/216019233-d568b3f5-89eb-4d46-86ad-30023caf8bba.png)
![Screenshot 2023-02-01 at 5 34 28 PM](https://user-images.githubusercontent.com/30390872/216018927-3968f6d3-5347-4bdf-a205-1cc9a6c293ad.png)


# Checklist
- [X] Chart version bumped
- [X] README.md updated
