### PR TITLE
fix: Update the globApiHost variable to get the compatible value

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.4.11
+version: 0.4.12

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.11](https://img.shields.io/badge/Version-0.4.11-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
+![Version: 0.4.12](https://img.shields.io/badge/Version-0.4.12-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
 
 MLP API
 

--- a/charts/mlp/templates/configmap.yaml
+++ b/charts/mlp/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- $globOauthClientID := include "common.get-oauth-client" .Values.global }}
-{{- $globApiHost := include "common.get-component-value" (list .Values.global "mlp"  (list "vsPrefix" "apiPrefix")) }}
+{{- $globApiHost := include "common.get-component-value" (list .Values.global "mlp"  (list "vsPrefix")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/mlp/tests/mlp_cm_test.yaml
+++ b/charts/mlp/tests/mlp_cm_test.yaml
@@ -62,7 +62,7 @@ tests:
       - matchRegex:
           path: data.[mlp-config.yaml]
           pattern: |
-            (?s).*apiHost: "/api/v1"
+            (?s).*apiHost: "/api"
             .*oauthClientID: "test-client-123"
             .*applications:
             .*api: \/api\/merlin\/v1


### PR DESCRIPTION
# Motivation
ApiHost part in the configMap always evaluates to `/api/v1` in caraml but it must be `/api`. 


# Modification
* Update the globApiHost variable to get the compatible value

# Checklist
- [x] Chart version bumped
- [x] README.md updated
