### PR TITLE
fix(mlp): Common helper functions to be used in postgres-secret

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.4.14
+version: 0.4.15

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.14](https://img.shields.io/badge/Version-0.4.14-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
+![Version: 0.4.15](https://img.shields.io/badge/Version-0.4.15-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
 
 MLP API
 

--- a/charts/mlp/templates/postgres-secret.yaml
+++ b/charts/mlp/templates/postgres-secret.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "postgres.password-secret-name" . }}
+  name: {{ include "common.postgres-password-secret-name" (list .Values.postgresql .Values.externalPostgresql .Release .Chart ) | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mlp.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{ template "postgres.password-secret-key" . }}: {{ .Values.externalPostgresql.password }}
+  {{ include "common.postgres-password-secret-key" (list .Values.externalPostgresql) }}: {{ .Values.externalPostgresql.password }}
 {{- end -}}


### PR DESCRIPTION
# Motivation
When the postgres helper functions are removed from the charts and moved to common chart. Their usage is not moved for this scenario. When enabled and external postgres secret is created. It needs to use the common helper functions. 

# Modification

# Checklist
- [x] Chart version bumped
- [x] README.md updated
