### PR TITLE
fix(knative): remove duplicate label

### DIFF
--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
   name: caraml-dev
 name: knative-serving-istio
 type: application
-version: 1.7.1
+version: 1.7.2

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square)
 ![AppVersion: v1.7.1](https://img.shields.io/badge/AppVersion-v1.7.1-informational?style=flat-square)
 
 Installs Knative-serving for Istio

--- a/charts/knative-serving-istio/templates/deployments/net-istio-controller.yaml
+++ b/charts/knative-serving-istio/templates/deployments/net-istio-controller.yaml
@@ -33,7 +33,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: net-istio-controller
-        serving.knative.dev/release: "v1.0.0"
         {{- include "knative-net-istio.labels" . | nindent 8 }}
         {{- if .Values.global.extraPodLabels }}
           {{- toYaml .Values.global.extraPodLabels | nindent 8 }}


### PR DESCRIPTION
# Motivation
A duplicate label was causing JSON marshalling failure

# Modification
- removed duplicate

# Checklist
- [x] Chart version bumped
- [x] README.md updated
