### PR TITLE
fix(xp-management): Make DB env var creation in deployment optional

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.13
+version: 0.1.14

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square)
+![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -40,11 +40,13 @@ spec:
         image: "{{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         env:
+          {{- if and .Values.externalPostgresql.enabled .Values.externalPostgresql.createSecret }}
           - name: "DBCONFIG_PASSWORD"
             valueFrom:
               secretKeyRef:
                 name: {{ include "common.postgres-password-secret-name" (list (index .Values "postgresql") .Values.externalPostgresql .Release .Chart ) }}
                 key: {{ include "common.postgres-password-secret-key" (list .Values.externalPostgresql) }}
+          {{- end }}
           {{- with .Values.deployment.extraEnvs }}
           {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/xp-treatment/Chart.lock
+++ b/charts/xp-treatment/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.13
+  version: 0.1.14
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.8

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: xp-management.enabled
   name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.13
+  version: 0.1.14
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.8


### PR DESCRIPTION
# Motivation
In #247, a change was made to introduce a `DBCONFIG_PASSWORD` env variable for the XP Management Service deployment to store the password of an external PostgreSQL database. 
https://github.com/caraml-dev/helm-charts/blob/0766f7543e98e7bc6fb5075313714a7bbf567a79/charts/xp-management/templates/deployment.yaml#L42-L47

However, if the deployment has not been configured to use this database, the same env variable will still be created even though its corresponding secret will not: https://github.com/caraml-dev/helm-charts/blob/0766f7543e98e7bc6fb5075313714a7bbf567a79/charts/xp-management/templates/database-secret.yaml#L1

This causes a `CreateContainerError` in the Kubernetes pod since the Secret it expects to be mounted will not be present:
<img width="802" alt="Screenshot 2023-05-26 at 11 04 15 AM" src="https://github.com/caraml-dev/helm-charts/assets/36802364/d59eac4a-03cf-4e45-8c0d-483057af5fbe">

This PR simply adds additional braces to perform the same logical check as found in the Secret before deciding whether to create the `DBCONFIG_PASSWORD` env variable in the deployment.

cc. @shydefoo 

# Modification
- `charts/xp-management/templates/deployment.yaml` - Introduction of an if condition before the `DBCONFIG_PASSWORD` env variable is created

# Checklist
- [x] Chart version bumped
- [ ] README.md updated
