### PR TITLE
chore(xp-treatment): Upgrade hpa API to autoscaling/v2

### DIFF
--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.14
+version: 0.1.15

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments

--- a/charts/xp-treatment/templates/hpa.yaml
+++ b/charts/xp-treatment/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "treatment-svc.fullname" . }}


### PR DESCRIPTION
# Motivation
Autoscaling API version `autoscaling/v2beta2` is removed in Kubernetes 1.26: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126

# Modification
Upgrading the xp-treatment chart to use `autoscaling/v2` that's available since Kubernetes 1.23

# Checklist
- [x] Chart version bumped
- [x] README.md updated
