### PR TITLE
fix: update mlp api prefix

### DIFF
--- a/charts/caraml/Chart.yaml
+++ b/charts/caraml/Chart.yaml
@@ -68,4 +68,4 @@ maintainers:
   name: caraml-dev
 name: caraml
 type: application
-version: 0.5.6
+version: 0.5.7

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -1,6 +1,6 @@
 # caraml
 
-![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML components
 
@@ -90,7 +90,7 @@ A Helm chart for deploying CaraML components
 | global.merlin.vsPrefix | string | `"/api/merlin"` |  |
 | global.mlflow.externalPort | string | `"80"` |  |
 | global.mlflow.serviceName | string | `"merlin-mlflow"` |  |
-| global.mlp.apiPrefix | string | `"/"` |  |
+| global.mlp.apiPrefix | string | `""` |  |
 | global.mlp.externalPort | string | `"8080"` |  |
 | global.mlp.postgresqlDatabase | string | `"mlp"` |  |
 | global.mlp.serviceName | string | `"mlp"` |  |

--- a/charts/caraml/values.yaml
+++ b/charts/caraml/values.yaml
@@ -20,7 +20,7 @@ global:
     serviceName: caraml-authz
   mlp:
     postgresqlDatabase: mlp
-    apiPrefix: "/"  # path prefix to where mlp endpoints lie if running on localhost
+    apiPrefix: ""  # path prefix to where mlp endpoints lie if running on localhost
     serviceName: mlp
     externalPort: "8080"
     vsPrefix: "/api"

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.26
+version: 0.2.27

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.26](https://img.shields.io/badge/Version-0.2.26-informational?style=flat-square)
+![Version: 0.2.27](https://img.shields.io/badge/Version-0.2.27-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.

--- a/charts/turing/ci/ci-values.yaml
+++ b/charts/turing/ci/ci-values.yaml
@@ -1,7 +1,7 @@
 global:
   oauthClientID: "global-client-123"
   mlp:
-    apiPrefix: "/"
+    apiPrefix: ""
     serviceName: mlp
     externalPort: "8080"
     vsPrefix: "/api"

--- a/charts/turing/values-global.yaml
+++ b/charts/turing/values-global.yaml
@@ -15,7 +15,7 @@ global:
     mlflow: ["mlflow"]
 
   mlp:
-    apiPrefix: "/"  # path prefix to where mlp endpoints lie if running on localhost
+    apiPrefix: ""  # path prefix to where mlp endpoints lie if running on localhost
     serviceName: mlp
     externalPort: "8080"
     vsPrefix: "/api"


### PR DESCRIPTION
# Motivation

Avoid double slash when creating mlp url in caraml and turing chart

# Modification

Set default mlp apiPrefix to empty string instead of slash ("/")

# Checklist
- [x] Chart version bumped
- [x] README.md updated
