### PR TITLE
feat: remove encryption key from caraml chart

### DIFF
--- a/charts/caraml/Chart.lock
+++ b/charts/caraml/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.10.18
 - name: turing
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.24
+  version: 0.2.25
 - name: xp-treatment
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.1.9
@@ -41,5 +41,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.8.2
-digest: sha256:474444525a266ce9c9a4770c1c2143f987316b45d668032b8d5ac3a613ff4bf2
-generated: "2023-05-26T04:01:31.227855884Z"
+digest: sha256:0a172b6e80ddd5182c013180c2028054b77b92d58de6b447c5be8f9f9f7ab1bf
+generated: "2023-05-30T11:30:24.50632+08:00"

--- a/charts/caraml/Chart.yaml
+++ b/charts/caraml/Chart.yaml
@@ -68,4 +68,4 @@ maintainers:
   name: caraml-dev
 name: caraml
 type: application
-version: 0.5.4
+version: 0.5.5

--- a/charts/caraml/Chart.yaml
+++ b/charts/caraml/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 - condition: turing.enabled
   name: turing
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.24
+  version: 0.2.25
 - condition: xp-treatment.enabled
   name: xp-treatment
   repository: https://caraml-dev.github.io/helm-charts

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -194,7 +194,7 @@ A Helm chart for deploying CaraML components
 | postgresql.postgresqlDatabase | string | `"caraml"` | To set the database schema name created in postgres |
 | postgresql.postgresqlUsername | string | `"caraml"` | To set the user name for the database instance |
 | postgresql.resources | object | `{}` | Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/ |
-| turing.config.MLPConfig | string | `nil` |  |
+| turing.config | object | `{}` |  |
 | turing.deployment.resources.limits.cpu | string | `"500m"` |  |
 | turing.deployment.resources.limits.memory | string | `"512Mi"` |  |
 | turing.deployment.resources.requests.cpu | string | `"250m"` |  |

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -1,6 +1,6 @@
 # caraml
 
-![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML components
 
@@ -185,10 +185,8 @@ A Helm chart for deploying CaraML components
 | merlin.mlflow.resources.requests.cpu | string | `"250m"` |  |
 | merlin.mlflow.resources.requests.memory | string | `"256Mi"` |  |
 | merlin.mlp.enabled | bool | `false` |  |
-| merlin.mlpApi.encryptionKey | string | `"example-key-here"` |  |
 | mlp.deployment.authorization.enabled | bool | `true` |  |
 | mlp.enabled | bool | `true` | To enable/disable MLP chart installation. |
-| mlp.encryption.key | string | `"example-key-here"` |  |
 | mlp.postgresql.enabled | bool | `false` | To enable/disable MLP specific postgres |
 | postgresql.enabled | bool | `true` | To enable/disable CaraML specific postgres |
 | postgresql.initdbScripts."init.sql" | string | `"CREATE DATABASE mlp;\nCREATE DATABASE merlin;\nCREATE DATABASE mlflow;\nCREATE DATABASE authz;\nCREATE DATABASE turing;\nCREATE DATABASE xp;\n"` |  |
@@ -196,7 +194,7 @@ A Helm chart for deploying CaraML components
 | postgresql.postgresqlDatabase | string | `"caraml"` | To set the database schema name created in postgres |
 | postgresql.postgresqlUsername | string | `"caraml"` | To set the user name for the database instance |
 | postgresql.resources | object | `{}` | Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/ |
-| turing.config.MLPConfig.MLPEncryptionKey | string | `"example-key-here"` |  |
+| turing.config.MLPConfig | string | `nil` |  |
 | turing.deployment.resources.limits.cpu | string | `"500m"` |  |
 | turing.deployment.resources.limits.memory | string | `"512Mi"` |  |
 | turing.deployment.resources.requests.cpu | string | `"250m"` |  |

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -23,7 +23,7 @@ A Helm chart for deploying CaraML components
 | https://caraml-dev.github.io/helm-charts | istiod(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | merlin | 0.10.18 |
 | https://caraml-dev.github.io/helm-charts | mlp | 0.4.20 |
-| https://caraml-dev.github.io/helm-charts | turing | 0.2.24 |
+| https://caraml-dev.github.io/helm-charts | turing | 0.2.25 |
 | https://caraml-dev.github.io/helm-charts | xp-treatment | 0.1.9 |
 | https://charts.helm.sh/stable | postgresql | 7.0.2 |
 | https://charts.jetstack.io | cert-manager | v1.8.2 |
@@ -90,7 +90,7 @@ A Helm chart for deploying CaraML components
 | global.merlin.vsPrefix | string | `"/api/merlin"` |  |
 | global.mlflow.externalPort | string | `"80"` |  |
 | global.mlflow.serviceName | string | `"merlin-mlflow"` |  |
-| global.mlp.apiPrefix | string | `"/v1"` |  |
+| global.mlp.apiPrefix | string | `"/"` |  |
 | global.mlp.externalPort | string | `"8080"` |  |
 | global.mlp.postgresqlDatabase | string | `"mlp"` |  |
 | global.mlp.serviceName | string | `"mlp"` |  |

--- a/charts/caraml/values.yaml
+++ b/charts/caraml/values.yaml
@@ -63,14 +63,9 @@ mlp:
   deployment:
     authorization:
       enabled: true
-  encryption:
-    key: "example-key-here"
 merlin:
   # -- To enable/disable merlin chart installation.
   enabled: true
-  mlpApi:
-    # encryptionKey must be specified using --set flag.
-    encryptionKey: "example-key-here"
   deployment:
     resources:
       requests:
@@ -440,7 +435,6 @@ turing:
         memory: 512Mi
   config:
     MLPConfig:
-      MLPEncryptionKey: "example-key-here"
 
 ###################################################################
 # xp dependency

--- a/charts/caraml/values.yaml
+++ b/charts/caraml/values.yaml
@@ -433,8 +433,7 @@ turing:
       limits:
         cpu: "500m"
         memory: 512Mi
-  config:
-    MLPConfig:
+  config: {}
 
 ###################################################################
 # xp dependency

--- a/charts/caraml/values.yaml
+++ b/charts/caraml/values.yaml
@@ -20,7 +20,7 @@ global:
     serviceName: caraml-authz
   mlp:
     postgresqlDatabase: mlp
-    apiPrefix: "/v1"  # path prefix to where mlp endpoints lie if running on localhost
+    apiPrefix: "/"  # path prefix to where mlp endpoints lie if running on localhost
     serviceName: mlp
     externalPort: "8080"
     vsPrefix: "/api"


### PR DESCRIPTION
# Motivation

Similar to https://github.com/caraml-dev/helm-charts/pull/258, https://github.com/caraml-dev/helm-charts/pull/257, and https://github.com/caraml-dev/helm-charts/pull/255 which removes the need for encryption key in mlp

# Modification

Remove encryption key config from top level CaraML chart

# Checklist
- [x] Chart version bumped
- [x] README.md updated
