### PR TITLE
feat: Support XP Management Service CRD name override

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.4
+version: 0.1.5

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square)
 ![AppVersion: v0.11.1](https://img.shields.io/badge/AppVersion-v0.11.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/service.yaml
+++ b/charts/xp-management/templates/service.yaml
@@ -1,7 +1,8 @@
+{{- $globServiceName := include "common.get-component-value" (list .Values.global "xp" (list "serviceName")) }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "management-svc.fullname" .}}
+  name: {{ include "common.set-value" (list (include "management-svc.fullname" .) $globServiceName) }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "management-svc.labels" . | nindent 4 }}

--- a/charts/xp-management/values-global.yaml
+++ b/charts/xp-management/values-global.yaml
@@ -41,7 +41,7 @@ global:
     uiServiceName: turing
 
   xp:
-    apiPrefix: "/"
+    apiPrefix: "/v1"
     serviceName: xp-management
     vsPrefix: "/api/xp"
     useServiceFqdn: true  # url generated will use k8s service fqdn/path instead of vs hosts/path


### PR DESCRIPTION
# Motivation

Add support for overriding XP Management's Service CRD's name.

# Modification

Add global service name override.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
