### PR TITLE
fix(caraml-store): use correct indentation for map type envoverride

### DIFF
--- a/charts/caraml-store/Chart.yaml
+++ b/charts/caraml-store/Chart.yaml
@@ -20,4 +20,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: caraml-store
-version: 0.1.14
+version: 0.1.15

--- a/charts/caraml-store/README.md
+++ b/charts/caraml-store/README.md
@@ -1,6 +1,6 @@
 # caraml-store
 
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
 
 CaraML store registry: Feature registry for CaraML store.
 

--- a/charts/caraml-store/templates/registry/deployment.yaml
+++ b/charts/caraml-store/templates/registry/deployment.yaml
@@ -72,7 +72,7 @@ spec:
           - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
             {{- if eq (kindOf $value) "map" }}
             valueFrom:
-              {{- toYaml $value | nindent 12}}
+              {{- toYaml $value | nindent 14}}
             {{- else }}
             value: {{ $value | quote }}
             {{- end}}

--- a/charts/caraml-store/templates/serving/deployment.yaml
+++ b/charts/caraml-store/templates/serving/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
             {{- if eq (kindOf $value) "map" }}
               valueFrom:
-              {{- toYaml $value | nindent 12}}
+              {{- toYaml $value | nindent 16}}
             {{- else }}
               value: {{ $value | quote }}
             {{- end}}


### PR DESCRIPTION
# Motivation
envOverride is currently broken when the value of the override is of the map type. 

# Modification
Fix the indentation for envOverride

# Checklist
- [x] Chart version bumped
- [x] README.md updated
