### PR TITLE
fix(knative): use quotes for port mappings to prevent kustomize errors

### DIFF
--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
   name: caraml-dev
 name: knative-serving-istio
 type: application
-version: 1.7.1
+version: 1.7.2

--- a/charts/knative-serving-istio/Chart.yaml
+++ b/charts/knative-serving-istio/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
   name: caraml-dev
 name: knative-serving-istio
 type: application
-version: 1.7.2
+version: 1.7.3

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square)
+![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square)
 ![AppVersion: v1.7.1](https://img.shields.io/badge/AppVersion-v1.7.1-informational?style=flat-square)
 
 Installs Knative-serving for Istio

--- a/charts/knative-serving-istio/README.md
+++ b/charts/knative-serving-istio/README.md
@@ -1,7 +1,7 @@
 # knative-serving-istio
 
 ---
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square)
 ![AppVersion: v1.7.1](https://img.shields.io/badge/AppVersion-v1.7.1-informational?style=flat-square)
 
 Installs Knative-serving for Istio

--- a/charts/knative-serving-istio/templates/peer-authentication/domain-mapping-webhook.yaml
+++ b/charts/knative-serving-istio/templates/peer-authentication/domain-mapping-webhook.yaml
@@ -23,5 +23,5 @@ spec:
     matchLabels:
       app: domainmapping-webhook
   portLevelMtls:
-    8443:
+    "8443":
       mode: PERMISSIVE

--- a/charts/knative-serving-istio/templates/peer-authentication/net-istio-webhook.yaml
+++ b/charts/knative-serving-istio/templates/peer-authentication/net-istio-webhook.yaml
@@ -23,5 +23,5 @@ spec:
     matchLabels:
       app: net-istio-webhook
   portLevelMtls:
-    8443:
+    "8443":
       mode: PERMISSIVE


### PR DESCRIPTION
# Motivation
Some resources in knative istio chart have configuration where integer is used as a key in yaml map:
```yaml
   portLevelMtls:
     8443:
       mode: PERMISSIVE
```
This is a known but not yet fixed error https://github.com/kubernetes-sigs/kustomize/issues/3446

# Modification
Quote integers

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
