### PR TITLE
fix: update patch version for dap-secret chart since chart.lock got a…

### DIFF
--- a/charts/dap-secret-webhook/Chart.yaml
+++ b/charts/dap-secret-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dap-secret-webhook
 description: dap-secret-webhook is a Kubernetes pod mutating webhook for using CaraML Secrets in Flyte.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.0.1
 dependencies:
 - condition: mlp.enabled

--- a/charts/dap-secret-webhook/README.md
+++ b/charts/dap-secret-webhook/README.md
@@ -1,7 +1,7 @@
 # dap-secret-webhook
 
 ---
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
 ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 dap-secret-webhook is a Kubernetes pod mutating webhook for using CaraML Secrets in Flyte.

--- a/charts/dap-secret-webhook/README.md.gotmpl
+++ b/charts/dap-secret-webhook/README.md.gotmpl
@@ -11,10 +11,10 @@ dap-secret-webhook is a Kubernetes pod mutating webhook for using CaraML Secrets
 
 The webhook is deployed using a deployment resource which requires the following to operate
 - ServiceAccount with roles to operate on `Secrets` and `MutatingWebhookConfiguration`
-- Env var 
+- Env var
   - Configuration to create MutatingWebhookConfiguration programmatically
   - MLP host
-  - Secrets with TLS 
+  - Secrets with TLS
 
 ## Maintainers
 

--- a/charts/kserve/Chart.yaml
+++ b/charts/kserve/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
   name: caraml-dev
 name: kserve
 type: application
-version: 0.8.21
+version: 0.8.22

--- a/charts/kserve/README.md
+++ b/charts/kserve/README.md
@@ -1,7 +1,7 @@
 # kserve
 
 ---
-![Version: 0.8.21](https://img.shields.io/badge/Version-0.8.21-informational?style=flat-square)
+![Version: 0.8.22](https://img.shields.io/badge/Version-0.8.22-informational?style=flat-square)
 ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for installing Kserve

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.29
+version: 0.2.30

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.29](https://img.shields.io/badge/Version-0.2.29-informational?style=flat-square)
+![Version: 0.2.30](https://img.shields.io/badge/Version-0.2.30-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.


### PR DESCRIPTION
# Motivation
In the previous chart release post auto-upgrade, The dap chart release failed because it didn't have a chart version upgrade. (that was because it just added a missing chart.lock file). It also resulted in chart release failure for two other charts. job ref: 
https://github.com/caraml-dev/helm-charts/actions/runs/5278187240/jobs/9547180613

# Modification
This PR manually upgrades the chart version of those failed charts to release the latest version. 


# Checklist
- [x] Chart version bumped
- [x] README.md updated
