### PR TITLE
fix(turing): use global svc name when needed

### DIFF
--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.25
+version: 0.2.26

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.25](https://img.shields.io/badge/Version-0.2.25-informational?style=flat-square)
+![Version: 0.2.26](https://img.shields.io/badge/Version-0.2.26-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.

--- a/charts/turing/templates/turing-service.yaml
+++ b/charts/turing/templates/turing-service.yaml
@@ -1,7 +1,8 @@
+{{- $globServiceName := include "common.get-component-value" (list .Values.global "turing" (list "serviceName")) }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "turing.fullname" . }}
+  name: {{ include "common.set-value" (list (include "turing.fullname" .) $globServiceName) }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "turing.fullname" . }}


### PR DESCRIPTION
# Motivation
Make svc name consistent with other caraml components.

# Modification
* Add global value override for svc name

# Checklist
- [x] Chart version bumped
- [x] README.md updated
