### PR TITLE
feat(xp-management): Remove v prefix from chart appVersion

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.11.1
+appVersion: 0.11.1
 dependencies:
 - alias: postgresql
   condition: postgresql.enabled
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.5
+version: 0.1.6

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,8 +1,8 @@
 # xp-management
 
 ---
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square)
-![AppVersion: v0.11.1](https://img.shields.io/badge/AppVersion-v0.11.1-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square)
+![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments
 


### PR DESCRIPTION
# Motivation

To standardize with other charts in the repository, we should remove the `v` prefix from `xp-management` chart's `appVersion`.

# Modification

Removed the `v` prefix from `xp-management` chart's `appVersion`.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
