### PR TITLE
chore: update observation service fluentd dep name

### DIFF
--- a/charts/observation-svc/Chart.lock
+++ b/charts/observation-svc/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: timber-fluentd
+- name: fluentd
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.3
-digest: sha256:4a6f1a1ec68fc06b1950e6c9b5cf494807f60afb4787fc215258d273c1e672bc
-generated: "2023-02-08T13:52:11.566823+08:00"
+  version: 0.1.4
+digest: sha256:6b6394e2f5a0caad584ea25bc667909fbec900373bde949877d7a353d5cac977
+generated: "2023-02-09T14:02:20.859016+08:00"

--- a/charts/observation-svc/Chart.yaml
+++ b/charts/observation-svc/Chart.yaml
@@ -3,13 +3,13 @@ appVersion: 0.1.0
 dependencies:
 - alias: fluentd
   condition: fluentd.enabled
-  name: timber-fluentd
+  name: fluentd
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.3
+  version: 0.1.4
 description: Observation Service - Logging system for collecting ground truth observation
   result from ML prediction
 maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: observation-svc
-version: 0.2.4
+version: 0.2.5

--- a/charts/observation-svc/README.md
+++ b/charts/observation-svc/README.md
@@ -1,7 +1,7 @@
 # observation-svc
 
 ---
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Observation Service - Logging system for collecting ground truth observation result from ML prediction


### PR DESCRIPTION
# Motivation
Follow up to https://github.com/caraml-dev/helm-charts/pull/175, as the chart name was reduce due to char limits in kubernate resource

# Modification
Depdencies rename from `timber-fluentd` to `fluentd`

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
