### PR TITLE
fix(caraml-authz): Modify policy and role creation k8s job

### DIFF
--- a/charts/caraml-authz/Chart.yaml
+++ b/charts/caraml-authz/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: authz
-version: 0.1.9
+version: 0.1.10

--- a/charts/caraml-authz/README.md
+++ b/charts/caraml-authz/README.md
@@ -1,6 +1,6 @@
 # authz
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
 
 Helm chart for deploying Ory Keto
 

--- a/charts/caraml-authz/templates/bootstrap-policy-job.yaml
+++ b/charts/caraml-authz/templates/bootstrap-policy-job.yaml
@@ -5,6 +5,7 @@ kind: Job
 metadata:
   name: {{ template "caraml-authz.resource-prefix" . }}-bootstrap-policy
 spec:
+  backoffLimit: 10
   template:
     spec:
       containers:

--- a/charts/caraml-authz/templates/bootstrap-policy-job.yaml
+++ b/charts/caraml-authz/templates/bootstrap-policy-job.yaml
@@ -4,10 +4,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "caraml-authz.resource-prefix" . }}-bootstrap-policy
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:

--- a/charts/caraml-authz/templates/bootstrap-role-job.yaml
+++ b/charts/caraml-authz/templates/bootstrap-role-job.yaml
@@ -4,10 +4,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "caraml-authz.resource-prefix" . }}-bootstrap-role
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:

--- a/charts/caraml-authz/templates/bootstrap-role-job.yaml
+++ b/charts/caraml-authz/templates/bootstrap-role-job.yaml
@@ -5,6 +5,7 @@ kind: Job
 metadata:
   name: {{ template "caraml-authz.resource-prefix" . }}-bootstrap-role
 spec:
+  backoffLimit: 10
   template:
     spec:
       containers:


### PR DESCRIPTION
# Motivation
This MR modifies the job resources that are used to create keto roles and policies by removing the `post-install` annotation. Previously, the `post-install` annotations specified on the jobs resulted in the job resources being created after all other resources were created successfully when `--wait` flag is passed when running `helm install` command

This causes all installations that use `--wait` flag to fail if the resources in the helm chart require the K8s jobs to run first.

# Modification

# Checklist
- [x] Chart version bumped
- [x] README.md updated