### PR TITLE
fix(xp): update the logic for default config creation

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.2.1
+version: 0.2.2

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/_helpers.tpl
+++ b/charts/xp-management/templates/_helpers.tpl
@@ -136,10 +136,6 @@ API config related
 
 {{- define "management-svc.defaultConfig" -}}
 {{- $globMlpApiHost := include "management-svc.get-workload-host" (list .Values.global .Release.Namespace "mlp")}}
-<<<<<<< HEAD
-Glob: {{ include "common.set-value" (list .Values.deployment.apiConfig.MlpConfig.URL $globMlpApiHost) }}
-=======
->>>>>>> 31ede2a (fix(xp): make the workload host consistent)
 Port: 8080
 AllowedOrigins: "*"
 AuthorizationConfig:

--- a/charts/xp-management/templates/_helpers.tpl
+++ b/charts/xp-management/templates/_helpers.tpl
@@ -167,5 +167,5 @@ XpUIConfig:
 
 {{- define "management-svc.config" -}}
 {{- $defaultConfig := include "management-svc.defaultConfig" . | fromYaml -}}
-{{ .Values.deployment.apiConfig | mergeOverwrite $defaultConfig | toYaml }}
+{{  merge .Values.deployment.apiConfig $defaultConfig | toYaml }}
 {{- end -}}

--- a/charts/xp-management/templates/_helpers.tpl
+++ b/charts/xp-management/templates/_helpers.tpl
@@ -136,7 +136,10 @@ API config related
 
 {{- define "management-svc.defaultConfig" -}}
 {{- $globMlpApiHost := include "management-svc.get-workload-host" (list .Values.global .Release.Namespace "mlp")}}
+<<<<<<< HEAD
 Glob: {{ include "common.set-value" (list .Values.deployment.apiConfig.MlpConfig.URL $globMlpApiHost) }}
+=======
+>>>>>>> 31ede2a (fix(xp): make the workload host consistent)
 Port: 8080
 AllowedOrigins: "*"
 AuthorizationConfig:

--- a/charts/xp-management/tests/secret_test.yaml
+++ b/charts/xp-management/tests/secret_test.yaml
@@ -1,4 +1,4 @@
-suite: Unit tests for xp-management Deployment
+suite: Unit tests for xp-management api-config secret
 templates:
   - secret.yaml
 release:

--- a/charts/xp-management/tests/secret_test.yaml
+++ b/charts/xp-management/tests/secret_test.yaml
@@ -1,0 +1,107 @@
+suite: Unit tests for xp-management Deployment
+templates:
+  - secret.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+  revision: 1
+  isUpgrade: true
+tests:
+  - it: should set mlpURL from values if provided in values and globals is empty
+    set:
+      global: {}
+      deployment:
+        apiConfig:
+          MlpConfig:
+            URL: http://mlp-url
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-xp-management-api-config
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: |
+            (?s).*MlpConfig:
+            .*  URL: http://mlp-url
+  - it: should set mlpURL from values if provided in values and globals is not empty
+    set:
+      global:
+        protocol: http
+        mlp:
+          apiPrefix: ""
+          serviceName: mlp
+          externalPort: "8080"
+          useServiceFqdn: true
+      deployment:
+        apiConfig:
+          MlpConfig:
+            URL: http://mlp-url
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-xp-management-api-config
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: |
+            (?s).*MlpConfig:
+            .*  URL: http://mlp-url
+  - it: should set mlpURL from globals if empty value in values.yaml and globals is not empty
+    set:
+      global:
+        protocol: http
+        mlp:
+          apiPrefix: ""
+          serviceName: mlp
+          externalPort: "8080"
+          useServiceFqdn: true
+      deployment:
+        apiConfig:
+          MlpConfig:
+            URL: ""
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-xp-management-api-config
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: |
+            (?s).*MlpConfig:
+            .*  URL: http://mlp.my-namespace.svc.cluster.local:8080
+  - it: should set values from values.yaml if non-empty value in values.yaml and not reset to defaults
+    set:
+      global:
+        protocol: http
+        mlp:
+          apiPrefix: ""
+          serviceName: mlp
+          externalPort: "8080"
+          useServiceFqdn: true
+      deployment:
+        apiConfig:
+          MlpConfig:
+            URL: ""
+          AuthorizationConfig:
+            Enabled: true
+          DeploymentConfig:
+            EnvironmentType: my-env
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-xp-management-api-config
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: |
+            (?s).*AuthorizationConfig:
+            .*  Enabled: true
+            .*DeploymentConfig:
+            .*  EnvironmentType: my-env
+            .*MlpConfig:
+            .*  URL: http://mlp.my-namespace.svc.cluster.local:8080

--- a/charts/xp-management/values.yaml
+++ b/charts/xp-management/values.yaml
@@ -5,12 +5,15 @@ global:
   sentry:
     # -- (string) Global Sentry DSN value
     dsn:
+<<<<<<< HEAD
   mlp:
     apiPrefix: ""
     serviceName: mlp
     externalPort: "8080"
     useServiceFqdn: true
 
+=======
+>>>>>>> d030473 (fix(xp): helper func values fix)
 
 deployment:
   image:

--- a/charts/xp-management/values.yaml
+++ b/charts/xp-management/values.yaml
@@ -5,15 +5,12 @@ global:
   sentry:
     # -- (string) Global Sentry DSN value
     dsn:
-<<<<<<< HEAD
   mlp:
     apiPrefix: ""
     serviceName: mlp
     externalPort: "8080"
     useServiceFqdn: true
 
-=======
->>>>>>> d030473 (fix(xp): helper func values fix)
 
 deployment:
   image:


### PR DESCRIPTION
# Motivation
Since MLP url value is used in determining the value for the default config, the overwrite in the config generation is causing issues. It results in the generated value never being used.  This MR fixes the same. 

# Modification
* update config generation logic. 
* Add tests.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
