### PR TITLE
chore(mlp): Update chart values to get rid of redundant keys

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: mlp
-version: 0.5.0
+version: 0.5.1

--- a/charts/mlp/README.md
+++ b/charts/mlp/README.md
@@ -1,6 +1,6 @@
 # mlp
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![AppVersion: v1.7.4-build.6-322163a](https://img.shields.io/badge/AppVersion-v1.7.4--build.6--322163a-informational?style=flat-square)
 
 MLP API
 
@@ -27,15 +27,15 @@ MLP API
 | config.apiHost | string | `"http://mlp/v1"` |  |
 | config.applications | list | `[{"configuration":{"api":"/api/merlin/v1","iconName":"machineLearningApp","navigation":[{"destination":"/models","label":"Models"},{"destination":"/transformer-simulator","label":"Transformer Simulator"}]},"description":"Platform for deploying machine learning models","homepage":"/merlin","name":"Merlin"},{"configuration":{"api":"/api/turing/v1","iconName":"graphApp","navigation":[{"destination":"/routers","label":"Routers"},{"destination":"/ensemblers","label":"Ensemblers"},{"destination":"/jobs","label":"Ensembling Jobs"},{"destination":"/experiments","label":"Experiments"}]},"description":"Platform for setting up ML experiments","homepage":"/turing","name":"Turing"},{"configuration":{"api":"/feast/api","iconName":"appSearchApp","navigation":[{"destination":"/entities","label":"Entities"},{"destination":"/featuretables","label":"Feature Tables"},{"destination":"/jobs/batch","label":"Batch Ingestion Jobs"},{"destination":"/jobs/stream","label":"Stream Ingestion Jobs"}]},"description":"Platform for managing and serving ML features","homepage":"/feast","name":"Feast"},{"configuration":{"iconName":"pipelineApp"},"description":"Platform for managing ML pipelines","homepage":"/pipeline","name":"Pipelines"}]` | Enabled CaraML applications |
 | config.authorization.enabled | bool | `false` |  |
-| config.authorization.serverUrl | string | `"http://mlp-authorization-keto"` |  |
+| config.authorization.ketoServerURL | string | `"http://mlp-authorization-keto"` |  |
 | config.defaultSecretStorage | object | `{}` | Default Secret Storage for storing secrets. Supported values: "vault". If not specified, secrets will be stored as "internal" secret |
 | config.docs | list | `[{"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},{"href":"https://github.com/gojek/turing","label":"Turing User Guide"},{"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"}]` | Documentation list for caraml components |
 | config.environment | string | `"production"` |  |
-| config.mlflow.trackingUrl | string | `"http://mlflow.mlp"` |  |
+| config.mlflow.trackingURL | string | `"http://mlflow.mlp"` |  |
 | config.oauthClientID | string | `""` | OAuth client id for login |
 | config.streams | object | `{}` | Streams list |
-| config.ui.clockworkHomepage | string | `"http://clockwork.dev"` |  |
-| config.ui.kubeflowHomepage | string | `"http://kubeflow.org"` |  |
+| config.ui.clockworkUIHomepage | string | `"http://clockwork.dev"` |  |
+| config.ui.kubeflowUIHomepage | string | `"http://kubeflow.org"` |  |
 | deployment.extraLabels | object | `{}` | Additional labels to apply on the deployment |
 | deployment.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"caraml-dev/mlp","tag":"v1.7.7-build.63-8309142"}` | mlp image related configs |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` |  |

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -70,7 +70,7 @@ app.kubernetes.io/part-of: caraml
             {{- $globalAuthzUrl = (printf "%s://%s" $protocol (include "common.get-component-value" (list .Values.global "authz" (list "serviceName")))) }}
         {{- end }}
     {{- end }}
-    {{- printf "%s" (include "common.set-value" (list .Values.config.authorization.serverUrl $globalAuthzUrl)) -}}
+    {{- printf "%s" (include "common.set-value" (list .Values.config.authorization.ketoServerURL $globalAuthzUrl)) -}}
 {{- end -}}
 
 {{- define "mlp.config.applications" -}}
@@ -120,9 +120,6 @@ database:
     host: {{ include "common.postgres-host" (list .Values.postgresql .Values.externalPostgresql .Release .Chart ) }}
     user: {{ include "common.postgres-username" (list .Values.postgresql .Values.externalPostgresql .Values.global ) }}
     database: {{ include "common.postgres-database" (list .Values.postgresql .Values.externalPostgresql .Values.global "mlp" "postgresqlDatabase") }}
-ui:
-    clockworkUIHomepage: "{{ .Values.config.ui.clockworkHomepage }}"
-    kubeflowUIHomepage: "{{ .Values.config.ui.kubeflowHomepage }}"
 {{- end -}}
 
 {{- define "mlp.config" -}}

--- a/charts/mlp/tests/mlp_cm_test.yaml
+++ b/charts/mlp/tests/mlp_cm_test.yaml
@@ -74,27 +74,6 @@ tests:
             .*homepage: \/feast
             .*name: Feast
             .*oauthClientID: test-client-123
-  - it: should not set the authorization server url when it is not enabled
-    set:
-      config:
-        authorization:
-          enabled: false
-    asserts:
-      - isKind:
-          of: ConfigMap
-      - matchRegex:
-          path: metadata.name
-          pattern: mlp-*-config$
-      - matchRegex:
-          path: data.[mlp-config.yaml]
-          pattern: |
-            (?s).*authorization:
-            .*enabled: false
-      - notMatchRegex:
-          path: data.[mlp-config.yaml]
-          pattern: |
-            (?s).*authorization:
-            .*ketoServerURL: .*
   - it: should set the authorization server url from values when it is enabled and no authz config found in global values
     set:
       global:
@@ -102,7 +81,7 @@ tests:
       config:
         authorization:
           enabled: true
-          serverUrl: "http://authz-url"
+          ketoServerURL: "http://authz-url"
     asserts:
       - isKind:
           of: ConfigMap
@@ -123,7 +102,7 @@ tests:
       config:
         authorization:
           enabled: true
-          serverUrl: "http://authz-url"
+          ketoServerURL: "http://authz-url"
     asserts:
       - isKind:
           of: ConfigMap
@@ -145,7 +124,7 @@ tests:
       config:
         authorization:
           enabled: true
-          serverUrl: "http://authz-url"
+          ketoServerURL: "http://authz-url"
     asserts:
       - isKind:
           of: ConfigMap

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -257,7 +257,7 @@ config:
 
   authorization:
     enabled: false
-    serverUrl: http://mlp-authorization-keto
+    ketoServerURL: http://mlp-authorization-keto
 
   # -- Streams list
   streams: {}
@@ -277,8 +277,8 @@ config:
       href: "https://docs.feast.dev/user-guide/overview"
 
   ui:
-    clockworkHomepage: "http://clockwork.dev"
-    kubeflowHomepage: "http://kubeflow.org"
+    clockworkUIHomepage: "http://clockwork.dev"
+    kubeflowUIHomepage: "http://kubeflow.org"
 
   # -- Default Secret Storage for storing secrets. Supported values: "vault".
   # If not specified, secrets will be stored as "internal" secret
@@ -296,4 +296,4 @@ config:
     #     token: root
 
   mlflow:
-    trackingUrl: "http://mlflow.mlp"
+    trackingURL: "http://mlflow.mlp"


### PR DESCRIPTION
# Motivation
The default configs have a slightly different naming convention than the configs in the values file. Since the 2 sets of values will ultimately be merged, it results in redundant keys. Eg:

![Screenshot 2023-06-15 at 6 09 48 PM](https://github.com/caraml-dev/helm-charts/assets/23465343/55f43a7e-af41-4568-9310-2afc307677b6)

# Modification
This PR simply renames some of the configs in the values file to match the keys that will ultimately be needed by the app.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
