### PR TITLE
fix(merlin): remove redundant labels for mlflow service and deployment

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.9.34
+version: 0.9.35

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,6 +1,6 @@
 # merlin
 
-![Version: 0.9.34](https://img.shields.io/badge/Version-0.9.34-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.9.35](https://img.shields.io/badge/Version-0.9.35-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -65,6 +65,14 @@ Generated names
     {{- printf "%s-%s" .Chart.Name .Chart.Version -}}
 {{- end -}}
 
+{{- define "mlflow.name" -}}
+    {{- if .Values.mlflow.nameOverride -}}
+        {{- .Values.mlflow.nameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- printf "%s-%s" .Chart.Name .Values.mlflow.name | trunc 63 | trimSuffix "-" -}}
+    {{- end -}}
+{{- end -}}
+
 {{- define "mlflow.fullname" -}}
     {{- if .Values.mlflow.fullnameOverride -}}
         {{- .Values.mlflow.fullnameOverride | trunc 63 | trimSuffix "-" -}}

--- a/charts/merlin/templates/mlflow-deployment.yaml
+++ b/charts/merlin/templates/mlflow-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ template "mlflow.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "mlflow.fullname" . }}
     {{- include "merlin.labels" . | nindent 4 }}
     {{- if .Values.mlflow.deploymentLabels}}
       {{- toYaml .Values.mlflow.deploymentLabels | nindent 4 }}
@@ -13,7 +12,7 @@ spec:
   replicas: {{ .Values.mlflow.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "mlflow.fullname" . }}
+      app: {{ template "mlflow.name" . }}
       release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
@@ -23,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "mlflow.fullname" . }}
+        app: {{ template "mlflow.name" . }}
         release: {{ .Release.Name }}
         {{- if .Values.mlflow.podLabels }}
           {{- toYaml .Values.mlflow.podLabels | nindent 8 }}

--- a/charts/merlin/templates/mlflow-service.yaml
+++ b/charts/merlin/templates/mlflow-service.yaml
@@ -10,7 +10,6 @@ metadata:
 {{ toYaml .Values.mlflow.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "mlflow.fullname" . }}
     {{- include "merlin.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.mlflow.service.type }}
@@ -34,5 +33,5 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: {{ template "mlflow.fullname" . }}
+    app: {{ template "mlflow.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
# Motivation
After adding `app` label to the template `merlin.label` chart started generating resources with duplicated labels in mlflow service and deployments.

# Modification
Remove `app` label from `mlflow` templates

# Checklist
- [x] Chart version bumped
- [x] README.md updated
