### PR TITLE
feat: Adding standard transformer keep alive & kafka configurations

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,12 +52,12 @@ jobs:
         env:
           CHARTS_CHANGED: ${{ steps.list-changed.outputs.charts_changed }}
         run: |
-          helm plugin install https://github.com/quintush/helm-unittest > /dev/null 2>&1
+          helm plugin install https://github.com/helm-unittest/helm-unittest > /dev/null 2>&1
           for chart in $CHARTS_CHANGED; do
             chart=`echo $chart | sed 's/ *$//g'`
             cd $chart
             helm dep build > /dev/null 2>&1
-            helm unittest --helm3 -u -d .
+            helm unittest -u -d .
             cd ../../
           done
 

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.26.0-rc6
+appVersion: v0.27.0-rc1
 dependencies:
 - alias: merlin-postgresql
   condition: merlin-postgresql.enabled

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.10.12
+version: 0.10.13

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -72,8 +72,8 @@ The following table lists the configurable parameters of the Merlin chart and th
 | authorization.serverUrl | string | `"http://mlp-authorization-keto"` |  |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.registry | string | `"ghcr.io"` |  |
-| deployment.image.repository | string | `"gojek/merlin"` |  |
-| deployment.image.tag | string | `"v0.27.0-rc1"` |  |
+| deployment.image.repository | string | `"caraml-dev/merlin"` |  |
+| deployment.image.tag | string | `"0.27.0-rc1"` |  |
 | deployment.labels | object | `{}` |  |
 | deployment.podLabels | object | `{}` |  |
 | deployment.replicaCount | string | `"2"` |  |
@@ -252,7 +252,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | newrelic.appname | string | `"merlin-api-dev"` |  |
 | newrelic.enabled | bool | `false` |  |
 | newrelic.licenseSecretName | string | `"newrelic-license-secret"` |  |
-| pyfuncGRPCOptions | object | `{}` |  |
+| pyfuncGRPCOptions | string | `"{}"` |  |
 | queue.numOfWorkers | int | `1` |  |
 | sentry.dsn | string | `""` |  |
 | sentry.enabled | bool | `false` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -293,6 +293,8 @@ The following table lists the configurable parameters of the Merlin chart and th
 | transformer.model.grpc.keepAliveEnabled | bool | `false` | |
 | transformer.model.grpc.keepAliveTime | string | `"60s"` | |
 | transformer.model.grpc.keepAliveTimeout | string | `"5s"` | |
+| transformer.kafka.brokers | string | |
+| transformer.kafka.maxMessageSize| int | `1048588` | |
 | transformer.simulation.feastBigtableServingURL | string | `"online-serving-bt.feast.dev"` |  |
 | transformer.simulation.feastRedisServingURL | string | `"online-serving-redis.feast.dev"` |  |
 | ui.apiHost | string | `"/api/merlin/v1"` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -2,7 +2,7 @@
 
 ---
 ![Version: 0.10.13](https://img.shields.io/badge/Version-0.10.13-informational?style=flat-square)
-![AppVersion: v0.27.0-rc1](https://img.shields.io/badge/AppVersion-0.26.0--rc6-informational?style=flat-square)
+![AppVersion: v0.27.0-rc1](https://img.shields.io/badge/AppVersion-v0.27.0--rc1-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.registry | string | `"ghcr.io"` |  |
 | deployment.image.repository | string | `"gojek/merlin"` |  |
-| deployment.image.tag | string | `"0.26.0-rc9"` |  |
+| deployment.image.tag | string | `"v0.27.0-rc1"` |  |
 | deployment.labels | object | `{}` |  |
 | deployment.podLabels | object | `{}` |  |
 | deployment.replicaCount | string | `"2"` |  |
@@ -83,7 +83,6 @@ The following table lists the configurable parameters of the Merlin chart and th
 | deployment.resources.requests.memory | string | `"1Gi"` |  |
 | deployment.tolerations | list | `[]` |  |
 | deploymentLabelPrefix | string | `"gojek.com/"` |  |
-| pyfuncGRPCOptions| object | `{}` | |
 | encryption.key | string | `"password"` |  |
 | environment | string | `"dev"` |  |
 | environmentConfigs[0].cluster | string | `"test"` |  |
@@ -253,6 +252,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | newrelic.appname | string | `"merlin-api-dev"` |  |
 | newrelic.enabled | bool | `false` |  |
 | newrelic.licenseSecretName | string | `"newrelic-license-secret"` |  |
+| pyfuncGRPCOptions | object | `{}` |  |
 | queue.numOfWorkers | int | `1` |  |
 | sentry.dsn | string | `""` |  |
 | sentry.enabled | bool | `false` |  |
@@ -268,14 +268,14 @@ The following table lists the configurable parameters of the Merlin chart and th
 | swagger.service.externalPort | int | `8080` |  |
 | swagger.service.internalPort | int | `8081` |  |
 | transformer.feast.authEnabled | bool | `false` |  |
-| transformer.feast.grpc.keepAliveEnabled | bool | `false` | |
-| transformer.feast.grpc.keepAliveTime | string | `"60s"` | |
-| transformer.feast.grpc.keepAliveTimeout | string | `"5s"` | |
 | transformer.feast.bigtableCredential | string | `nil` |  |
 | transformer.feast.coreAuthAudience | string | `"core.feast.dev"` |  |
 | transformer.feast.coreURL | string | `"core.feast.dev"` |  |
 | transformer.feast.defaultFeastSource | string | `"BIGTABLE"` |  |
 | transformer.feast.defaultServingURL | string | `"online-serving-redis.feast.dev"` |  |
+| transformer.feast.grpc.keepAliveEnabled | bool | `false` |  |
+| transformer.feast.grpc.keepAliveTime | string | `"60s"` |  |
+| transformer.feast.grpc.keepAliveTimeout | string | `"5s"` |  |
 | transformer.feast.servingURLs[0].host | string | `"online-serving-redis.feast.dev"` |  |
 | transformer.feast.servingURLs[0].icon | string | `"redis"` |  |
 | transformer.feast.servingURLs[0].label | string | `"Online Serving with Redis"` |  |
@@ -290,11 +290,11 @@ The following table lists the configurable parameters of the Merlin chart and th
 | transformer.jaeger.disabled | bool | `false` |  |
 | transformer.jaeger.samplerParam | int | `1` |  |
 | transformer.jaeger.samplerType | string | `"const"` |  |
-| transformer.model.grpc.keepAliveEnabled | bool | `false` | |
-| transformer.model.grpc.keepAliveTime | string | `"60s"` | |
-| transformer.model.grpc.keepAliveTimeout | string | `"5s"` | |
-| transformer.kafka.brokers | string | |
-| transformer.kafka.maxMessageSize| int | `1048588` | |
+| transformer.kafka.brokers | string | `"kafka-brokers"` |  |
+| transformer.kafka.maxMessageSize | string | `"1048588"` |  |
+| transformer.model.grpc.keepAliveEnabled | bool | `false` |  |
+| transformer.model.grpc.keepAliveTime | string | `"60s"` |  |
+| transformer.model.grpc.keepAliveTimeout | string | `"5s"` |  |
 | transformer.simulation.feastBigtableServingURL | string | `"online-serving-bt.feast.dev"` |  |
 | transformer.simulation.feastRedisServingURL | string | `"online-serving-redis.feast.dev"` |  |
 | ui.apiHost | string | `"/api/merlin/v1"` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,12 +1,8 @@
 # merlin
 
-<<<<<<< HEAD
 ---
-![Version: 0.10.12](https://img.shields.io/badge/Version-0.10.12-informational?style=flat-square)
-![AppVersion: 0.26.0-rc6](https://img.shields.io/badge/AppVersion-0.26.0--rc6-informational?style=flat-square)
-=======
-![Version: 0.10.12](https://img.shields.io/badge/Version-0.10.12-informational?style=flat-square) ![AppVersion: 0.26.0-rc9](https://img.shields.io/badge/AppVersion-0.26.0--rc9-informational?style=flat-square)
->>>>>>> cd0f90b (Add keep alive configuration for standard transformer)
+![Version: 0.10.13](https://img.shields.io/badge/Version-0.10.13-informational?style=flat-square)
+![AppVersion: v0.27.0-rc1](https://img.shields.io/badge/AppVersion-0.26.0--rc6-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,8 +1,12 @@
 # merlin
 
+<<<<<<< HEAD
 ---
 ![Version: 0.10.12](https://img.shields.io/badge/Version-0.10.12-informational?style=flat-square)
 ![AppVersion: 0.26.0-rc6](https://img.shields.io/badge/AppVersion-0.26.0--rc6-informational?style=flat-square)
+=======
+![Version: 0.10.12](https://img.shields.io/badge/Version-0.10.12-informational?style=flat-square) ![AppVersion: 0.26.0-rc9](https://img.shields.io/badge/AppVersion-0.26.0--rc9-informational?style=flat-square)
+>>>>>>> cd0f90b (Add keep alive configuration for standard transformer)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -73,7 +77,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.registry | string | `"ghcr.io"` |  |
 | deployment.image.repository | string | `"gojek/merlin"` |  |
-| deployment.image.tag | string | `"0.26.0-rc6"` |  |
+| deployment.image.tag | string | `"0.26.0-rc9"` |  |
 | deployment.labels | object | `{}` |  |
 | deployment.podLabels | object | `{}` |  |
 | deployment.replicaCount | string | `"2"` |  |
@@ -83,6 +87,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | deployment.resources.requests.memory | string | `"1Gi"` |  |
 | deployment.tolerations | list | `[]` |  |
 | deploymentLabelPrefix | string | `"gojek.com/"` |  |
+| pyfuncGRPCOptions| object | `{}` | |
 | encryption.key | string | `"password"` |  |
 | environment | string | `"dev"` |  |
 | environmentConfigs[0].cluster | string | `"test"` |  |
@@ -267,6 +272,9 @@ The following table lists the configurable parameters of the Merlin chart and th
 | swagger.service.externalPort | int | `8080` |  |
 | swagger.service.internalPort | int | `8081` |  |
 | transformer.feast.authEnabled | bool | `false` |  |
+| transformer.feast.grpc.keepAliveEnabled | bool | `false` | |
+| transformer.feast.grpc.keepAliveTime | string | `30s` | |
+| transformer.feast.grpc.keepAliveTimeout | string | `5s` | |
 | transformer.feast.bigtableCredential | string | `nil` |  |
 | transformer.feast.coreAuthAudience | string | `"core.feast.dev"` |  |
 | transformer.feast.coreURL | string | `"core.feast.dev"` |  |
@@ -286,6 +294,9 @@ The following table lists the configurable parameters of the Merlin chart and th
 | transformer.jaeger.disabled | bool | `false` |  |
 | transformer.jaeger.samplerParam | int | `1` |  |
 | transformer.jaeger.samplerType | string | `"const"` |  |
+| transformer.model.grpc.keepAliveEnabled | bool | `false` | |
+| transformer.model.grpc.keepAliveTime | string | `30s` | |
+| transformer.model.grpc.keepAliveTimeout | string | `5s` | |
 | transformer.simulation.feastBigtableServingURL | string | `"online-serving-bt.feast.dev"` |  |
 | transformer.simulation.feastRedisServingURL | string | `"online-serving-redis.feast.dev"` |  |
 | ui.apiHost | string | `"/api/merlin/v1"` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -269,8 +269,8 @@ The following table lists the configurable parameters of the Merlin chart and th
 | swagger.service.internalPort | int | `8081` |  |
 | transformer.feast.authEnabled | bool | `false` |  |
 | transformer.feast.grpc.keepAliveEnabled | bool | `false` | |
-| transformer.feast.grpc.keepAliveTime | string | `30s` | |
-| transformer.feast.grpc.keepAliveTimeout | string | `5s` | |
+| transformer.feast.grpc.keepAliveTime | string | `"60s"` | |
+| transformer.feast.grpc.keepAliveTimeout | string | `"5s"` | |
 | transformer.feast.bigtableCredential | string | `nil` |  |
 | transformer.feast.coreAuthAudience | string | `"core.feast.dev"` |  |
 | transformer.feast.coreURL | string | `"core.feast.dev"` |  |
@@ -291,8 +291,8 @@ The following table lists the configurable parameters of the Merlin chart and th
 | transformer.jaeger.samplerParam | int | `1` |  |
 | transformer.jaeger.samplerType | string | `"const"` |  |
 | transformer.model.grpc.keepAliveEnabled | bool | `false` | |
-| transformer.model.grpc.keepAliveTime | string | `30s` | |
-| transformer.model.grpc.keepAliveTimeout | string | `5s` | |
+| transformer.model.grpc.keepAliveTime | string | `"60s"` | |
+| transformer.model.grpc.keepAliveTimeout | string | `"5s"` | |
 | transformer.simulation.feastBigtableServingURL | string | `"online-serving-bt.feast.dev"` |  |
 | transformer.simulation.feastRedisServingURL | string | `"online-serving-redis.feast.dev"` |  |
 | ui.apiHost | string | `"/api/merlin/v1"` |  |

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -161,6 +161,12 @@ spec:
                 {{- end }}
           - name: DEFAULT_FEAST_SERVING_URL
             value: "{{ .Values.transformer.feast.defaultServingURL }}"
+          - name: FEAST_SERVING_KEEP_ALIVE_ENABLED
+            value: "{{ .Values.merlin.transformer.feast.grpc.keepAliveEnabled }}"
+          - name: FEAST_SERVING_KEEP_ALIVE_TIME
+            value: "{{ .Values.merlin.transformer.feast.grpc.keepAliveTime }}"
+          - name: FEAST_SERVING_KEEP_ALIVE_TIMEOUT
+            value: "{{ .Values.merlin.transformer.feast.grpc.keepAliveTimeout }}"
           - name: FEAST_SERVING_URLS
             value: {{ .Values.transformer.feast.servingURLs | toJson | quote }}
           {{- if .Values.transformer.feast.redisStorage }}
@@ -187,6 +193,12 @@ spec:
             value: "{{ .Values.transformer.feast.authEnabled }}"
           - name: STANDARD_TRANSFORMER_IMAGE_NAME
             value: "{{ .Values.transformer.image }}"
+          - name: MODEL_CLIENT_KEEP_ALIVE_ENABLED
+            value: "{{ .Values.merlin.transformer.model.grpc.keepAliveEnabled }}"
+          - name: MODEL_CLIENT_KEEP_ALIVE_TIME
+            value: "{{ .Values.merlin.transformer.model.grpc.keepAliveTime }}"
+          - name: MODEL_CLIENT_KEEP_ALIVE_TIMEOUT
+            value: "{{ .Values.merlin.transformer.model.grpc.keepAliveTimeout }}"
           - name: JAEGER_AGENT_HOST
             value: "{{ .Values.transformer.jaeger.agentHost }}"
           - name: JAEGER_AGENT_PORT
@@ -197,6 +209,8 @@ spec:
             value: "{{ .Values.transformer.jaeger.samplerParam }}"
           - name: JAEGER_DISABLED
             value: "{{ .Values.transformer.jaeger.disabled }}"
+          - name: PYFUNC_GRPC_OPTIONS
+            value: "{{ .Values.merlin.pyfuncGRPCOptions }}"
           - name: DEPLOYMENT_CONFIG_PATH
             value: {{ ternary (printf "/opt/config/%s" "environment.yaml") (printf "/opt/config/%s" .Values.mlp.environmentConfigSecret.envKey) (eq .Values.mlp.environmentConfigSecret.name "")}}
           {{ if .Values.sentry.enabled }}

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -199,6 +199,10 @@ spec:
             value: "{{ .Values.transformer.model.grpc.keepAliveTime }}"
           - name: MODEL_CLIENT_KEEP_ALIVE_TIMEOUT
             value: "{{ .Values.transformer.model.grpc.keepAliveTimeout }}"
+          - name: KAFKA_BROKERS
+            value: "{{ .Values.merlin.transformer.kafka.brokers }}"
+          - name: KAFKA_MAX_MESSAGE_SIZE_BYTES
+            value: "{{ .Values.merlin.transformer.kafka.maxMessageSize }}"
           - name: JAEGER_AGENT_HOST
             value: "{{ .Values.transformer.jaeger.agentHost }}"
           - name: JAEGER_AGENT_PORT

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -162,11 +162,11 @@ spec:
           - name: DEFAULT_FEAST_SERVING_URL
             value: "{{ .Values.transformer.feast.defaultServingURL }}"
           - name: FEAST_SERVING_KEEP_ALIVE_ENABLED
-            value: "{{ .Values.merlin.transformer.feast.grpc.keepAliveEnabled }}"
+            value: "{{ .Values.transformer.feast.grpc.keepAliveEnabled }}"
           - name: FEAST_SERVING_KEEP_ALIVE_TIME
-            value: "{{ .Values.merlin.transformer.feast.grpc.keepAliveTime }}"
+            value: "{{ .Values.transformer.feast.grpc.keepAliveTime }}"
           - name: FEAST_SERVING_KEEP_ALIVE_TIMEOUT
-            value: "{{ .Values.merlin.transformer.feast.grpc.keepAliveTimeout }}"
+            value: "{{ .Values.transformer.feast.grpc.keepAliveTimeout }}"
           - name: FEAST_SERVING_URLS
             value: {{ .Values.transformer.feast.servingURLs | toJson | quote }}
           {{- if .Values.transformer.feast.redisStorage }}
@@ -194,11 +194,11 @@ spec:
           - name: STANDARD_TRANSFORMER_IMAGE_NAME
             value: "{{ .Values.transformer.image }}"
           - name: MODEL_CLIENT_KEEP_ALIVE_ENABLED
-            value: "{{ .Values.merlin.transformer.model.grpc.keepAliveEnabled }}"
+            value: "{{ .Values.transformer.model.grpc.keepAliveEnabled }}"
           - name: MODEL_CLIENT_KEEP_ALIVE_TIME
-            value: "{{ .Values.merlin.transformer.model.grpc.keepAliveTime }}"
+            value: "{{ .Values.transformer.model.grpc.keepAliveTime }}"
           - name: MODEL_CLIENT_KEEP_ALIVE_TIMEOUT
-            value: "{{ .Values.merlin.transformer.model.grpc.keepAliveTimeout }}"
+            value: "{{ .Values.transformer.model.grpc.keepAliveTimeout }}"
           - name: JAEGER_AGENT_HOST
             value: "{{ .Values.transformer.jaeger.agentHost }}"
           - name: JAEGER_AGENT_PORT
@@ -210,7 +210,7 @@ spec:
           - name: JAEGER_DISABLED
             value: "{{ .Values.transformer.jaeger.disabled }}"
           - name: PYFUNC_GRPC_OPTIONS
-            value: "{{ .Values.merlin.pyfuncGRPCOptions }}"
+            value: "{{ .Values.pyfuncGRPCOptions }}"
           - name: DEPLOYMENT_CONFIG_PATH
             value: {{ ternary (printf "/opt/config/%s" "environment.yaml") (printf "/opt/config/%s" .Values.mlp.environmentConfigSecret.envKey) (eq .Values.mlp.environmentConfigSecret.name "")}}
           {{ if .Values.sentry.enabled }}

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -200,9 +200,9 @@ spec:
           - name: MODEL_CLIENT_KEEP_ALIVE_TIMEOUT
             value: "{{ .Values.transformer.model.grpc.keepAliveTimeout }}"
           - name: KAFKA_BROKERS
-            value: "{{ .Values.merlin.transformer.kafka.brokers }}"
+            value: "{{ .Values.transformer.kafka.brokers }}"
           - name: KAFKA_MAX_MESSAGE_SIZE_BYTES
-            value: "{{ .Values.merlin.transformer.kafka.maxMessageSize }}"
+            value: "{{ .Values.transformer.kafka.maxMessageSize }}"
           - name: JAEGER_AGENT_HOST
             value: "{{ .Values.transformer.jaeger.agentHost }}"
           - name: JAEGER_AGENT_PORT

--- a/charts/merlin/tests/merlin_deployment_test.yaml
+++ b/charts/merlin/tests/merlin_deployment_test.yaml
@@ -133,7 +133,7 @@ tests:
           path: metadata.name
           pattern: my-release-merlin$
       - equal:
-          path: spec.template.spec.containers[0].env[53].value
+          path: spec.template.spec.containers[0].env[60].value
           value: authz-server-url
   - it: should set authz url from values if global is set
     set:
@@ -150,7 +150,7 @@ tests:
           path: metadata.name
           pattern: my-release-merlin$
       - equal:
-          path: spec.template.spec.containers[0].env[53].value
+          path: spec.template.spec.containers[0].env[60].value
           value: http://caraml-authz
 
   - it: should set authz url from values if global doesn't have authz
@@ -167,7 +167,7 @@ tests:
           path: metadata.name
           pattern: my-release-merlin$
       - equal:
-          path: spec.template.spec.containers[0].env[53].value
+          path: spec.template.spec.containers[0].env[60].value
           value: authz-server-url
 
   - it: should set authz url from values if global doesn't have authz serviceName
@@ -185,5 +185,5 @@ tests:
           path: metadata.name
           pattern: my-release-merlin$
       - equal:
-          path: spec.template.spec.containers[0].env[53].value
+          path: spec.template.spec.containers[0].env[60].value
           value: authz-server-url

--- a/charts/merlin/tests/merlin_deployment_test.yaml
+++ b/charts/merlin/tests/merlin_deployment_test.yaml
@@ -133,7 +133,7 @@ tests:
           path: metadata.name
           pattern: my-release-merlin$
       - equal:
-          path: spec.template.spec.containers[0].env[60].value
+          path: spec.template.spec.containers[0].env[62].value
           value: authz-server-url
   - it: should set authz url from values if global is set
     set:
@@ -150,7 +150,7 @@ tests:
           path: metadata.name
           pattern: my-release-merlin$
       - equal:
-          path: spec.template.spec.containers[0].env[60].value
+          path: spec.template.spec.containers[0].env[62].value
           value: http://caraml-authz
 
   - it: should set authz url from values if global doesn't have authz
@@ -167,7 +167,7 @@ tests:
           path: metadata.name
           pattern: my-release-merlin$
       - equal:
-          path: spec.template.spec.containers[0].env[60].value
+          path: spec.template.spec.containers[0].env[62].value
           value: authz-server-url
 
   - it: should set authz url from values if global doesn't have authz serviceName
@@ -185,5 +185,5 @@ tests:
           path: metadata.name
           pattern: my-release-merlin$
       - equal:
-          path: spec.template.spec.containers[0].env[60].value
+          path: spec.template.spec.containers[0].env[62].value
           value: authz-server-url

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -160,6 +160,9 @@ transformer:
       keepAliveEnabled: false
       keepAliveTime: 60s
       keepAliveTimeout: 5s
+  kafka:
+    # brokers: 
+    maxMessageSize: "1048588"
 
 # Google service account used to access GCP's resources.
 #

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -161,7 +161,7 @@ transformer:
       keepAliveTime: 60s
       keepAliveTimeout: 5s
   kafka:
-    # brokers: 
+    # brokers: ""
     maxMessageSize: "1048588"
 
 # Google service account used to access GCP's resources.

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -5,7 +5,7 @@ deployment:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: gojek/merlin
-    tag: 0.26.0-rc6
+    tag: v0.27.0-rc1
   replicaCount: "2"
   # Additional labels to apply to the deployment
   labels: {}
@@ -161,7 +161,7 @@ transformer:
       keepAliveTime: 60s
       keepAliveTimeout: 5s
   kafka:
-    # brokers: ""
+    brokers: "kafka-brokers"
     maxMessageSize: "1048588"
 
 # Google service account used to access GCP's resources.

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -144,10 +144,10 @@ transformer:
     coreURL: core.feast.dev
     coreAuthAudience: core.feast.dev
     authEnabled: false
-  grpc:
-    keepAliveEnabled: true
-    keepAliveTime: 30s
-    keepAliveTimeout: 5s
+    grpc:
+      keepAliveEnabled: false
+      keepAliveTime: 60s
+      keepAliveTimeout: 5s
   image: merlin-transformer:1.0.0
   jaeger:
     agentHost: localhost
@@ -157,8 +157,8 @@ transformer:
     disabled: false
   model:
     grpc:
-      keepAliveEnabled: true
-      keepAliveTime: 30s
+      keepAliveEnabled: false
+      keepAliveTime: 60s
       keepAliveTimeout: 5s
 
 # Google service account used to access GCP's resources.

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -28,6 +28,7 @@ deployment:
   tolerations: []
 environment: dev
 deploymentLabelPrefix: "gojek.com/"
+pyfuncGRPCOptions : "{}"
 loggerDestinationURL: "http://yourDestinationLogger"
 queue:
   numOfWorkers: 1
@@ -143,6 +144,10 @@ transformer:
     coreURL: core.feast.dev
     coreAuthAudience: core.feast.dev
     authEnabled: false
+  grpc:
+    keepAliveEnabled: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
   image: merlin-transformer:1.0.0
   jaeger:
     agentHost: localhost
@@ -150,6 +155,12 @@ transformer:
     samplerType: const
     samplerParam: 1
     disabled: false
+  model:
+    grpc:
+      keepAliveEnabled: true
+      keepAliveTime: 30s
+      keepAliveTimeout: 5s
+
 # Google service account used to access GCP's resources.
 #
 # gcpServiceAccount:

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -4,8 +4,8 @@ deployment:
   image:
     pullPolicy: IfNotPresent
     registry: ghcr.io
-    repository: gojek/merlin
-    tag: v0.27.0-rc1
+    repository: caraml-dev/merlin
+    tag: 0.27.0-rc1
   replicaCount: "2"
   # Additional labels to apply to the deployment
   labels: {}
@@ -28,7 +28,7 @@ deployment:
   tolerations: []
 environment: dev
 deploymentLabelPrefix: "gojek.com/"
-pyfuncGRPCOptions: {}
+pyfuncGRPCOptions: "{}"
 loggerDestinationURL: "http://yourDestinationLogger"
 queue:
   numOfWorkers: 1

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -28,7 +28,7 @@ deployment:
   tolerations: []
 environment: dev
 deploymentLabelPrefix: "gojek.com/"
-pyfuncGRPCOptions : "{}"
+pyfuncGRPCOptions: {}
 loggerDestinationURL: "http://yourDestinationLogger"
 queue:
   numOfWorkers: 1


### PR DESCRIPTION
# Motivation

Recent change on standard transformer, introducing enable gRPC client keep alive and also publish prediction log. This PR adding the required helm chart changes to enable configuration change

# Modification
Adding several environment variables
```
transformer.feast.grpc.keepAliveEnabled
transformer.feast.grpc.keepAliveTime
transformer.feast.grpc.keepAliveTimeout
transformer.model.grpc.keepAliveEnabled
transformer.model.grpc.keepAliveTime
transformer.model.grpc.keepAliveTimeout
transformer.kafka.brokers
transformer.kafka.maxMessageSize
pyfuncGRPCOptions
```

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
