### PR TITLE
fix: Add missing tolerations in turing, xp-mgmt chart

### DIFF
--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.27
+version: 0.2.28

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.27](https://img.shields.io/badge/Version-0.2.27-informational?style=flat-square)
+![Version: 0.2.28](https://img.shields.io/badge/Version-0.2.28-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.

--- a/charts/turing/templates/turing-deployment.yaml
+++ b/charts/turing/templates/turing-deployment.yaml
@@ -91,7 +91,7 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
-      - name: config 
+      - name: config
         secret:
           secretName: {{ template "turing.fullname" . }}-config
       - name: environments
@@ -100,7 +100,7 @@ spec:
       - name: plugins-volume
         emptyDir: {}
       {{- if .Values.openApiSpecOverrides }}
-      - name: openapi 
+      - name: openapi
         configMap:
           name: {{ template "turing.fullname" . }}-openapi
       {{- end }}
@@ -114,3 +114,7 @@ spec:
 {{ toYaml .Values.nodeSelector | indent 8 }}
 {{ end -}}
 {{ end -}}
+{{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+{{- end }}

--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.15
+version: 0.1.16

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square)
+![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -147,3 +147,7 @@ spec:
       nodeSelector:
 {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
 {{- end -}}
+{{- with .Values.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+{{- end }}


### PR DESCRIPTION
# Motivation
templates to add Tolerations are missing in deployment manifests.

# Modification
* add tolerations to turning, xp-mgmt deployments


# Checklist
- [x] Chart version bumped
- [x] README.md updated
