### PR TITLE
feat: Add support for mlp deployment to have extra labels added in values

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.4.17
+version: 0.4.18

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.17](https://img.shields.io/badge/Version-0.4.17-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
+![Version: 0.4.18](https://img.shields.io/badge/Version-0.4.18-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
 
 MLP API
 
@@ -30,6 +30,7 @@ MLP API
 | deployment.authorization.serverUrl | string | `"http://mlp-authorization-keto"` |  |
 | deployment.docs | list | `[{"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},{"href":"https://github.com/gojek/turing","label":"Turing User Guide"},{"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"}]` | Documentation list for caraml components |
 | deployment.environment | string | `"production"` |  |
+| deployment.extraLabels | object | `{}` | Additional labels to apply on the deployment |
 | deployment.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"gojek/mlp","tag":"v1.7.4-build.6-322163a"}` | mlp image related configs |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` |  |
 | deployment.mlflowTrackingUrl | string | `"http://mlflow.mlp"` |  |

--- a/charts/mlp/templates/deployment.yaml
+++ b/charts/mlp/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mlp.labels" . | nindent 4 }}
+    {{- with .Values.deployment.extraLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.deployment.replicaCount }}
   selector:

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -37,6 +37,9 @@ deployment:
   mlflowTrackingUrl: "http://mlflow.mlp"
   environment: "production"
 
+  # -- Additional labels to apply on the deployment
+  extraLabels: {}
+
   # -- Enabled CaraML applications
   applications:
     - name: Merlin


### PR DESCRIPTION
# Motivation
Allow extra labels in deployment.

# Modification
* Add support for mlp deployment to have extra labels added via values.yaml


# Checklist
- [x] Chart version bumped
- [x] README.md updated
