### PR TITLE
chore(caraml): bump up common chart version

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,10 +15,10 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.8"
+appVersion: "0.2.9"

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,8 +1,8 @@
 # common
 
 ---
-![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square)
-![AppVersion: 0.2.8](https://img.shields.io/badge/AppVersion-0.2.8-informational?style=flat-square)
+![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square)
+![AppVersion: 0.2.9](https://img.shields.io/badge/AppVersion-0.2.9-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
# Motivation
In #254, a tiny change was made to one of the comments in the templates of the `common` chart, though the overall chart version was not updated. This caused an error to occur in the CD job to release a new chart version: https://github.com/caraml-dev/helm-charts/actions/runs/5342383824/jobs/9684150972#step:6:58. 

This PR simply bumps up the common chart version to fix the issue above. 

# Modification

# Checklist
- [x] Chart version bumped
- [x] README.md updated
