### PR TITLE
chore(mlp): Refactor app configs

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.4.21
+version: 0.5.0

--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.4.20
+version: 0.4.21

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.21](https://img.shields.io/badge/Version-0.4.21-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
 
 MLP API
 

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.4.20](https://img.shields.io/badge/Version-0.4.20-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
+![Version: 0.4.21](https://img.shields.io/badge/Version-0.4.21-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
 
 MLP API
 
@@ -24,26 +24,26 @@ MLP API
 | caramlEnvironments.enabled | bool | `true` |  |
 | caramlEnvironments.environmentConfigs | object | `{}` |  |
 | caramlEnvironments.imageBuilderConfigs | string | `""` |  |
-| deployment.apiHost | string | `"http://mlp/v1"` |  |
-| deployment.applications | list | `[{"configuration":{"api":"/api/merlin/v1","iconName":"machineLearningApp","navigation":[{"destination":"/models","label":"Models"},{"destination":"/transformer-simulator","label":"Transformer Simulator"}]},"description":"Platform for deploying machine learning models","homepage":"/merlin","name":"Merlin"},{"configuration":{"api":"/api/turing/v1","iconName":"graphApp","navigation":[{"destination":"/routers","label":"Routers"},{"destination":"/ensemblers","label":"Ensemblers"},{"destination":"/jobs","label":"Ensembling Jobs"},{"destination":"/experiments","label":"Experiments"}]},"description":"Platform for setting up ML experiments","homepage":"/turing","name":"Turing"},{"configuration":{"api":"/feast/api","iconName":"appSearchApp","navigation":[{"destination":"/entities","label":"Entities"},{"destination":"/featuretables","label":"Feature Tables"},{"destination":"/jobs/batch","label":"Batch Ingestion Jobs"},{"destination":"/jobs/stream","label":"Stream Ingestion Jobs"}]},"description":"Platform for managing and serving ML features","homepage":"/feast","name":"Feast"},{"configuration":{"iconName":"pipelineApp"},"description":"Platform for managing ML pipelines","homepage":"/pipeline","name":"Pipelines"}]` | Enabled CaraML applications |
-| deployment.authorization.enabled | bool | `false` |  |
-| deployment.authorization.serverUrl | string | `"http://mlp-authorization-keto"` |  |
-| deployment.defaultSecretStorage | object | `{}` | Default Secret Storage for storing secrets. Supported values: "vault". If not specified, secrets will be stored as "internal" secret |
-| deployment.docs | list | `[{"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},{"href":"https://github.com/gojek/turing","label":"Turing User Guide"},{"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"}]` | Documentation list for caraml components |
-| deployment.environment | string | `"production"` |  |
+| config.apiHost | string | `"http://mlp/v1"` |  |
+| config.applications | list | `[{"configuration":{"api":"/api/merlin/v1","iconName":"machineLearningApp","navigation":[{"destination":"/models","label":"Models"},{"destination":"/transformer-simulator","label":"Transformer Simulator"}]},"description":"Platform for deploying machine learning models","homepage":"/merlin","name":"Merlin"},{"configuration":{"api":"/api/turing/v1","iconName":"graphApp","navigation":[{"destination":"/routers","label":"Routers"},{"destination":"/ensemblers","label":"Ensemblers"},{"destination":"/jobs","label":"Ensembling Jobs"},{"destination":"/experiments","label":"Experiments"}]},"description":"Platform for setting up ML experiments","homepage":"/turing","name":"Turing"},{"configuration":{"api":"/feast/api","iconName":"appSearchApp","navigation":[{"destination":"/entities","label":"Entities"},{"destination":"/featuretables","label":"Feature Tables"},{"destination":"/jobs/batch","label":"Batch Ingestion Jobs"},{"destination":"/jobs/stream","label":"Stream Ingestion Jobs"}]},"description":"Platform for managing and serving ML features","homepage":"/feast","name":"Feast"},{"configuration":{"iconName":"pipelineApp"},"description":"Platform for managing ML pipelines","homepage":"/pipeline","name":"Pipelines"}]` | Enabled CaraML applications |
+| config.authorization.enabled | bool | `false` |  |
+| config.authorization.serverUrl | string | `"http://mlp-authorization-keto"` |  |
+| config.defaultSecretStorage | object | `{}` | Default Secret Storage for storing secrets. Supported values: "vault". If not specified, secrets will be stored as "internal" secret |
+| config.docs | list | `[{"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},{"href":"https://github.com/gojek/turing","label":"Turing User Guide"},{"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"}]` | Documentation list for caraml components |
+| config.environment | string | `"production"` |  |
+| config.mlflow.trackingUrl | string | `"http://mlflow.mlp"` |  |
+| config.oauthClientID | string | `""` | OAuth client id for login |
+| config.streams | object | `{}` | Streams list |
+| config.ui.clockworkHomepage | string | `"http://clockwork.dev"` |  |
+| config.ui.kubeflowHomepage | string | `"http://kubeflow.org"` |  |
 | deployment.extraLabels | object | `{}` | Additional labels to apply on the deployment |
 | deployment.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"caraml-dev/mlp","tag":"v1.7.7-build.63-8309142"}` | mlp image related configs |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` |  |
-| deployment.mlflowTrackingUrl | string | `"http://mlflow.mlp"` |  |
-| deployment.oauthClientID | string | `""` | OAuth client id for login |
 | deployment.podLabels | object | `{}` | Additional labels to apply on the pod level |
 | deployment.readinessProbe.path | string | `"/v1/internal/ready"` |  |
 | deployment.replicaCount | int | `1` |  |
 | deployment.resources | object | `{}` | Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/ |
-| deployment.streams | object | `{}` | Streams list |
 | deployment.tolerations | list | `[]` |  |
-| deployment.ui.clockworkHomepage | string | `"http://clockwork.dev"` |  |
-| deployment.ui.kubeflowHomepage | string | `"http://kubeflow.org"` |  |
 | externalPostgresql.address | string | `"127.0.0.1"` | Host address for the External postgres |
 | externalPostgresql.createSecret | bool | `false` |  |
 | externalPostgresql.database | string | `"mlp"` | External postgres database schema |
@@ -64,6 +64,7 @@ MLP API
 | postgresql.postgresqlDatabase | string | `"mlp"` |  |
 | postgresql.postgresqlUsername | string | `"mlp"` |  |
 | postgresql.resources | object | `{}` | Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/ |
+| sentry.dsn | string | `""` | Sentry DSN value used by both Turing API and Turing UI |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -103,6 +103,8 @@ app.kubernetes.io/part-of: caraml
 {{- end -}}
 
 {{- define "mlp.defaultConfig" -}}
+{{- $globOauthClientID := include "common.get-oauth-client" .Values.global }}
+{{- $globApiHost := include "common.get-component-value" (list .Values.global "mlp"  (list "vsPrefix")) }}
 apiHost: {{ include "common.set-value" (list .Values.config.apiHost $globApiHost) | quote }}
 port: {{ .Values.service.internalPort }}
 sentryDSN: {{ .Values.sentry.dsn }}

--- a/charts/mlp/templates/configmap.yaml
+++ b/charts/mlp/templates/configmap.yaml
@@ -9,34 +9,4 @@ metadata:
     {{- include "mlp.labels" . | nindent 4 }}
 data:
   mlp-config.yaml: |
-    apiHost: {{ include "common.set-value" (list .Values.deployment.apiHost $globApiHost) | quote }}
-    environment: {{ .Values.deployment.environment }}
-    port: {{ .Values.service.internalPort }}
-    sentryDSN: {{ .Values.deployment.sentryDSN }}
-    oauthClientID: {{ include "common.set-value" (list .Values.deployment.oauthClientID $globOauthClientID) | quote }}
-    applications:
-      {{- include "mlp.deployment.applications" . | nindent 6 }}
-    authorization:
-      enabled: {{ .Values.deployment.authorization.enabled }}
-      {{- if .Values.deployment.authorization.enabled }}
-      ketoServerURL: {{ include "authorization.server.url" . | quote}}
-      {{- end }}
-    database:
-      host: {{ include "common.postgres-host" (list .Values.postgresql .Values.externalPostgresql .Release .Chart ) }}
-      user: {{ include "common.postgres-username" (list .Values.postgresql .Values.externalPostgresql .Values.global ) }}
-      database: {{ include "common.postgres-database" (list .Values.postgresql .Values.externalPostgresql .Values.global "mlp" "postgresqlDatabase") }}
-    {{- if .Values.deployment.docs }}
-    docs:
-      {{- toYaml .Values.deployment.docs | nindent 6 }}
-    {{- end }}
-    mlflow:
-      trackingURL: {{ .Values.deployment.mlflowTrackingUrl }}
-    {{- if .Values.deployment.streams }}
-    streams:
-      {{- toYaml .Values.deployment.streams | nindent 6 }}
-    {{- end }}
-    ui:
-      clockworkUIHomepage: "{{ .Values.deployment.ui.clockworkHomepage }}"
-      kubeflowUIHomepage: "{{ .Values.deployment.ui.kubeflowHomepage }}"
-    defaultSecretStorage:
-      {{- toYaml .Values.deployment.defaultSecretStorage | nindent 6 }}
+    {{- include "mlp.config" . | nindent 4 -}}

--- a/charts/mlp/templates/configmap.yaml
+++ b/charts/mlp/templates/configmap.yaml
@@ -1,5 +1,3 @@
-{{- $globOauthClientID := include "common.get-oauth-client" .Values.global }}
-{{- $globApiHost := include "common.get-component-value" (list .Values.global "mlp"  (list "vsPrefix")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/mlp/tests/mlp_cm_test.yaml
+++ b/charts/mlp/tests/mlp_cm_test.yaml
@@ -10,8 +10,8 @@ tests:
   - it: should set the configs from values if no global values found
     set:
       global: {}
-      deployment.apiHost: "http://mlp/v1"
-      deployment.oauthClientID: "oauthId"
+      config.apiHost: "http://mlp/v1"
+      config.oauthClientID: "oauthId"
     asserts:
       - isKind:
           of: ConfigMap
@@ -21,8 +21,7 @@ tests:
       - matchRegex:
           path: data.[mlp-config.yaml]
           pattern: |
-            (?s).*apiHost: "http://mlp/v1"
-            .*oauthClientID: "oauthId"
+            (?s).*apiHost: http://mlp/v1
             .*applications:
             .*api: \/api\/merlin\/v1
             .*homepage: \/merlin
@@ -33,6 +32,7 @@ tests:
             .*api: \/feast\/api
             .*homepage: \/feast
             .*name: Feast
+            .*oauthClientID: oauthId
   - it: should set the configs from global if global values found
     set:
       global:
@@ -62,8 +62,7 @@ tests:
       - matchRegex:
           path: data.[mlp-config.yaml]
           pattern: |
-            (?s).*apiHost: "/api"
-            .*oauthClientID: "test-client-123"
+            (?s).*apiHost: /api
             .*applications:
             .*api: \/api\/merlin\/v1
             .*homepage: \/merlin
@@ -74,9 +73,10 @@ tests:
             .*api: \/feast\/api
             .*homepage: \/feast
             .*name: Feast
+            .*oauthClientID: test-client-123
   - it: should not set the authorization server url when it is not enabled
     set:
-      deployment:
+      config:
         authorization:
           enabled: false
     asserts:
@@ -99,7 +99,7 @@ tests:
     set:
       global:
         protocol: http
-      deployment:
+      config:
         authorization:
           enabled: true
           serverUrl: "http://authz-url"
@@ -114,13 +114,13 @@ tests:
           pattern: |
             (?s).*authorization:
             .*enabled: true
-            .*ketoServerURL: "http://authz-url"
+            .*ketoServerURL: http://authz-url
   - it: should set the authorization server url from values when it is enabled and no serviceName in authz config in global values
     set:
       global:
         protocol: http
         authz: {}
-      deployment:
+      config:
         authorization:
           enabled: true
           serverUrl: "http://authz-url"
@@ -135,14 +135,14 @@ tests:
           pattern: |
             (?s).*authorization:
             .*enabled: true
-            .*ketoServerURL: "http://authz-url"
+            .*ketoServerURL: http://authz-url
   - it: should set the authorization server url from global when it is enabled and serviceName in authz config in global values
     set:
       global:
         protocol: http
         authz:
           serviceName: "caraml-authz"
-      deployment:
+      config:
         authorization:
           enabled: true
           serverUrl: "http://authz-url"
@@ -157,10 +157,10 @@ tests:
           pattern: |
             (?s).*authorization:
             .*enabled: true
-            .*ketoServerURL: "http://caraml-authz"
+            .*ketoServerURL: http://caraml-authz
   - it: should set streams config when exists
     set:
-      deployment:
+      config:
         streams:
           marketing:
             - promotions
@@ -177,20 +177,17 @@ tests:
           path: data.[mlp-config.yaml]
           pattern: |
             (?s).*streams.*
-  - it: should not set streams config when it doesn't exist
-    set:
-      deployment:
-        streams: {}
+  - it: should set empty streams when it doesn't exist
     asserts:
       - isKind:
           of: ConfigMap
       - matchRegex:
           path: metadata.name
           pattern: mlp-*-config$
-      - notMatchRegex:
+      - matchRegex:
           path: data.[mlp-config.yaml]
           pattern: |
-            (?s).*streams.*
+            (?s).*streams: \{\}.*
   - it: should set database config from values if chart specific db is enabled
     set:
       global:
@@ -215,9 +212,9 @@ tests:
           path: data.[mlp-config.yaml]
           pattern: |
             (?s).*database:
+            .*database: mlp
             .*host: my-release-mlp-postgresql.my-namespace.svc.cluster.local
             .*user: mlp
-            .*database: mlp
   - it: should set database config from values if chart specific db is disabled, external db is enabled
     set:
       global:
@@ -242,9 +239,9 @@ tests:
           path: data.[mlp-config.yaml]
           pattern: |
             (?s).*database:
+            .*database: mlp-ext
             .*host: postgresql
             .*user: mlp-ext
-            .*database: mlp-ext
   - it: should set database config from global values if chart specific db is disabled, external db is disabled
     set:
       global:
@@ -270,6 +267,6 @@ tests:
           path: data.[mlp-config.yaml]
           pattern: |
             (?s).*database:
+            .*database: mlp-global
             .*host: my-release-postgresql.my-namespace.svc.cluster.local
             .*user: mlp-global
-            .*database: mlp-global

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -33,12 +33,176 @@ deployment:
   readinessProbe:
     path: "/v1/internal/ready"
 
-  apiHost: "http://mlp/v1"
-  mlflowTrackingUrl: "http://mlflow.mlp"
-  environment: "production"
-
   # -- Additional labels to apply on the deployment
   extraLabels: {}
+
+service:
+  externalPort: 8080
+  internalPort: 8080
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: mlp
+  annotations: {}
+    # example.io/example: example
+
+ingress:
+  enabled: false
+  # class: "nginx"
+  # host: "localhost"
+  # path: "/"
+  # Ref for pathTypes https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+  # pathType: "Prefix"
+
+sentry:
+  # -- Sentry DSN value used by both Turing API and Turing UI
+  dsn: ""
+
+externalPostgresql:
+  # -- If you would like to use an external postgres database, enable it here using this
+  enabled: false
+  # -- External postgres database user
+  username: mlp
+  # -- External postgres database schema
+  database: mlp
+  # -- Set the External postgres db password using this value at runtime (using --set flag) to create a secret
+  password: password
+  # -- Host address for the External postgres
+  address: 127.0.0.1
+  createSecret: false
+  # -- If a secret is created by external systems (eg. Vault)., mention the secret name here
+  secretName: ""
+  # -- If a secret is created by external systems (eg. Vault)., mention the key under which password is stored in secret (eg. postgresql-password)
+  secretKey: "postgresql-password"
+  # -- Enable if you want to configure a sidecar for creating a proxy for your db connections.
+  enableProxySidecar: false
+  # -- Type of sidecar to be created, mentioned type needs to have the spec below.
+  proxyType: cloudSqlProxy
+  # -- container spec for the sidecar
+  sidecarSpec:
+    # -- container spec for the Google CloudSQL auth proxy sidecar, ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine
+    cloudSqlProxy:
+      dbConnectionName: "asia-east-1:mlp-db"
+      dbPort: 5432
+      image:
+        tag: 1.33.2
+      resources: &cloudCarSpecResource
+        requests:
+          cpu: 200m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 1G
+      spec:
+        - name: cloud-sql-proxy
+          image: gcr.io/cloudsql-docker/gce-proxy:{{ .Values.externalPostgresql.sidecarSpec.cloudSqlProxy.image.tag }}
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout"
+            - "-instances={{ .Values.externalPostgresql.sidecarSpec.cloudSqlProxy.dbConnectionName }}=tcp:{{ .Values.externalPostgresql.sidecarSpec.cloudSqlProxy.dbPort }}"
+          securityContext:
+            runAsNonRoot: true
+          resources: *cloudCarSpecResource
+
+postgresql:
+  # -- Enable creating mlp specific postgres instance
+  enabled: true
+
+  # -- Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  resources: {}
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+
+  persistence:
+    size: 10Gi
+
+  # -- override the name here so that db gets created like <release_name>-mlp-postgresql
+  nameOverride: mlp-postgresql
+
+  postgresqlUsername: mlp
+  postgresqlDatabase: mlp
+  # metrics:
+  #   enabled: true
+  #   serviceMonitor:
+  #     enabled: true
+  # replication:
+  #   enabled: true
+  #   user: repl_user
+  #   password: repl_password
+  #   slaveReplicas: 2
+  #   ## Set synchronous commit mode: on, off, remote_apply, remote_write and local
+  #   ## ref: https://www.postgresql.org/docs/9.6/runtime-config-wal.html#GUC-WAL-LEVEL
+  #   synchronousCommit: "on"
+  #   ## From the number of `slaveReplicas` defined above, set the number of those that will have synchronous replication
+  #   ## NOTE: It cannot be > slaveReplicas
+  #   numSynchronousReplicas: 2
+  #   ## Replication Cluster application name. Useful for defining multiple replication policies
+  #   applicationName: mlp
+
+caramlEnvironments:
+  enabled: true
+  environmentConfigs: {}
+    # Example
+    # - name: "id-dev"
+    #   is_default: true
+    #   cluster: "test"
+    #   region: "id"
+    #   gcp_project: "gcp-project"
+    #   deployment_timeout: "10m"
+    #   namespace_timeout: "2m"
+    #   max_cpu: "8"
+    #   max_memory: "8Gi"
+    #   queue_resource_percentage: "20"
+    #   is_prediction_job_enabled: true
+    #   is_default_prediction_job: true
+    #   default_prediction_job_config:
+    #     executor_replica: 3
+    #     driver_cpu_request: "2"
+    #     driver_memory_request: "2Gi"
+    #     executor_cpu_request: "2"
+    #     executor_memory_request: "2Gi"
+    #   default_deployment_config:
+    #     min_replica: 0
+    #     max_replica: 1
+    #     cpu_request: "500m"
+    #     memory_request: "500Mi"
+    #   default_transformer_config:
+    #     min_replica: 0
+    #     max_replica: 1
+    #     cpu_request: "500m"
+    #     memory_request: "500Mi"
+    #   k8s_config: {}
+  imageBuilderConfigs: ''
+      # Example
+      # '{
+      #   "name": "dev-cluster",
+      #   "cluster": {
+      #     "server": "https://k8s.cluster",
+      #     "certificate-authority-data": "some_cert_data"
+      #   },
+      #   "user": {
+      #     "exec": {
+      #       "apiVersion": "client.authentication.k8s.io/v1beta1",
+      #       "args": [
+      #         "--use_application_default_credentials"
+      #       ],
+      #       "command": "gke-gcloud-auth-plugin",
+      #       "interactiveMode": "IfAvailable",
+      #       "provideClusterInfo": true
+      #     }
+      #   }
+      # }'
+
+config:
+  apiHost: "http://mlp/v1"
+  mlflow:
+    trackingUrl: "http://mlflow.mlp"
+  environment: "production"
 
   # -- Enabled CaraML applications
   applications:
@@ -131,160 +295,3 @@ deployment:
     #     # Only for testing, do not use in production
     #     authMethod: token
     #     token: root
-
-ingress:
-  enabled: false
-  # class: "nginx"
-  # host: "localhost"
-  # path: "/"
-  # Ref for pathTypes https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-  # pathType: "Prefix"
-
-service:
-  externalPort: 8080
-  internalPort: 8080
-
-serviceAccount:
-  # Specifies whether a ServiceAccount should be created
-  create: true
-  # The name of the ServiceAccount to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: mlp
-  annotations: {}
-    # example.io/example: example
-
-externalPostgresql:
-  # -- If you would like to use an external postgres database, enable it here using this
-  enabled: false
-  # -- External postgres database user
-  username: mlp
-  # -- External postgres database schema
-  database: mlp
-  # -- Set the External postgres db password using this value at runtime (using --set flag) to create a secret
-  password: password
-  # -- Host address for the External postgres
-  address: 127.0.0.1
-  createSecret: false
-  # -- If a secret is created by external systems (eg. Vault)., mention the secret name here
-  secretName: ""
-  # -- If a secret is created by external systems (eg. Vault)., mention the key under which password is stored in secret (eg. postgresql-password)
-  secretKey: "postgresql-password"
-  # -- Enable if you want to configure a sidecar for creating a proxy for your db connections.
-  enableProxySidecar: false
-  # -- Type of sidecar to be created, mentioned type needs to have the spec below.
-  proxyType: cloudSqlProxy
-  # -- container spec for the sidecar
-  sidecarSpec:
-    # -- container spec for the Google CloudSQL auth proxy sidecar, ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine
-    cloudSqlProxy:
-      dbConnectionName: "asia-east-1:mlp-db"
-      dbPort: 5432
-      image:
-        tag: 1.33.2
-      resources: &cloudCarSpecResource
-        requests:
-          cpu: 200m
-          memory: 512Mi
-        limits:
-          cpu: 1000m
-          memory: 1G
-      spec:
-        - name: cloud-sql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:{{ .Values.externalPostgresql.sidecarSpec.cloudSqlProxy.image.tag }}
-          command:
-            - "/cloud_sql_proxy"
-            - "-ip_address_types=PRIVATE"
-            - "-log_debug_stdout"
-            - "-instances={{ .Values.externalPostgresql.sidecarSpec.cloudSqlProxy.dbConnectionName }}=tcp:{{ .Values.externalPostgresql.sidecarSpec.cloudSqlProxy.dbPort }}"
-          securityContext:
-            runAsNonRoot: true
-          resources: *cloudCarSpecResource
-
-postgresql:
-  # -- Enable creating mlp specific postgres instance
-  enabled: true
-
-  # -- Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  resources: {}
-  #   requests:
-  #     cpu: 100m
-  #     memory: 128Mi
-
-  persistence:
-    size: 10Gi
-
-  # -- override the name here so that db gets created like <release_name>-mlp-postgresql
-  nameOverride: mlp-postgresql
-
-  postgresqlUsername: mlp
-  postgresqlDatabase: mlp
-  # metrics:
-  #   enabled: true
-  #   serviceMonitor:
-  #     enabled: true
-  # replication:
-  #   enabled: true
-  #   user: repl_user
-  #   password: repl_password
-  #   slaveReplicas: 2
-  #   ## Set synchronous commit mode: on, off, remote_apply, remote_write and local
-  #   ## ref: https://www.postgresql.org/docs/9.6/runtime-config-wal.html#GUC-WAL-LEVEL
-  #   synchronousCommit: "on"
-  #   ## From the number of `slaveReplicas` defined above, set the number of those that will have synchronous replication
-  #   ## NOTE: It cannot be > slaveReplicas
-  #   numSynchronousReplicas: 2
-  #   ## Replication Cluster application name. Useful for defining multiple replication policies
-  #   applicationName: mlp
-caramlEnvironments:
-  enabled: true
-  environmentConfigs: {}
-    # Example
-    # - name: "id-dev"
-    #   is_default: true
-    #   cluster: "test"
-    #   region: "id"
-    #   gcp_project: "gcp-project"
-    #   deployment_timeout: "10m"
-    #   namespace_timeout: "2m"
-    #   max_cpu: "8"
-    #   max_memory: "8Gi"
-    #   queue_resource_percentage: "20"
-    #   is_prediction_job_enabled: true
-    #   is_default_prediction_job: true
-    #   default_prediction_job_config:
-    #     executor_replica: 3
-    #     driver_cpu_request: "2"
-    #     driver_memory_request: "2Gi"
-    #     executor_cpu_request: "2"
-    #     executor_memory_request: "2Gi"
-    #   default_deployment_config:
-    #     min_replica: 0
-    #     max_replica: 1
-    #     cpu_request: "500m"
-    #     memory_request: "500Mi"
-    #   default_transformer_config:
-    #     min_replica: 0
-    #     max_replica: 1
-    #     cpu_request: "500m"
-    #     memory_request: "500Mi"
-    #   k8s_config: {}
-  imageBuilderConfigs: ''
-      # Example
-      # '{
-      #   "name": "dev-cluster",
-      #   "cluster": {
-      #     "server": "https://k8s.cluster",
-      #     "certificate-authority-data": "some_cert_data"
-      #   },
-      #   "user": {
-      #     "exec": {
-      #       "apiVersion": "client.authentication.k8s.io/v1beta1",
-      #       "args": [
-      #         "--use_application_default_credentials"
-      #       ],
-      #       "command": "gke-gcloud-auth-plugin",
-      #       "interactiveMode": "IfAvailable",
-      #       "provideClusterInfo": true
-      #     }
-      #   }
-      # }'

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -200,10 +200,10 @@ caramlEnvironments:
 
 config:
   apiHost: "http://mlp/v1"
-  
+
   # -- OAuth client id for login
   oauthClientID: ""
-  
+
   environment: "production"
 
   # -- Enabled CaraML applications

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -200,8 +200,10 @@ caramlEnvironments:
 
 config:
   apiHost: "http://mlp/v1"
-  mlflow:
-    trackingUrl: "http://mlflow.mlp"
+  
+  # -- OAuth client id for login
+  oauthClientID: ""
+  
   environment: "production"
 
   # -- Enabled CaraML applications
@@ -278,9 +280,6 @@ config:
     clockworkHomepage: "http://clockwork.dev"
     kubeflowHomepage: "http://kubeflow.org"
 
-  # -- OAuth client id for login
-  oauthClientID: ""
-
   # -- Default Secret Storage for storing secrets. Supported values: "vault".
   # If not specified, secrets will be stored as "internal" secret
   defaultSecretStorage: {}
@@ -295,3 +294,6 @@ config:
     #     # Only for testing, do not use in production
     #     authMethod: token
     #     token: root
+
+  mlflow:
+    trackingUrl: "http://mlflow.mlp"


### PR DESCRIPTION
# Motivation
Per the current implementation, the MLP configmap's structure is largely fixed. This means that, with every new config introduced, the chart must be updated, which is not ideal.

# Modification
This PR refactors the MLP configs (moving them from `.Values.deployment` -> `.Values.config`) and configmap (merging the `.Values.config` with a set of default configs generated from other values in the chart), so that the configs can be dynamically extended. This is similar to other components like Turing.
* `charts/mlp/templates/_helpers.tpl` - Create default MLP config that can be merged with `.Values.config`
* `charts/mlp/templates/configmap.yaml` - Let configmap use the merged config
* `charts/mlp/tests/mlp_cm_test.yaml` - Update tests:
    - Key order matters in regex matches of configmap, now they are sorted alphabetically.
    - `""` are removed from strings that don't need to be quoted
    - Change `deployment:` -> `config:` in test input
* `charts/mlp/values.yaml` - Most of the values that were under `deployment` are moved under `config`, for consistency with other CaraML components.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
