### PR TITLE
chore: [fluentd] Rename template variable

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluentd
 description: Fluentd service - Fluentd service that supports UPI logs parsing
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.1.0
 maintainers:
 - email: caraml-dev@caraml.dev

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -1,7 +1,7 @@
 # fluentd
 
 ---
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square)
 ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Fluentd service - Fluentd service that supports UPI logs parsing

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "timber-fluentd.resource-prefix-with-release-name" -}}
+{{- define "fluentd.resource-prefix-with-release-name" -}}
     {{- if .Values.fullnameOverride -}}
         {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
@@ -14,7 +14,7 @@ Expand the name of the chart.
     {{- end -}}
 {{- end -}}
 
-{{- define "timber-fluentd.resource-prefix" -}}
+{{- define "fluentd.resource-prefix" -}}
     {{- if .Values.nameOverride -}}
         {{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
@@ -23,28 +23,28 @@ Expand the name of the chart.
     {{- end -}}
 {{- end -}}
 
-{{- define "timber-fluentd.name" -}}
-    {{- printf "%s" (include "timber-fluentd.resource-prefix" .) -}}
+{{- define "fluentd.name" -}}
+    {{- printf "%s" (include "fluentd.resource-prefix" .) -}}
 {{- end }}
 
-{{- define "timber-fluentd.fullname" -}}
-    {{- printf "%s" (include "timber-fluentd.resource-prefix-with-release-name" .) -}}
+{{- define "fluentd.fullname" -}}
+    {{- printf "%s" (include "fluentd.resource-prefix-with-release-name" .) -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "timber-fluentd.chart" -}}
+{{- define "fluentd.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "timber-fluentd.labels" -}}
-app: {{ template "timber-fluentd.name" .}}
+{{- define "fluentd.labels" -}}
+app: {{ template "fluentd.name" .}}
 release: {{ .Release.Name }}
-app.kubernetes.io/name: {{ template "timber-fluentd.name" . }}
+app.kubernetes.io/name: {{ template "fluentd.name" . }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote}}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/fluentd/templates/configmap.yaml
+++ b/charts/fluentd/templates/configmap.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "timber-fluentd.fullname" . }}
+  name: {{ include "fluentd.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "timber-fluentd.labels" . | nindent 4 }}
+    {{- include "fluentd.labels" . | nindent 4 }}
 data:
   fluent.conf: |-
 {{ .Values.fluentdConfig | nindent 4}}

--- a/charts/fluentd/templates/hpa.yaml
+++ b/charts/fluentd/templates/hpa.yaml
@@ -2,15 +2,15 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "timber-fluentd.fullname" . }}
+  name: {{ include "fluentd.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "timber-fluentd.labels" . | nindent 4 }}
+    {{- include "fluentd.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet
-    name: {{ include "timber-fluentd.fullname" . }}
+    name: {{ include "fluentd.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}

--- a/charts/fluentd/templates/secret.yaml
+++ b/charts/fluentd/templates/secret.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "timber-fluentd.fullname" . }}
+  name: {{ include "fluentd.fullname" . }}
   labels:
-    {{- include "timber-fluentd.labels" . | nindent 4 }}
+    {{- include "fluentd.labels" . | nindent 4 }}
 data:
   service-account.json: |-
 {{ .Values.gcpServiceAccount.credentialsData | indent 4 }}

--- a/charts/fluentd/templates/service.yaml
+++ b/charts/fluentd/templates/service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "timber-fluentd.fullname" . }}
+  name: {{ include "fluentd.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "timber-fluentd.fullname" . }}
-    {{- include "timber-fluentd.labels" . | nindent 4 }}
+    app: {{ include "fluentd.fullname" . }}
+    {{- include "fluentd.labels" . | nindent 4 }}
 spec:
   selector:
-    app: {{ include "timber-fluentd.name" . }}
+    app: {{ include "fluentd.name" . }}
     release: {{ .Release.Name }}
   type: ClusterIP
   ports:

--- a/charts/fluentd/templates/statefulset.yaml
+++ b/charts/fluentd/templates/statefulset.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "timber-fluentd.fullname" . }}
+  name: {{ include "fluentd.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "timber-fluentd.labels" . | nindent 4 }}
+    {{- include "fluentd.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -12,14 +12,14 @@ spec:
   minReadySeconds: 5
   selector:
     matchLabels:
-      app: {{ include "timber-fluentd.name" . }}
+      app: {{ include "fluentd.name" . }}
       release: {{ .Release.Name }}
-  serviceName: {{ include "timber-fluentd.fullname" . }}
+  serviceName: {{ include "fluentd.fullname" . }}
   template:
     metadata:
       labels:
-        app: {{ include "timber-fluentd.name" . }}
-        {{- include "timber-fluentd.labels" . | nindent 8 }}
+        app: {{ include "fluentd.name" . }}
+        {{- include "fluentd.labels" . | nindent 8 }}
         {{- if .Values.global.extraPodLabels }}
           {{- toYaml .Values.global.extraPodLabels | nindent 8 }}
         {{- end }}
@@ -62,7 +62,7 @@ spec:
       {{- if .Values.fluentdConfig }}
       - name: fluentd-conf
         configMap:
-          name: {{ include "timber-fluentd.fullname" . }}
+          name: {{ include "fluentd.fullname" . }}
           defaultMode: 0777
       {{- end }}
       {{- if .Values.gcpServiceAccount.credentials }}
@@ -76,7 +76,7 @@ spec:
       {{- if .Values.gcpServiceAccount.credentialsData }}
       - name: gcp-service-account
         secret:
-          secretName: {{ include "timber-fluentd.fullname" . }}
+          secretName: {{ include "fluentd.fullname" . }}
       {{- end }}
   {{- if .Values.pvcConfig }}
   volumeClaimTemplates:


### PR DESCRIPTION
# Motivation

Template variables in `fluentd` helm chart still use `timber-fluentd` as name. It's inconsistent with the chart name and might confuse users of the chart.

# Modification

Rename `timber-fluentd` template variables to `fluentd`

# Checklist
- [X] Chart version bumped
- [X] README.md updated
