### PR TITLE
feat(caraml-authz): Add sha1sum as annotation in caraml-authz job

### DIFF
--- a/charts/caraml-authz/Chart.yaml
+++ b/charts/caraml-authz/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: authz
-version: 0.1.10
+version: 0.1.11

--- a/charts/caraml-authz/README.md
+++ b/charts/caraml-authz/README.md
@@ -1,6 +1,6 @@
 # authz
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
 
 Helm chart for deploying Ory Keto
 

--- a/charts/caraml-authz/templates/bootstrap-policy-job.yaml
+++ b/charts/caraml-authz/templates/bootstrap-policy-job.yaml
@@ -4,6 +4,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "caraml-authz.resource-prefix" . }}-bootstrap-policy
+  annotations:
+    caraml-authz.cm.shasum: {{ printf "%s%s" (.Values.bootstrap.roles | toJson) (.Values.bootstrap.policies | toJson) | sha1sum }}
 spec:
   backoffLimit: 10
   template:

--- a/charts/caraml-authz/templates/bootstrap-role-job.yaml
+++ b/charts/caraml-authz/templates/bootstrap-role-job.yaml
@@ -4,6 +4,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "caraml-authz.resource-prefix" . }}-bootstrap-role
+  annotations:
+    caraml-authz.cm.shasum: {{ printf "%s%s" (.Values.bootstrap.roles | toJson) (.Values.bootstrap.policies | toJson) | sha1sum }}
 spec:
   backoffLimit: 10
   template:


### PR DESCRIPTION
# Motivation
This PR adds a sha1sum annoation to caraml-authz jobs. Sha1sum is created from the roles and policies specified in values.yaml

This forces the job spec to be updated when there is a change in role/policy

# Modification

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated