### PR TITLE
fix: Update Merlin helm chart with valid default resource values

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.26.0-rc5
+appVersion: 0.26.0-rc6
 dependencies:
 - alias: merlin-postgresql
   condition: merlin-postgresql.enabled
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.10.7
+version: 0.10.8

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,6 +1,6 @@
 # merlin
 
-![Version: 0.10.7](https://img.shields.io/badge/Version-0.10.7-informational?style=flat-square) ![AppVersion: 0.26.0-rc5](https://img.shields.io/badge/AppVersion-0.26.0--rc5-informational?style=flat-square)
+![Version: 0.10.8](https://img.shields.io/badge/Version-0.10.8-informational?style=flat-square) ![AppVersion: 0.26.0-rc6](https://img.shields.io/badge/AppVersion-0.26.0--rc6-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -38,7 +38,7 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.registry | string | `"ghcr.io"` |  |
 | deployment.image.repository | string | `"gojek/merlin"` |  |
-| deployment.image.tag | string | `"0.26.0-rc5"` |  |
+| deployment.image.tag | string | `"0.26.0-rc6"` |  |
 | deployment.labels | object | `{}` |  |
 | deployment.podLabels | object | `{}` |  |
 | deployment.replicaCount | string | `"2"` |  |
@@ -94,9 +94,9 @@ Kubernetes-friendly ML model management, deployment, and serving.
 | imageBuilder.predictionJobBaseImages."3.7.*".imageName | string | `"pyspark-py37:v0.1.0"` |  |
 | imageBuilder.predictionJobBaseImages."3.7.*".mainAppPath | string | `"/merlin-spark-app/main.py"` |  |
 | imageBuilder.predictionJobContextSubPath | string | `""` |  |
-| imageBuilder.resources.limits.cpu | int | `1` |  |
+| imageBuilder.resources.limits.cpu | string | `"1"` |  |
 | imageBuilder.resources.limits.memory | string | `"1Gi"` |  |
-| imageBuilder.resources.requests.cpu | int | `1` |  |
+| imageBuilder.resources.requests.cpu | string | `"1"` |  |
 | imageBuilder.resources.requests.memory | string | `"512Mi"` |  |
 | imageBuilder.retention | string | `"48h"` |  |
 | imageBuilder.timeout | string | `"30m"` |  |

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -5,7 +5,7 @@ deployment:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: gojek/merlin
-    tag: 0.26.0-rc5
+    tag: 0.26.0-rc6
   replicaCount: "2"
   # Additional labels to apply to the deployment
   labels: {}
@@ -59,10 +59,10 @@ imageBuilder:
   kanikoImage: "gcr.io/kaniko-project/executor:v1.6.0"
   resources:
     requests:
-      cpu: 1
+      cpu: "1"
       memory: 512Mi
     limits:
-      cpu: 1
+      cpu: "1"
       memory: 1Gi
   tolerations: []
   nodeSelectors: {}


### PR DESCRIPTION
# Motivation

Default `cpu` value was incorrectly used when resource specification for imagebuilder was introduced in https://github.com/caraml-dev/helm-charts/pull/212.

# Modification

Ensure default `cpu` value is of string type.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
