### PR TITLE
fix: Fix service account creation in Turing chart

### DIFF
--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.23
+version: 0.2.24

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.23](https://img.shields.io/badge/Version-0.2.23-informational?style=flat-square)
+![Version: 0.2.24](https://img.shields.io/badge/Version-0.2.24-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.

--- a/charts/turing/templates/turing-deployment.yaml
+++ b/charts/turing/templates/turing-deployment.yaml
@@ -24,9 +24,7 @@ spec:
 {{ toYaml .Values.deployment.labels | indent 8 -}}
 {{- end }}
     spec:
-      {{- if or .Values.serviceAccount.create .Values.clusterConfig.useInClusterConfig }}
       serviceAccountName: {{ template "turing.serviceAccountName" . }}
-      {{- end }}
       {{- with (include "turing.initContainers" . | fromYaml) }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/turing/templates/turing-service-account.yaml
+++ b/charts/turing/templates/turing-service-account.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.serviceAccount.create .Values.clusterConfig.useInClusterConfig -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -136,8 +136,7 @@ service:
   internalPort: 8080
 
 serviceAccount:
-  # Specifies whether a ServiceAccount should be created. If disabled and clusterConfig.useInClusterConfig is set,
-  # a service account will be created nonetheless.
+  # Specifies whether a ServiceAccount should be created. If set to false, the service account is expected to exist.
   create: true
   # The name of the ServiceAccount to use.
   name: turing


### PR DESCRIPTION
# Motivation
Previously, the `useInClusterConfig` was partially driving the creation of the service account. However, this is confusing. Also, existing service accounts could not be associated to the Turing deployment if `useInClusterConfig` was set to `false`.

# Modification
This PR updates the service account association such that the deployment will always use a service account - by default, an SA with the name `turing` will be created. An existing SA can be used if `serviceAccount.create` is set to `false`.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
