### PR TITLE
fix(timber): Amend helm charts HPA CR

### DIFF
--- a/charts/observation-service/Chart.yaml
+++ b/charts/observation-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: observation-service
 description: Observation Service - Logging system for collecting ground truth observation result from ML prediction
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.1.0
 maintainers:
 - email: caraml-dev@caraml.dev

--- a/charts/observation-service/README.md
+++ b/charts/observation-service/README.md
@@ -1,7 +1,7 @@
 # observation-service
 
 ---
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Observation Service - Logging system for collecting ground truth observation result from ML prediction

--- a/charts/observation-service/templates/fluentd-hpa.yaml
+++ b/charts/observation-service/templates/fluentd-hpa.yaml
@@ -13,11 +13,7 @@ spec:
     name: {{ include "observation-service.fullname" . }}-fluentd
   minReplicas: {{ .Values.fluentd.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.autoscaling.maxReplicas }}
-  metrics:
-    {{- if .Values.fluentd.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.fluentd.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
+  {{- if .Values.fluentd.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.fluentd.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
 {{- end }}

--- a/charts/observation-service/templates/hpa.yaml
+++ b/charts/observation-service/templates/hpa.yaml
@@ -13,11 +13,7 @@ spec:
     name: {{ include "observation-service.fullname" . }}
   minReplicas: {{ .Values.observationService.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.observationService.autoscaling.maxReplicas }}
-  metrics:
-    {{- if .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
+  {{- if .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
 {{- end }}

--- a/charts/observation-service/tests/fluentd_hpa_test.yaml
+++ b/charts/observation-service/tests/fluentd_hpa_test.yaml
@@ -1,0 +1,25 @@
+suite: Unit tests for Observation Service Fluentd HPA
+templates:
+  - fluentd-hpa.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+  revision: 1
+  isUpgrade: true
+tests:
+  - it: should set specified targetCPUUtilizationPercentage
+    set:
+      global: {}
+      fluentd:
+        autoscaling:
+          enabled: true
+          targetCPUUtilizationPercentage: 90
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-observation-service-fluentd$
+      - equal: # check targetCPUUtilizationPercentage
+          path: spec.targetCPUUtilizationPercentage
+          value: 90

--- a/charts/observation-service/tests/observation_service_deployment_hpa_test.yaml
+++ b/charts/observation-service/tests/observation_service_deployment_hpa_test.yaml
@@ -1,0 +1,25 @@
+suite: Unit tests for Observation Service HPA
+templates:
+  - hpa.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+  revision: 1
+  isUpgrade: true
+tests:
+  - it: should set specified targetCPUUtilizationPercentage
+    set:
+      global: {}
+      observationService:
+        autoscaling:
+          enabled: true
+          targetCPUUtilizationPercentage: 90
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-observation-service$
+      - equal: # check targetCPUUtilizationPercentage
+          path: spec.targetCPUUtilizationPercentage
+          value: 90

--- a/charts/timber-fluentd/Chart.yaml
+++ b/charts/timber-fluentd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: timber-fluentd
 description: Fluentd service - Fluentd service that supports UPI logs parsing
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.0
 maintainers:
 - email: caraml-dev@caraml.dev

--- a/charts/timber-fluentd/README.md
+++ b/charts/timber-fluentd/README.md
@@ -1,7 +1,7 @@
 # timber-fluentd
 
 ---
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Fluentd service - Fluentd service that supports UPI logs parsing

--- a/charts/timber-fluentd/templates/hpa.yaml
+++ b/charts/timber-fluentd/templates/hpa.yaml
@@ -13,11 +13,7 @@ spec:
     name: {{ include "timber-fluentd.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
-  metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
 {{- end }}

--- a/charts/timber-fluentd/tests/fluentd_hpa_test.yaml
+++ b/charts/timber-fluentd/tests/fluentd_hpa_test.yaml
@@ -1,0 +1,24 @@
+suite: Unit tests for Fluentd HPA
+templates:
+  - hpa.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+  revision: 1
+  isUpgrade: true
+tests:
+  - it: should set specified targetCPUUtilizationPercentage
+    set:
+      global: {}
+      autoscaling:
+        enabled: true
+        targetCPUUtilizationPercentage: 90
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-timber-fluentd$
+      - equal: # check targetCPUUtilizationPercentage
+          path: spec.targetCPUUtilizationPercentage
+          value: 90

--- a/charts/timber-observation-service/Chart.yaml
+++ b/charts/timber-observation-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: timber-observation-service
 description: Observation Service - Logging system for collecting ground truth observation result from ML prediction
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.1.0
 dependencies:
 - alias: fluentd

--- a/charts/timber-observation-service/README.md
+++ b/charts/timber-observation-service/README.md
@@ -1,7 +1,7 @@
 # timber-observation-service
 
 ---
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Observation Service - Logging system for collecting ground truth observation result from ML prediction

--- a/charts/timber-observation-service/templates/hpa.yaml
+++ b/charts/timber-observation-service/templates/hpa.yaml
@@ -13,11 +13,7 @@ spec:
     name: {{ include "observation-service.fullname" . }}
   minReplicas: {{ .Values.observationService.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.observationService.autoscaling.maxReplicas }}
-  metrics:
-    {{- if .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
+  {{- if .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.observationService.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
 {{- end }}

--- a/charts/timber-observation-service/tests/observation_service_deployment_hpa_test.yaml
+++ b/charts/timber-observation-service/tests/observation_service_deployment_hpa_test.yaml
@@ -1,0 +1,25 @@
+suite: Unit tests for Observation Service HPA
+templates:
+  - hpa.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+  revision: 1
+  isUpgrade: true
+tests:
+  - it: should set specified targetCPUUtilizationPercentage
+    set:
+      global: {}
+      observationService:
+        autoscaling:
+          enabled: true
+          targetCPUUtilizationPercentage: 90
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-timber-observation-service$
+      - equal: # check targetCPUUtilizationPercentage
+          path: spec.targetCPUUtilizationPercentage
+          value: 90

--- a/charts/timber-observation-service/tests/observation_service_deployment_test.yaml
+++ b/charts/timber-observation-service/tests/observation_service_deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
           content:
            name: gcp-service-account
            secret:
-            secretName:  my-release-timber-observation-service-fluentd
+            secretName: my-release-timber-observation-service-fluentd
       - contains: # check env var added
           path: spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
# Motivation

Timber helm charts currently use `HorizontalPodAutoscaler` for `apiVersion: autoscaling/v1`. The current specification is supported for `apiVersion: autoscaling/v2` and hence is defined incorrectly.

# Modification

Update `HorizontalPodAutoscaler` CR and add tests.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
