### PR TITLE
chore: Bump up dependencies on CaraML umbrella chart

### DIFF
--- a/charts/caraml/Chart.lock
+++ b/charts/caraml/Chart.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.20
+  version: 0.5.1
 - name: merlin
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.10.21
 - name: turing
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.30
+  version: 0.2.31
 - name: xp-treatment
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.11
+  version: 0.1.12
 - name: postgresql
   repository: https://charts.helm.sh/stable
   version: 7.0.2
@@ -41,5 +41,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.8.2
-digest: sha256:d71bf8b9635a6f91abddd60e66c3fad5584c9e12805e2fbd195fce2912ab3e34
-generated: "2023-06-15T14:39:11.282552934Z"
+digest: sha256:9eab520320525f8ec041680b8d68705af0395f1ae9c7cd8fe014d84927408ce7
+generated: "2023-06-17T09:03:22.244813+08:00"

--- a/charts/caraml/Chart.yaml
+++ b/charts/caraml/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
 - condition: mlp.enabled
   name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.20
+  version: 0.5.1
 - condition: merlin.enabled
   name: merlin
   repository: https://caraml-dev.github.io/helm-charts
@@ -12,11 +12,11 @@ dependencies:
 - condition: turing.enabled
   name: turing
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.30
+  version: 0.2.31
 - condition: xp-treatment.enabled
   name: xp-treatment
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.1.11
+  version: 0.1.12
 - condition: postgresql.enabled
   name: postgresql
   repository: https://charts.helm.sh/stable
@@ -68,4 +68,4 @@ maintainers:
   name: caraml-dev
 name: caraml
 type: application
-version: 0.5.12
+version: 0.5.13

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -1,6 +1,6 @@
 # caraml
 
-![Version: 0.5.12](https://img.shields.io/badge/Version-0.5.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.5.13](https://img.shields.io/badge/Version-0.5.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML components
 
@@ -22,9 +22,9 @@ A Helm chart for deploying CaraML components
 | https://caraml-dev.github.io/helm-charts | istioIngressGateway(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | istiod(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | merlin | 0.10.21 |
-| https://caraml-dev.github.io/helm-charts | mlp | 0.4.20 |
-| https://caraml-dev.github.io/helm-charts | turing | 0.2.30 |
-| https://caraml-dev.github.io/helm-charts | xp-treatment | 0.1.11 |
+| https://caraml-dev.github.io/helm-charts | mlp | 0.5.1 |
+| https://caraml-dev.github.io/helm-charts | turing | 0.2.31 |
+| https://caraml-dev.github.io/helm-charts | xp-treatment | 0.1.12 |
 | https://charts.helm.sh/stable | postgresql | 7.0.2 |
 | https://charts.jetstack.io | cert-manager | v1.8.2 |
 | https://istio-release.storage.googleapis.com/charts | base(base) | 1.13.9 |


### PR DESCRIPTION
# Motivation
This PR simply updates the caraml component dependencies in the umbrella chart, to consume the latest changes.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
