### PR TITLE
(fix): Fix DB secret ref in XP management secret

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.17
+version: 0.2.0

--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.1.16
+version: 0.1.17

--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 appVersion: 0.12.1
 dependencies:
-- alias: postgresql
-  condition: postgresql.enabled
+- alias: xp-management-postgresql
+  condition: xp-management-postgresql.enabled
   name: postgresql
   repository: https://charts.helm.sh/stable
   version: 7.0.2

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square)
+![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments
@@ -62,24 +62,24 @@ The following table lists the configurable parameters of the XP Management Servi
 | deployment.serviceAccount.annotations | object | `{}` |  |
 | deployment.serviceAccount.create | bool | `true` |  |
 | deployment.serviceAccount.name | string | `""` |  |
-| externalPostgresql.address | string | `"127.0.0.1"` | Host address for the External postgres |
-| externalPostgresql.createSecret | bool | `false` | Enable this if you need the chart to create a secret when you provide the password above. To be used together with password. |
-| externalPostgresql.database | string | `"xp"` | External postgres database schema |
-| externalPostgresql.enabled | bool | `false` | If you would like to use an external postgres database, enable it here using this |
-| externalPostgresql.password | string | `"password"` |  |
-| externalPostgresql.secretKey | string | `""` | Secret key in Secret which contains postgresql credentials |
-| externalPostgresql.secretName | string | `""` | Secret name which contains credentials to access externalPostgresql |
-| externalPostgresql.username | string | `"xp"` | External postgres database user |
 | global.environment | string | `"dev"` | Environment of Management Service deployment |
 | global.mlp.serviceName | string | `"mlp"` | Global MLP service name |
 | global.sentry.dsn | string | `nil` | Global Sentry DSN value |
-| postgresql | object | `{"containerPorts":{"postgresql":5432},"enabled":true,"nameOverride":"xp-management-postgresql","persistence":{"enabled":true,"size":"10Gi"},"postgresqlDatabase":"xp","postgresqlPassword":"xp","postgresqlUsername":"xp","resources":{"requests":{"cpu":"100m","memory":"256Mi"}},"tls":{"enabled":false}}` | Postgresql configuration to be applied to XP Management Service's postgresql database deployment Reference: https://artifacthub.io/packages/helm/bitnami/postgresql/10.16.2#parameters |
-| postgresql.persistence.enabled | bool | `true` | Persist Postgresql data in a Persistent Volume Claim |
-| postgresql.postgresqlPassword | string | `"xp"` | Password for XP Management Service Postgresql database |
-| postgresql.resources | object | `{"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources requests and limits for XP Management Service database. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | swaggerUi.apiServer | string | `"http://127.0.0.1/v1"` | URL of API server |
 | swaggerUi.enabled | bool | `true` |  |
 | swaggerUi.image | object | `{"tag":"v3.47.1"}` | Docker tag for Swagger UI https://hub.docker.com/r/swaggerapi/swagger-ui |
 | swaggerUi.service.externalPort | int | `3000` | Swagger UI Kubernetes service port number |
 | swaggerUi.service.internalPort | int | `8081` | Swagger UI container port number |
 | uiConfig | object | `{"apiConfig":{"mlpApiUrl":"/api/v1","xpApiUrl":"/api/xp/v1"},"appConfig":{"docsUrl":[{"href":"https://github.com/caraml-dev/xp/tree/main/docs","label":"XP User Guide"}]},"authConfig":{"oauthClientId":""},"sentryConfig":{}}` | XP UI configuration. |
+| xp-management-postgresql | object | `{"containerPorts":{"postgresql":5432},"enabled":true,"persistence":{"enabled":true,"size":"10Gi"},"postgresqlDatabase":"xp","postgresqlPassword":"xp","postgresqlUsername":"xp","resources":{"requests":{"cpu":"100m","memory":"256Mi"}},"tls":{"enabled":false}}` | Postgresql configuration to be applied to XP Management Service's postgresql database deployment Reference: https://artifacthub.io/packages/helm/bitnami/postgresql/10.16.2#parameters |
+| xp-management-postgresql.persistence.enabled | bool | `true` | Persist Postgresql data in a Persistent Volume Claim |
+| xp-management-postgresql.postgresqlPassword | string | `"xp"` | Password for XP Management Service Postgresql database |
+| xp-management-postgresql.resources | object | `{"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources requests and limits for XP Management Service database. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| xpManagementExternalPostgresql.address | string | `"127.0.0.1"` | Host address for the External postgres |
+| xpManagementExternalPostgresql.createSecret | bool | `false` | Enable this if you need the chart to create a secret when you provide the password above. To be used together with password. |
+| xpManagementExternalPostgresql.database | string | `"xp"` | External postgres database schema |
+| xpManagementExternalPostgresql.enabled | bool | `false` | If you would like to use an external postgres database, enable it here using this |
+| xpManagementExternalPostgresql.password | string | `"password"` |  |
+| xpManagementExternalPostgresql.secretKey | string | `""` | Secret key in Secret which contains postgresql credentials |
+| xpManagementExternalPostgresql.secretName | string | `""` | Secret name which contains credentials to access externalPostgresql |
+| xpManagementExternalPostgresql.username | string | `"xp"` | External postgres database user |

--- a/charts/xp-management/templates/database-secret.yaml
+++ b/charts/xp-management/templates/database-secret.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.postgres-password-secret-name" (list (index .Values "externalPostgresql") .Values.externalPostgresql .Release .Chart ) | quote }}
+  name: {{ include "common.postgres-password-secret-name" (list (index .Values "xp-management-postgresql") .Values.xpManagementExternalPostgresql .Release .Chart ) | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "management-svc.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{ include "common.postgres-password-secret-key" (list .Values.externalPostgresql) }}: {{ .Values.externalPostgresql.password }}
+  {{ include "common.postgres-password-secret-key" (list .Values.xpManagementExternalPostgresql) }}: {{ .Values.xpManagementExternalPostgresql.password }}
 {{- end }}

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           - name: "DBCONFIG_PASSWORD"
             valueFrom:
               secretKeyRef:
-                name: {{ include "common.postgres-password-secret-name" (list (index .Values "xp-management-postgresql") .Values.xpManagementExternalPostgresql .Release .Chart ) | quote }}
+                name: {{ include "common.postgres-password-secret-name" (list (index .Values "xp-management-postgresql") .Values.xpManagementExternalPostgresql .Release .Chart ) }}
                 key: {{ include "common.postgres-password-secret-key" (list .Values.xpManagementExternalPostgresql) }}
           {{- with .Values.deployment.extraEnvs }}
           {{- toYaml . | nindent 12 }}

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -43,8 +43,8 @@ spec:
           - name: "DBCONFIG_PASSWORD"
             valueFrom:
               secretKeyRef:
-                name: {{ include "common.postgres-password-secret-name" (list (index .Values "externalPostgresql") .Values.externalPostgresql .Release .Chart ) | quote }}
-                key: {{ include "common.postgres-password-secret-key" (list .Values.externalPostgresql) }}
+                name: {{ include "common.postgres-password-secret-name" (list (index .Values "xp-management-postgresql") .Values.xpManagementExternalPostgresql .Release .Chart ) | quote }}
+                key: {{ include "common.postgres-password-secret-key" (list .Values.xpManagementExternalPostgresql) }}
           {{- with .Values.deployment.extraEnvs }}
           {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           - name: "DBCONFIG_PASSWORD"
             valueFrom:
               secretKeyRef:
-                name: {{ include "common.postgres-password-secret-name" (list (index .Values "postgresql") .Values.externalPostgresql .Release .Chart ) }}
+                name: {{ include "common.postgres-password-secret-name" (list (index .Values "externalPostgresql") .Values.externalPostgresql .Release .Chart ) | quote }}
                 key: {{ include "common.postgres-password-secret-key" (list .Values.externalPostgresql) }}
           {{- with .Values.deployment.extraEnvs }}
           {{- toYaml . | nindent 12 }}

--- a/charts/xp-management/tests/deployment_test.yaml
+++ b/charts/xp-management/tests/deployment_test.yaml
@@ -1,0 +1,80 @@
+suite: Unit tests for xp-management Deployment
+templates:
+  - deployment.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+  revision: 1
+  isUpgrade: true
+tests:
+  - it: should set database secret key and name from values if chart specific db is enabled
+    set:
+      global: {}
+      xp-management-postgresql:
+        enabled: true
+        postgresqlDatabase: xp
+        postgresqlUsername: xp
+      xpManagementExternalPostgresql:
+        enabled: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-xp-management
+      - equal: # check database secret name
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: my-release-xp-management-postgresql
+      - equal: # check database secret key
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
+          value: postgresql-password
+  
+  - it: should set database secret key and name from values if chart specific db is disabled, external db is enabled, createSecret is set
+    set:
+      global: {}
+      xp-management-postgresql:
+        enabled: false
+      xpManagementExternalPostgresql:
+        enabled: true
+        address: xp-management-ext-db-address
+        username: xp-management-ext
+        database: xp-management-ext
+        password: xp-management-ext-password
+        createSecret: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-xp-management$
+      - equal: # check database secret name
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: my-release-xp-management-external-postgresql
+      - equal: # check database secret key
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
+          value: postgresql-password
+
+  - it: should use database secret key and name from values if chart specific db is disabled, external db is enabled, secret name & key are set
+    set:
+      global: {}
+      xp-management-postgresql:
+        enabled: false
+      xpManagementExternalPostgresql:
+        enabled: true
+        address: xp-management-ext-db-address
+        username: xp-management-ext
+        database: xp-management-ext
+        secretName: secret-name
+        secretKey: secret-key
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-xp-management$
+      - equal: # check database secret name
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: secret-name
+      - equal: # check database secret key
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
+          value: secret-key

--- a/charts/xp-management/values.yaml
+++ b/charts/xp-management/values.yaml
@@ -154,7 +154,7 @@ uiConfig:
   sentryConfig: {}
 
 # If you would like to use an external postgres database for XP Management Service, you can connect using these credentials
-externalPostgresql:
+xpManagementExternalPostgresql:
   # -- If you would like to use an external postgres database, enable it here using this
   enabled: false
   # -- External postgres database user
@@ -174,9 +174,8 @@ externalPostgresql:
 
 # -- Postgresql configuration to be applied to XP Management Service's postgresql database deployment
 # Reference: https://artifacthub.io/packages/helm/bitnami/postgresql/10.16.2#parameters
-postgresql:
+xp-management-postgresql:
   enabled: true
-  nameOverride: xp-management-postgresql
   postgresqlDatabase: xp
   postgresqlUsername: xp
   # -- Password for XP Management Service Postgresql database


### PR DESCRIPTION
# Motivation
The XP management external DB secret was created with the name:

```
{{ include "common.postgres-password-secret-name" (list (index .Values "externalPostgresql") .Values.externalPostgresql .Release .Chart ) | quote }}
```

while the deployment specs were referring to:

```
{ include "common.postgres-password-secret-name" (list (index .Values "postgresql") .Values.externalPostgresql .Release .Chart ) }}
```

This is causing problems when the app is deployed.

# Modification

This PR primarily updates the 2 secret names to be identical. In addition, the structure of the values files is modified a little, to match other CaraML components (thus, a minor version update on the chart version):
* `postgresql:` -> `xp-management-postgresql:`
* `externalPostgresql:` -> `xpManagementExternalPostgresql:`

# Checklist
- [x] Chart version bumped
- [x] README.md updated
