### PR TITLE
chore: revert minor version bump in chart bumper

### DIFF
--- a/.github/workflows/chart-bumper.yaml
+++ b/.github/workflows/chart-bumper.yaml
@@ -39,7 +39,6 @@ jobs:
 
       - name: Run chart bumper script & update docs
         run: |
-          export BUMP_MINOR=true
           python scripts/chart_bumper.py
           rm -f manifest.yaml
           rm -f manifest_gdi_dependant.yaml


### PR DESCRIPTION
# Motivation

Remove the flag to bump minor version. This will be handled later since it has external deps upgraded and it needs fixes before merging. To unblock the auto-upgrades this flag is removed. 

# Modification

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
