### PR TITLE
chore(merlin): Remove v1 prefix for UI API config

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.10.16
+version: 0.10.17

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.10.16](https://img.shields.io/badge/Version-0.10.16-informational?style=flat-square)
+![Version: 0.10.17](https://img.shields.io/badge/Version-0.10.17-informational?style=flat-square)
 ![AppVersion: v0.27.0-rc1](https://img.shields.io/badge/AppVersion-v0.27.0--rc1-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
@@ -308,6 +308,6 @@ The following table lists the configurable parameters of the Merlin chart and th
 | ui.docsURL[0].label | string | `"Getting Started with Merlin"` |  |
 | ui.homepage | string | `"/merlin"` |  |
 | ui.maxAllowedReplica | int | `20` |  |
-| ui.mlp.apiHost | string | `"/api/v1"` |  |
+| ui.mlp.apiHost | string | `"/api"` |  |
 | ui.oauthClientID | string | `""` |  |
 | ui.upiDocURL | string | `"https://github.com/caraml-dev/universal-prediction-interface/blob/main/docs/api_markdown/caraml/upi/v1/index.md"` |  |

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -1,6 +1,6 @@
 {{- $globReactAppHomepage := include "common.get-component-value" (list .Values.global "merlin" (list "uiPrefix"))}}
 {{- $globMerlinApi := include "common.get-component-value" (list .Values.global "merlin" (list "vsPrefix" "apiPrefix"))}}
-{{- $globMlpApi := include "common.get-component-value" (list .Values.global "mlp" (list "vsPrefix" "apiPrefix"))}}
+{{- $globMlpApi := include "common.get-component-value" (list .Values.global "mlp" (list "vsPrefix"))}}
 {{- $globMlpApiHost := include "merlin.get-workload-host" (list .Values.global .Release.Namespace "mlp")}}
 {{- $globOauthClientID := include "common.get-oauth-client" .Values.global }}
 {{- $globFeastApiHost := include "merlin.get-feast-api-host" .Values.global }}

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -249,7 +249,7 @@ ui:
   apiHost: /api/merlin/v1
   upiDocURL: "https://github.com/caraml-dev/universal-prediction-interface/blob/main/docs/api_markdown/caraml/upi/v1/index.md"
   mlp:
-    apiHost: /api/v1
+    apiHost: /api
   docsURL:
     [
       {


### PR DESCRIPTION
# Motivation

As part of MLP applications V2 API implementation (https://github.com/caraml-dev/mlp/pull/72) and recent upgrade to latest MLP UI version (https://github.com/caraml-dev/merlin/pull/378) in Merlin, we should remove `/v1` from the MLP API host used by the Merlin UI.

# Modification

Remove `apiPrefix` from host variable used for setting `REACT_APP_MLP_API` environment variable.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
