### PR TITLE
fix(xp): Use mergeOverwrite to override the user set values for apiConfig

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.8
+version: 0.1.9

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square)
 ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/_helpers.tpl
+++ b/charts/xp-management/templates/_helpers.tpl
@@ -130,7 +130,7 @@ AuthorizationConfig:
 DbConfig:
   Host: {{ include "common.postgres-host" (list .Values.postgresql .Values.externalPostgresql .Release .Chart ) }}
   Port: 5432
-  Database: {{ include "common.postgres-database" (list .Values.postgresql .Values.externalPostgresql .Values.global "mlp" "postgresqlDatabase") }}
+  Database: {{ include "common.postgres-database" (list .Values.postgresql .Values.externalPostgresql .Values.global "xp" "postgresqlDatabase") }}
   User: {{ include "common.postgres-username" (list .Values.postgresql .Values.externalPostgresql .Values.global ) }}
   ConnMaxIdleTime: {{ .Values.deployment.apiConfig.DbConfig.ConnMaxIdleTime }}
   ConnMaxLifetime: {{ .Values.deployment.apiConfig.DbConfig.ConnMaxLifetime }}
@@ -154,5 +154,5 @@ XpUIConfig:
 
 {{- define "management-svc.config" -}}
 {{- $defaultConfig := include "management-svc.defaultConfig" . | fromYaml -}}
-{{ .Values.deployment.apiConfig | merge $defaultConfig | toYaml }}
+{{ .Values.deployment.apiConfig | mergeOverwrite $defaultConfig | toYaml }}
 {{- end -}}


### PR DESCRIPTION
# Motivation
Using `merge` doesn't overwrite the values from the 2nd dict. 
eg:

Given:
```
dst:
  default: default
  overwrite: me
  key: true

src:
  overwrite: overwritten
  key: false
```
will result in:
```
newdict:
  default: default
  overwrite: me
  key: true
```
when doing: `$newdict := merge $dest $source1 $source2`. 
To get the dst overwritten, need to use `mergeOverwrite`

ref: https://helm.sh/docs/chart_template_guide/function_list/#mergeoverwrite-mustmergeoverwrite 


# Modification
* Use `mergeOverwrite` instead of `merge` in apiConfig.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
