### PR TITLE
feat(routes): allow users to use provided CertificateIssuer

### DIFF
--- a/charts/routes/Chart.yaml
+++ b/charts/routes/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.2
+appVersion: 1.0.0
 dependencies:
 - alias: istiod
   condition: istiod.enabled
@@ -35,4 +35,4 @@ maintainers:
   name: caraml-dev
 name: caraml-routes
 type: application
-version: 0.1.6
+version: 0.2.0

--- a/charts/routes/README.md
+++ b/charts/routes/README.md
@@ -1,8 +1,8 @@
 # caraml-routes
 
 ---
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square)
-![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
+![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML networking resources
 

--- a/charts/routes/README.md
+++ b/charts/routes/README.md
@@ -101,8 +101,8 @@ The following table lists the configurable parameters of the Routes chart and th
 | global.xp.useServiceFqdn | bool | `true` |  |
 | global.xp.vsPrefix | string | `"/api/xp"` |  |
 | https.certificateIssuer.create | bool | `true` |  |
-| https.certificateIssuer.kind | string | `"ClusterIssuer"` |  |
-| https.certificateIssuer.name | string | `"default"` |  |
+| https.certificateIssuer.external.kind | string | `"ClusterIssuer"` |  |
+| https.certificateIssuer.external.name | string | `"default"` |  |
 | https.enabled | bool | `true` |  |
 | https.tls.credentialName | string | `"mlp-tls-cert"` |  |
 | https.tls.mode | string | `"SIMPLE"` |  |

--- a/charts/routes/README.md
+++ b/charts/routes/README.md
@@ -100,6 +100,9 @@ The following table lists the configurable parameters of the Routes chart and th
 | global.xp.uiServiceName | string | `"xp-management"` |  |
 | global.xp.useServiceFqdn | bool | `true` |  |
 | global.xp.vsPrefix | string | `"/api/xp"` |  |
+| https.certificateIssuer.create | bool | `true` |  |
+| https.certificateIssuer.kind | string | `"ClusterIssuer"` |  |
+| https.certificateIssuer.name | string | `"default"` |  |
 | https.enabled | bool | `true` |  |
 | https.tls.credentialName | string | `"mlp-tls-cert"` |  |
 | https.tls.mode | string | `"SIMPLE"` |  |

--- a/charts/routes/templates/certs.yaml
+++ b/charts/routes/templates/certs.yaml
@@ -23,8 +23,8 @@ spec:
     name: {{ printf "%s-%s" (include "caraml-routes.fullname" . ) "issuer" }}
     kind: ClusterIssuer
     {{- else }}
-    name: {{ .Values.https.certificateIssuer.name }}
-    kind: {{ .Values.https.certificateIssuer.kind }}
+    name: {{ .Values.https.certificateIssuer.external.name }}
+    kind: {{ .Values.https.certificateIssuer.external.kind }}
     {{- end }}
     group: cert-manager.io
   dnsNames:

--- a/charts/routes/templates/certs.yaml
+++ b/charts/routes/templates/certs.yaml
@@ -1,5 +1,6 @@
 {{- $hosts := (concat (get $.Values.global.hosts "mlp") (get $.Values.global.hosts "mlpdocs") (get $.Values.global.hosts "mlflow") )}}
-{{- if and .Values.https.enabled }}
+{{- if .Values.https.enabled }}
+{{- if .Values.https.certificateIssuer.create }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -7,6 +8,7 @@ metadata:
   name: {{ printf "%s-%s" (include "caraml-routes.fullname" . ) "issuer" }}
 spec:
   selfSigned: {}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -17,8 +19,13 @@ metadata:
 spec:
   secretName: {{ include "caraml-routes.tls-cert-name" . }}
   issuerRef:
+    {{- if .Values.https.certificateIssuer.create }}
     name: {{ printf "%s-%s" (include "caraml-routes.fullname" . ) "issuer" }}
     kind: ClusterIssuer
+    {{- else }}
+    name: {{ .Values.https.certificateIssuer.name }}
+    kind: {{ .Values.https.certificateIssuer.kind }}
+    {{- end }}
     group: cert-manager.io
   dnsNames:
     {{- range $hosts }}

--- a/charts/routes/values.yaml
+++ b/charts/routes/values.yaml
@@ -156,6 +156,10 @@ mlp:
 https:
   # NOTE: Set https to true by default to allow google oauth login, disable from parent chart
   enabled: true
+  certificateIssuer:
+    create: true
+    name: default
+    kind: ClusterIssuer
   tls:
     mode: SIMPLE
     credentialName: mlp-tls-cert

--- a/charts/routes/values.yaml
+++ b/charts/routes/values.yaml
@@ -158,8 +158,9 @@ https:
   enabled: true
   certificateIssuer:
     create: true
-    name: default
-    kind: ClusterIssuer
+    external:
+      name: default
+      kind: ClusterIssuer
   tls:
     mode: SIMPLE
     credentialName: mlp-tls-cert


### PR DESCRIPTION
# Motivation
By default routes chart will create CertificateIssuer, which issues self-signed certificates. The goal is to make this behaviour customizable and allow users to use custom issuers.

# Modification
- make creation of ClusterIssuer optional

# Checklist
- [x] Chart version bumped
- [x] README.md updated
