### PR TITLE
ci: Allow minor chart version upgrades in chart-bumper

### DIFF
--- a/.github/workflows/chart-bumper.yaml
+++ b/.github/workflows/chart-bumper.yaml
@@ -43,6 +43,8 @@ jobs:
           rm -f manifest.yaml
           rm -f manifest_gdi_dependant.yaml
           bash scripts/helm-docs.sh
+        with:
+          BUMP_MINOR: true
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/scripts/chart_bumper.py
+++ b/scripts/chart_bumper.py
@@ -81,7 +81,7 @@ def update_chart(chart_path: str):
 
         # bump major or minor depending on set env variable
         version_major = f"{dependency['version'].split('.')[0]}" if not BUMP_MAJOR else "*"
-        version_minor = f"{dependency['version'].split('.')[1]}" if not BUMP_MAJOR else "*"
+        version_minor = f"{dependency['version'].split('.')[1]}" if not BUMP_MINOR else "*"
         version = f"{version_major}.{version_minor}.*"
         manifest = f"""
 sources:


### PR DESCRIPTION
# Motivation
So far, The chart-bumper workflow upgrades the charts by only patch versions. eg: 1.3.4 -> 1.3.7 is upgraded via this but 1.3.4 -> 1.4.0 isn't. This PR will allow minor version upgrades while looking for new chart releases.

# Modification
Set flag to true

# Checklist
- [ ] Chart version bumped - NA
- [ ] README.md updated - NA
