### PR TITLE
chore(xp): Bump xp-management helm chart version

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.11.1
+appVersion: 0.12.0
 dependencies:
 - alias: postgresql
   condition: postgresql.enabled
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.10
+version: 0.1.11

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,8 +1,8 @@
 # xp-management
 
 ---
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square)
-![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square)
+![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments
 
@@ -41,7 +41,7 @@ The following table lists the configurable parameters of the XP Management Servi
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | deployment.image.registry | string | `"ghcr.io"` | Docker registry for XP Management Service image |
 | deployment.image.repository | string | `"caraml-dev/xp/xp-management"` | Docker image repository for XP Management Service |
-| deployment.image.tag | string | `"v0.11.2-rc1"` | Docker image tag for XP Management Service |
+| deployment.image.tag | string | `"v0.12.0"` | Docker image tag for XP Management Service |
 | deployment.labels | object | `{}` | Labels to attach to the deployment. |
 | deployment.livenessProbe.initialDelaySeconds | int | `60` | Liveness probe delay and thresholds |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` | HTTP path for liveness check |

--- a/charts/xp-management/values.yaml
+++ b/charts/xp-management/values.yaml
@@ -17,7 +17,7 @@ deployment:
     # -- Docker image repository for XP Management Service
     repository: caraml-dev/xp/xp-management
     # -- Docker image tag for XP Management Service
-    tag: v0.11.2-rc1
+    tag: v0.12.0
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
# Motivation

`v0.12.0` version of XP has been released, and helm chart docker image version should be bumped.

# Modification

Bump XP Management helm chart and docker image versions.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
