### PR TITLE
fix: Timber fluentd HPA CR scaleTargetRef

### DIFF
--- a/charts/observation-service/Chart.yaml
+++ b/charts/observation-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: observation-service
 description: Observation Service - Logging system for collecting ground truth observation result from ML prediction
-version: 0.1.5
+version: 0.1.6
 appVersion: 0.1.0
 maintainers:
 - email: caraml-dev@caraml.dev

--- a/charts/observation-service/README.md
+++ b/charts/observation-service/README.md
@@ -1,7 +1,7 @@
 # observation-service
 
 ---
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Observation Service - Logging system for collecting ground truth observation result from ML prediction

--- a/charts/observation-service/templates/fluentd-hpa.yaml
+++ b/charts/observation-service/templates/fluentd-hpa.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: StatefulSet
     name: {{ include "observation-service.fullname" . }}-fluentd
   minReplicas: {{ .Values.fluentd.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.autoscaling.maxReplicas }}

--- a/charts/timber-fluentd/Chart.yaml
+++ b/charts/timber-fluentd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: timber-fluentd
 description: Fluentd service - Fluentd service that supports UPI logs parsing
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.1.0
 maintainers:
 - email: caraml-dev@caraml.dev

--- a/charts/timber-fluentd/README.md
+++ b/charts/timber-fluentd/README.md
@@ -1,7 +1,7 @@
 # timber-fluentd
 
 ---
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Fluentd service - Fluentd service that supports UPI logs parsing

--- a/charts/timber-fluentd/templates/hpa.yaml
+++ b/charts/timber-fluentd/templates/hpa.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: StatefulSet
     name: {{ include "timber-fluentd.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}


### PR DESCRIPTION
# Motivation

The incorrect `scaleTargetRef` was used for all Fluentd CR in Timber-related helm charts.

# Modification

Use `StatefulSet` instead of `Deployment` for all Fluentd CR in Timber-related helm charts.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
