### PR TITLE
feat(xp-treatment): Shift replicaCount parameter under deployment

### DIFF
--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: xp-treatment
+appVersion: 0.11.1
 dependencies:
 - alias: xp-management
   condition: xp-management.enabled
@@ -10,8 +10,8 @@ dependencies:
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.8
 description: Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments
-version: 0.1.3
-appVersion: 0.11.1
 maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
+name: xp-treatment
+version: 0.1.4

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square)
 ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments
@@ -58,6 +58,7 @@ The following table lists the configurable parameters of the XP Treatment Servic
 | deployment.readinessProbe.periodSeconds | int | `10` |  |
 | deployment.readinessProbe.successThreshold | int | `1` |  |
 | deployment.readinessProbe.timeoutSeconds | int | `5` |  |
+| deployment.replicaCount | int | `1` |  |
 | deployment.resources | object | `{}` | Resources requests and limits for XP Treatment Service API. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | deployment.service.externalPort | int | `8080` | XP Treatment Service Kubernetes service port number |
 | deployment.service.internalPort | int | `8080` | XP Treatment Service container port number |

--- a/charts/xp-treatment/templates/deployment.yaml
+++ b/charts/xp-treatment/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "treatment-svc.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.deployment.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.deployment.replicaCount }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/xp-treatment/values.yaml
+++ b/charts/xp-treatment/values.yaml
@@ -1,5 +1,6 @@
 global:
   protocol: http
+
 deployment:
   image:
     # -- Docker registry for XP Treatment Service image
@@ -10,6 +11,9 @@ deployment:
     tag: v0.11.2-rc1
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
+
+  # No. of pods to serve traffic to Treatment Service deployment
+  replicaCount: 1
 
   # -- Application configurations to pass to XP Treatment Service server container during application start-up
   apiConfig:


### PR DESCRIPTION
# Motivation

`replicaCount` is being shifted under `deployment`, similar to how all other charts define it.

# Modification

Update reference to `replicaCount`.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
