### PR TITLE
fix(merlin): Add additional default values

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.11.2
+version: 0.11.3

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -198,7 +198,6 @@ The following table lists the configurable parameters of the Merlin chart and th
 | imageBuilder.builderConfig.BaseImages."3.7.*".DockerfilePath | string | `"docker/Dockerfile"` |  |
 | imageBuilder.builderConfig.BaseImages."3.7.*".ImageName | string | `"pyfunc-py37:v0.1.0"` |  |
 | imageBuilder.builderConfig.BaseImages."3.7.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
-| imageBuilder.builderConfig.BuildContextURI | string | `"git://github.com/caraml-dev/merlin.git#refs/heads/main"` |  |
 | imageBuilder.builderConfig.BuildNamespace | string | `"mlp"` |  |
 | imageBuilder.builderConfig.BuildTimeout | string | `"30m"` |  |
 | imageBuilder.builderConfig.DockerRegistry | string | `"dockerRegistry"` |  |
@@ -210,7 +209,6 @@ The following table lists the configurable parameters of the Merlin chart and th
 | imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".DockerfilePath | string | `"docker/app.Dockerfile"` |  |
 | imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".ImageName | string | `"pyspark-py37:v0.1.0"` |  |
 | imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
-| imageBuilder.builderConfig.PredictionJobBuildContextURI | string | `"git://github.com/caraml-dev/merlin.git#refs/heads/main"` |  |
 | imageBuilder.builderConfig.Resources.Limits.CPU | string | `"1"` |  |
 | imageBuilder.builderConfig.Resources.Limits.Memory | string | `"1Gi"` |  |
 | imageBuilder.builderConfig.Resources.Requests.CPU | string | `"1"` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.11.2](https://img.shields.io/badge/Version-0.11.2-informational?style=flat-square)
+![Version: 0.11.3](https://img.shields.io/badge/Version-0.11.3-informational?style=flat-square)
 ![AppVersion: v0.27.0-rc1](https://img.shields.io/badge/AppVersion-v0.27.0--rc1-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -143,6 +143,10 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.StandardTransformerConfig.Jaeger.SamplerType | string | `"const"` |  |
 | config.StandardTransformerConfig.Kafka.Brokers | string | `"kafka-brokers"` |  |
 | config.StandardTransformerConfig.Kafka.MaxMessageSizeBytes | string | `"1048588"` |  |
+| config.StandardTransformerConfig.ModelClientKeepAlive.Enabled | bool | `false` |  |
+| config.StandardTransformerConfig.ModelClientKeepAlive.Time | string | `"60s"` |  |
+| config.StandardTransformerConfig.ModelClientKeepAlive.Timeout | string | `"5s"` |  |
+| config.StandardTransformerConfig.ModelServerConnCount | int | `10` |  |
 | config.StandardTransformerConfig.SimulationFeast.FeastBigtableURL | string | `"online-serving-bt.feast.dev"` |  |
 | config.StandardTransformerConfig.SimulationFeast.FeastRedisURL | string | `"online-serving-redis.feast.dev"` |  |
 | deployment.extraArgs | list | `[]` | List of string containing additional Merlin API server arguments. For example, multiple "-config" can be specified to use multiple config files |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -86,7 +86,6 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.FeatureToggleConfig.MonitoringConfig.MonitoringJobBaseURL | string | `""` |  |
 | config.LoggerDestinationURL | string | `"http://yourDestinationLogger"` |  |
 | config.MlpAPIConfig.APIHost | string | `"http://mlp:8080"` |  |
-| config.MlpAPIConfig.EncryptionKey | string | `"secret-encryption"` |  |
 | config.NewRelic.AppName | string | `"merlin-api-dev"` |  |
 | config.NewRelic.Enabled | bool | `false` |  |
 | config.NewRelic.IgnoreStatusCodes[0] | int | `400` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -157,7 +157,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.registry | string | `"ghcr.io"` |  |
 | deployment.image.repository | string | `"caraml-dev/merlin"` |  |
-| deployment.image.tag | string | `"0.0.0-2de575c41980f5584e099aa31a78653610eb727f"` |  |
+| deployment.image.tag | string | `"0.0.0-271a1277dd8d63acc114ace44310e207b04751dc"` |  |
 | deployment.labels | object | `{}` |  |
 | deployment.podLabels | object | `{}` |  |
 | deployment.replicaCount | string | `"2"` |  |

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -5,7 +5,7 @@ deployment:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: caraml-dev/merlin
-    tag: 0.0.0-2de575c41980f5584e099aa31a78653610eb727f
+    tag: 0.0.0-271a1277dd8d63acc114ace44310e207b04751dc
   replicaCount: "2"
   # Additional labels to apply to the deployment
   labels: {}

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -112,8 +112,6 @@ config:
       CacheCleanUpIntervalSeconds: 900
   MlpAPIConfig:
     APIHost: http://mlp:8080
-    # EncryptionKey must be specified using --set flag.
-    EncryptionKey: secret-encryption
   FeatureToggleConfig:
     MonitoringConfig:
       MonitoringEnabled: false

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -256,8 +256,6 @@ imageBuilder:
         BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
         MainAppPath: /merlin-spark-app/main.py
     BuildNamespace: "mlp"
-    BuildContextURI: git://github.com/caraml-dev/merlin.git#refs/heads/main
-    PredictionJobBuildContextURI: git://github.com/caraml-dev/merlin.git#refs/heads/main
     DockerRegistry: "dockerRegistry"
     BuildTimeout: "30m"
     KanikoImage: "gcr.io/kaniko-project/executor:v1.6.0"

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -193,6 +193,11 @@ config:
       Enabled: false
       Time: 60s
       Timeout: 5s
+    ModelClientKeepAlive:
+      Enabled: false
+      Time: 60s
+      Timeout: 5s
+    ModelServerConnCount: 10
     DefaultFeastSource: 2
     FeastCoreURL: core.feast.dev
     FeastCoreAuthAudience: core.feast.dev


### PR DESCRIPTION
# Motivation
In #254, a new schema was introduced due to the refactored Helm chart. #306 then tried to address some of the formatting issues with the chart as it was subsequently discovered that the refactoring was not without issues. However, it is found again that certain default Helm chart values which were originally present have been unintentionally removed; this PR thus adds these values back again (in its new yaml based schema) so that consumers of the Merlin chart do not need to explicitly specify them. 

This PR also removes fields unused by the Merlin API server:
- `BuildContextURI` - see this PR https://github.com/caraml-dev/merlin/pull/416/files
- `PredictionJobBuildContextURI` - see this PR https://github.com/caraml-dev/merlin/pull/416/files
- `EncryptionKey` - see https://github.com/caraml-dev/merlin/blob/main/api/config/config.go#L291

# Modification
- Addition of missing default Helm chart values
- Removal of Helm chart values that are not consumed by the Merlin API server

# Checklist
- [x] Chart version bumped
- [x] README.md updated
