### PR TITLE
chore(xp): Bump xp-treatment helm chart version

### DIFF
--- a/charts/xp-treatment/Chart.lock
+++ b/charts/xp-treatment/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.10
+  version: 0.1.11
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.8
-digest: sha256:ce6e31e3e0e472dab8cc7e1314d66aed5a6a383d7e2ec3c9a2bd58adfa8a94f6
-generated: "2023-04-25T10:35:16.37661504Z"
+digest: sha256:dd35736379b8ef5a45ef273e92ce52174e8e0b1af9d3f3fac77b6817bd6a67e4
+generated: "2023-04-26T10:31:48.822626+08:00"

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
-appVersion: 0.11.1
+appVersion: 0.12.0
 dependencies:
 - alias: xp-management
   condition: xp-management.enabled
   name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.10
+  version: 0.1.11
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.8
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.6
+version: 0.1.7

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,8 +1,8 @@
 # xp-treatment
 
 ---
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square)
-![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square)
+![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments
 
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the XP Treatment Servic
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | deployment.image.registry | string | `"ghcr.io"` | Docker registry for XP Treatment Service image |
 | deployment.image.repository | string | `"caraml-dev/xp/xp-treatment"` | Docker image repository for XP Treatment Service |
-| deployment.image.tag | string | `"v0.11.2-rc1"` | Docker image tag for XP Treatment Service |
+| deployment.image.tag | string | `"v0.12.0"` | Docker image tag for XP Treatment Service |
 | deployment.livenessProbe.initialDelaySeconds | int | `60` | Liveness probe delay and thresholds |
 | deployment.livenessProbe.path | string | `"/v1/internal/health/live"` | HTTP path for liveness check |
 | deployment.livenessProbe.periodSeconds | int | `10` |  |

--- a/charts/xp-treatment/values.yaml
+++ b/charts/xp-treatment/values.yaml
@@ -8,7 +8,7 @@ deployment:
     # -- Docker image repository for XP Treatment Service
     repository: caraml-dev/xp/xp-treatment
     # -- Docker image tag for XP Treatment Service
-    tag: v0.11.2-rc1
+    tag: v0.12.0
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
# Motivation

`v0.12.0` version of XP has been released, and helm chart docker image version should be bumped.

# Modification

Bump XP Treatment helm chart and docker image versions.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
