### PR TITLE
feat(routes): add possibility of configuring extra mappings for virtualservice

### DIFF
--- a/charts/routes/Chart.yaml
+++ b/charts/routes/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
   name: caraml-dev
 name: caraml-routes
 type: application
-version: 0.2.0
+version: 0.2.1

--- a/charts/routes/README.md
+++ b/charts/routes/README.md
@@ -1,7 +1,7 @@
 # caraml-routes
 
 ---
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square)
 ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML networking resources
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the Routes chart and th
 | cert-manager.enabled | bool | `true` |  |
 | certManagerBase.enabled | bool | `true` |  |
 | common.enabled | bool | `true` |  |
+| extraMappings | list | `[]` |  |
 | feast.enabled | bool | `true` |  |
 | global.authz.externalPort | string | `"80"` |  |
 | global.authz.serviceName | string | `"caraml-authz"` |  |

--- a/charts/routes/templates/_helpers.tpl
+++ b/charts/routes/templates/_helpers.tpl
@@ -102,7 +102,7 @@ Function to add generate Uri Match and redirect match for routess
       {{- if $enableHeaderMatch }}
       headers:
         Authorization:
-            regex: "^Bearer [^\\.]+\\.[^\\.]+\\.[^\\.]+$"
+            regex: "^Bearer e[^\\.]{2,}\\.e[^\\.]{2,}\\.[^\\.]+$"
       {{- end }}
   rewrite:
     uri: {{ $rewriteUri | quote }}

--- a/charts/routes/templates/mlp-vs.yaml
+++ b/charts/routes/templates/mlp-vs.yaml
@@ -33,11 +33,11 @@ spec:
     {{- include "caraml-routes.mlp-api-routes" (list .appName (include "common.get-prefix-match" $.Values.global.mlp) .rewriteUri $.Values.global.mlp.serviceName .authHeader) | indent 4}}
     {{- end }}
     {{- end }}
-    {{- if .Values.feast.enabled }}
     {{- if .Values.extraMappings }}
     {{- range .Values.extraMappings }}
     - {{- toYaml . | nindent 6 }}
     {{- end}}
+    {{- if .Values.feast.enabled }}
     {{- end}}
     - name: "feast-ui-backend"
       match:

--- a/charts/routes/templates/mlp-vs.yaml
+++ b/charts/routes/templates/mlp-vs.yaml
@@ -34,6 +34,11 @@ spec:
     {{- end }}
     {{- end }}
     {{- if .Values.feast.enabled }}
+    {{- if .Values.extraMappings }}
+    {{- range .Values.extraMappings }}
+    - {{- toYaml . | nindent 6 }}
+    {{- end}}
+    {{- end}}
     - name: "feast-ui-backend"
       match:
         - uri:

--- a/charts/routes/templates/mlp-vs.yaml
+++ b/charts/routes/templates/mlp-vs.yaml
@@ -37,8 +37,8 @@ spec:
     {{- range .Values.extraMappings }}
     - {{- toYaml . | nindent 6 }}
     {{- end}}
-    {{- if .Values.feast.enabled }}
     {{- end}}
+    {{- if .Values.feast.enabled }}
     - name: "feast-ui-backend"
       match:
         - uri:

--- a/charts/routes/values.yaml
+++ b/charts/routes/values.yaml
@@ -174,6 +174,17 @@ mlpGateway:
 
 # configuration for extra mappings in VS (e.g. authentication proxies)
 extraMappings: []
+  # name: auth-proxy
+  # match:
+  #   - uri:
+  #       prefix: /auth-proxy/
+  # rewrite:
+  #   uri: /
+  # route:
+  #   - destination:
+  #       host: auth-proxy
+  #       port:
+  #         number: 8080
 
 ############################################################
 # Istio Base

--- a/charts/routes/values.yaml
+++ b/charts/routes/values.yaml
@@ -174,17 +174,17 @@ mlpGateway:
 
 # configuration for extra mappings in VS (e.g. authentication proxies)
 extraMappings: []
-  # name: auth-proxy
-  # match:
-  #   - uri:
-  #       prefix: /auth-proxy/
-  # rewrite:
-  #   uri: /
-  # route:
-  #   - destination:
-  #       host: auth-proxy
-  #       port:
-  #         number: 8080
+  # - name: auth-proxy
+  #   match:
+  #     - uri:
+  #         prefix: /auth-proxy/
+  #   rewrite:
+  #     uri: /
+  #   route:
+  #     - destination:
+  #         host: auth-proxy
+  #         port:
+  #           number: 8080
 
 ############################################################
 # Istio Base

--- a/charts/routes/values.yaml
+++ b/charts/routes/values.yaml
@@ -172,6 +172,8 @@ mlpGateway:
   selector:
     istio: ingressgateway
 
+# configuration for extra mappings in VS (e.g. authentication proxies)
+extraMappings: []
 
 ############################################################
 # Istio Base


### PR DESCRIPTION
# Motivation
Sometimes we need to configure extra mappings in VS routing part to support cases like legacy authentication, etc.

# Modification
- add extra section to mlp-vs
- adjust JWT check

# Checklist
- [x] Chart version bumped
- [x] README.md updated
