### PR TITLE
chore: Update caraml version to 0.4.30

### DIFF
--- a/charts/caraml/Chart.lock
+++ b/charts/caraml/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.4.12
 - name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.9.37
+  version: 0.10.1
 - name: postgresql
   repository: https://charts.helm.sh/stable
   version: 7.0.2
@@ -35,5 +35,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.8.2
-digest: sha256:08c9ca09dcfac3ae02cbc32e32754cdb73ffa7f32d294faad635c2f8934ad2a9
-generated: "2023-02-07T11:37:03.635522226Z"
+digest: sha256:ef008ac811f678f531fd0007d58bcfc59e4798861ae6de688d5761a859fd72df
+generated: "2023-02-10T09:26:30.525103+08:00"

--- a/charts/caraml/Chart.yaml
+++ b/charts/caraml/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
 - condition: merlin.enabled
   name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.9.37
+  version: 0.10.1
 - condition: postgresql.enabled
   name: postgresql
   repository: https://charts.helm.sh/stable
@@ -60,4 +60,4 @@ maintainers:
   name: caraml-dev
 name: caraml
 type: application
-version: 0.4.29
+version: 0.4.30

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -1,6 +1,6 @@
 # caraml
 
-![Version: 0.4.29](https://img.shields.io/badge/Version-0.4.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.4.30](https://img.shields.io/badge/Version-0.4.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML components
 
@@ -21,7 +21,7 @@ A Helm chart for deploying CaraML components
 | https://caraml-dev.github.io/helm-charts | istiod(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | istioIngressGateway(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | clusterLocalGateway(generic-dep-installer) | 0.2.1 |
-| https://caraml-dev.github.io/helm-charts | merlin | 0.9.37 |
+| https://caraml-dev.github.io/helm-charts | merlin | 0.10.1 |
 | https://caraml-dev.github.io/helm-charts | mlp | 0.4.12 |
 | https://charts.helm.sh/stable | postgresql | 7.0.2 |
 | https://charts.jetstack.io | cert-manager | v1.8.2 |

--- a/scripts/generate-cluster-creds.sh
+++ b/scripts/generate-cluster-creds.sh
@@ -89,7 +89,9 @@ EOF
   output=$(yq e -o json '.k8s_config' /tmp/temp_k8sconfig.yaml | jq -r -M -c .)
   # NOTE: Write to ci/ files as these files will be used in ci tests! Consider looping through all files
   # in ci dir
+  # Write to merlin chart and caraml chart ci-values.yaml
   output="$output" yq '.environmentConfigs[0] *= load("/tmp/temp_k8sconfig.yaml") | .imageBuilder.k8sConfig |= strenv(output)' -i "${SCRIPT_DIR}/../charts/merlin/ci/ci-values.yaml"
+  output="$output" yq '.merlin.environmentConfigs[0] *= load("/tmp/temp_k8sconfig.yaml") | .merlin.imageBuilder.k8sConfig |= strenv(output)' -i "${SCRIPT_DIR}/../charts/caraml/ci/ci-values.yaml"
 }
 
 main "$@"


### PR DESCRIPTION
# Motivation
This PR bumps caraml to version 0.4.30, to use Merlin's new version 0.10.1

# Modification
* `./scripts/generate-cluster-creds.sh` now modifies caraml chart's ci/ci-values.yaml file as well

# Checklist
- [x] Chart version bumped
- [x] README.md updated