### PR TITLE
chore: update Turing and XP app versions

### DIFF
--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.9.2
+appVersion: 1.11.0
 dependencies:
 - alias: turing-postgresql
   condition: turing-postgresql.enabled
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.22
+version: 0.2.23

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,8 +1,8 @@
 # turing
 
 ---
-![Version: 0.2.22](https://img.shields.io/badge/Version-0.2.22-informational?style=flat-square)
-![AppVersion: 1.9.2](https://img.shields.io/badge/AppVersion-1.9.2-informational?style=flat-square)
+![Version: 0.2.23](https://img.shields.io/badge/Version-0.2.23-informational?style=flat-square)
+![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
 
@@ -71,7 +71,7 @@ The following table lists the configurable parameters of the Turing chart and th
 | deployment.extraVolumes | list | `[]` | Extra volumes to attach to the Pod. For example, you can mount additional secrets to these volumes |
 | deployment.image.registry | string | `"ghcr.io"` | Docker registry for Turing image |
 | deployment.image.repository | string | `"caraml-dev/turing"` | Docker image repository for Turing image |
-| deployment.image.tag | string | `"v1.9.2-build.7-b9139be"` | Docker image tag for Turing image |
+| deployment.image.tag | string | `"v1.11.0"` | Docker image tag for Turing image |
 | deployment.labels | object | `{}` |  |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` | HTTP path for liveness check |
 | deployment.readinessProbe.path | string | `"/v1/internal/ready"` | HTTP path for readiness check |

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -8,7 +8,7 @@ deployment:
     # -- Docker image repository for Turing image
     repository: caraml-dev/turing
     # -- Docker image tag for Turing image
-    tag: v1.9.2-build.7-b9139be
+    tag: v1.11.0
   labels: {}
   # -- Resources requests and limits for Turing API. This should be set
   # according to your cluster capacity and service level objectives.
@@ -229,7 +229,7 @@ config:
   Sentry:
     Enabled: false
   RouterDefaults:
-    Image: ghcr.io/caraml-dev/turing/turing-router:v1.9.2-build.7-b9139be
+    Image: ghcr.io/caraml-dev/turing/turing-router:v1.11.0
     FluentdConfig:
       Image: ghcr.io/caraml-dev/turing/fluentd:v1.8.0
 

--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.12.0
+appVersion: 0.12.1
 dependencies:
 - alias: postgresql
   condition: postgresql.enabled
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.11
+version: 0.1.12

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,8 +1,8 @@
 # xp-management
 
 ---
-![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square)
-![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
+![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square)
+![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments
 
@@ -41,7 +41,7 @@ The following table lists the configurable parameters of the XP Management Servi
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | deployment.image.registry | string | `"ghcr.io"` | Docker registry for XP Management Service image |
 | deployment.image.repository | string | `"caraml-dev/xp/xp-management"` | Docker image repository for XP Management Service |
-| deployment.image.tag | string | `"v0.12.0"` | Docker image tag for XP Management Service |
+| deployment.image.tag | string | `"v0.12.1"` | Docker image tag for XP Management Service |
 | deployment.labels | object | `{}` | Labels to attach to the deployment. |
 | deployment.livenessProbe.initialDelaySeconds | int | `60` | Liveness probe delay and thresholds |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` | HTTP path for liveness check |

--- a/charts/xp-management/values.yaml
+++ b/charts/xp-management/values.yaml
@@ -17,7 +17,7 @@ deployment:
     # -- Docker image repository for XP Management Service
     repository: caraml-dev/xp/xp-management
     # -- Docker image tag for XP Management Service
-    tag: v0.12.0
+    tag: v0.12.1
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
 

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.12.0
+appVersion: 0.12.1
 dependencies:
 - alias: xp-management
   condition: xp-management.enabled
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.7
+version: 0.1.8

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,8 +1,8 @@
 # xp-treatment
 
 ---
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square)
-![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square)
+![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments
 
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the XP Treatment Servic
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | deployment.image.registry | string | `"ghcr.io"` | Docker registry for XP Treatment Service image |
 | deployment.image.repository | string | `"caraml-dev/xp/xp-treatment"` | Docker image repository for XP Treatment Service |
-| deployment.image.tag | string | `"v0.12.0"` | Docker image tag for XP Treatment Service |
+| deployment.image.tag | string | `"v0.12.1"` | Docker image tag for XP Treatment Service |
 | deployment.livenessProbe.initialDelaySeconds | int | `60` | Liveness probe delay and thresholds |
 | deployment.livenessProbe.path | string | `"/v1/internal/health/live"` | HTTP path for liveness check |
 | deployment.livenessProbe.periodSeconds | int | `10` |  |

--- a/charts/xp-treatment/values.yaml
+++ b/charts/xp-treatment/values.yaml
@@ -8,7 +8,7 @@ deployment:
     # -- Docker image repository for XP Treatment Service
     repository: caraml-dev/xp/xp-treatment
     # -- Docker image tag for XP Treatment Service
-    tag: v0.12.0
+    tag: v0.12.1
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
# Motivation
Turing and XP have had recent releases. Updating their app versions accordingly, and bumping the chart version.

# Modification
For `turing`, `xp-management` and `xp-treatment`, updating the values files and Chart.yaml.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
