### PR TITLE
fix: Add missing tolerations in xp-treatment chart

### DIFF
--- a/charts/xp-treatment/Chart.lock
+++ b/charts/xp-treatment/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.15
+  version: 0.1.16
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.8
-digest: sha256:3595ed3dde621007520c2768e93faa356f95fd8fd3e0ee5b7a0dc402854cba9d
-generated: "2023-06-07T12:07:15.436776+05:30"
+digest: sha256:62a0e141753f0268197c1d9d9e5845dbc4ae13e599c430a131b56591fcedfe4c
+generated: "2023-06-07T13:55:01.03968+05:30"

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: xp-management.enabled
   name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.15
+  version: 0.1.16
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.8
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.10
+version: 0.1.11

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments

--- a/charts/xp-treatment/templates/deployment.yaml
+++ b/charts/xp-treatment/templates/deployment.yaml
@@ -125,7 +125,7 @@ spec:
           /usr/share/nginx/run.sh
       {{- end }}
       volumes:
-      - name: config 
+      - name: config
         secret:
           secretName: {{ template "treatment-svc.fullname" .}}-config
       {{- with .Values.deployment.extraVolumes }}
@@ -136,3 +136,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}
 {{ end -}}
+{{- with .Values.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+{{- end }}


### PR DESCRIPTION
# Motivation
templates to add Tolerations are missing in deployment manifests.

# Modification
add tolerations to xp-treatment deployments

# Checklist
- [x] Chart version bumped
- [x] README.md updated
