### PR TITLE
chore: bump caraml version

### DIFF
--- a/charts/caraml/Chart.lock
+++ b/charts/caraml/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.12
+  version: 0.4.13
 - name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.10.1
+  version: 0.10.2
 - name: postgresql
   repository: https://charts.helm.sh/stable
   version: 7.0.2
@@ -35,5 +35,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.8.2
-digest: sha256:ef008ac811f678f531fd0007d58bcfc59e4798861ae6de688d5761a859fd72df
-generated: "2023-02-10T09:26:30.525103+08:00"
+digest: sha256:b50d04950de398f741a124bcfd84761677d1ccceab48324c03d68cc14067847e
+generated: "2023-02-14T17:08:38.045057+08:00"

--- a/charts/caraml/Chart.yaml
+++ b/charts/caraml/Chart.yaml
@@ -4,11 +4,11 @@ dependencies:
 - condition: mlp.enabled
   name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.12
+  version: 0.4.13
 - condition: merlin.enabled
   name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.10.1
+  version: 0.10.2
 - condition: postgresql.enabled
   name: postgresql
   repository: https://charts.helm.sh/stable
@@ -60,4 +60,4 @@ maintainers:
   name: caraml-dev
 name: caraml
 type: application
-version: 0.4.30
+version: 0.4.31

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -1,6 +1,6 @@
 # caraml
 
-![Version: 0.4.30](https://img.shields.io/badge/Version-0.4.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.4.31](https://img.shields.io/badge/Version-0.4.31-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML components
 
@@ -21,8 +21,8 @@ A Helm chart for deploying CaraML components
 | https://caraml-dev.github.io/helm-charts | istiod(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | istioIngressGateway(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | clusterLocalGateway(generic-dep-installer) | 0.2.1 |
-| https://caraml-dev.github.io/helm-charts | merlin | 0.10.1 |
-| https://caraml-dev.github.io/helm-charts | mlp | 0.4.12 |
+| https://caraml-dev.github.io/helm-charts | merlin | 0.10.2 |
+| https://caraml-dev.github.io/helm-charts | mlp | 0.4.13 |
 | https://charts.helm.sh/stable | postgresql | 7.0.2 |
 | https://charts.jetstack.io | cert-manager | v1.8.2 |
 | https://istio-release.storage.googleapis.com/charts | base(base) | 1.13.9 |


### PR DESCRIPTION
# Motivation
This PR bumps caraml chart to use the merlin 0.10.2 and mlp 0.4.13

# Modification

# Checklist
- [x] Chart version bumped
- [x] README.md updated