### PR TITLE
fix(xp): Add node selector for xp-mgmt deployment

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.14
+version: 0.1.15

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/_helpers.tpl
+++ b/charts/xp-management/templates/_helpers.tpl
@@ -89,11 +89,12 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "management-svc.ui.defaultConfig" -}}
+{{- $globOauthClientID := include "common.get-oauth-client" .Values.global }}
 {{- if .Values.uiConfig -}}
 appConfig:
   environment: {{ .Values.uiConfig.appConfig.environment | default (include "management-svc.environment" .) }}
 authConfig:
-  oauthClientId: {{ .Values.global.oauthClientId | default .Values.uiConfig.authConfig.oauthClientId | quote }}
+  oauthClientId: {{ include "common.set-value" (list .Values.uiConfig.authConfig.oauthClientId $globOauthClientID) | quote }}
 {{- if (include "management-svc.sentry.enabled" .) }}
 sentryConfig:
   environment: {{ .Values.uiConfig.sentryConfig.environment | default (include "management-svc.environment" .) }}

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -142,3 +142,8 @@ spec:
       {{- with .Values.deployment.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+
+{{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+{{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+{{- end -}}


### PR DESCRIPTION
# Motivation
Missing node selectors in deployment manifests for xp-management. 

# Modification
* Add node selector
* Use global oauthClientId if present. 

# Checklist
- [x] Chart version bumped
- [x] README.md updated
