### PR TITLE
chore: add max conns, max-idle-conns for db connection for caraml-authz

### DIFF
--- a/charts/caraml-authz/Chart.yaml
+++ b/charts/caraml-authz/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: authz
-version: 0.1.11
+version: 0.1.12

--- a/charts/caraml-authz/README.md
+++ b/charts/caraml-authz/README.md
@@ -1,6 +1,6 @@
 # authz
 
-![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
+![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
 
 Helm chart for deploying Ory Keto
 

--- a/charts/caraml-authz/templates/_helpers.tpl
+++ b/charts/caraml-authz/templates/_helpers.tpl
@@ -57,7 +57,7 @@ app.kubernetes.io/part-of: caraml
 
 
 {{- define "caraml-authz.postgresql.dsn" -}}
-    {{- printf "postgres://%s:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/%s?sslmode=disable"
+    {{- printf "postgres://%s:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/%s?sslmode=disable&max_conns=0&max_idle_conns=0"
         (include "common.postgres-username" (list (index .Values "caraml-authz-postgresql") .Values.caramlAuthzExternalPostgresql .Values.global ))
         (include "common.postgres-database" (list (index .Values "caraml-authz-postgresql") .Values.caramlAuthzExternalPostgresql .Values.global "authz" "postgresqlDatabase"))
     -}}

--- a/charts/caraml-authz/tests/deployment_test.yaml
+++ b/charts/caraml-authz/tests/deployment_test.yaml
@@ -36,7 +36,7 @@ tests:
           value: my-release-authz-postgresql.my-namespace.svc.cluster.local
       - equal: # check database DSN url
           path: spec.template.spec.containers[0].env[2].value
-          value: postgres://authz:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/authz?sslmode=disable
+          value: postgres://authz:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/authz?sslmode=disable&max_conns=0&max_idle_conns=0
       - equal: # check database secret name
           path: spec.template.spec.initContainers[0].env[0].valueFrom.secretKeyRef.name
           value: my-release-authz-postgresql
@@ -51,7 +51,7 @@ tests:
           value: my-release-authz-postgresql.my-namespace.svc.cluster.local
       - equal: # check database DSN url
           path: spec.template.spec.initContainers[0].env[2].value
-          value: postgres://authz:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/authz?sslmode=disable
+          value: postgres://authz:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/authz?sslmode=disable&max_conns=0&max_idle_conns=0
 
   - it: should set database secret key and name from values if chart specific db is disabled, external db is enabled, secret name & key are set
     set:
@@ -85,7 +85,7 @@ tests:
           value: caraml-authz-ext-db-address
       - equal: # check database DSN url
           path: spec.template.spec.containers[0].env[2].value
-          value: postgres://caraml-authz-ext:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/caraml-authz-ext?sslmode=disable
+          value: postgres://caraml-authz-ext:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/caraml-authz-ext?sslmode=disable&max_conns=0&max_idle_conns=0
       - equal: # check database secret name
           path: spec.template.spec.initContainers[0].env[0].valueFrom.secretKeyRef.name
           value: ext-postgres-secret
@@ -100,7 +100,7 @@ tests:
           value: caraml-authz-ext-db-address
       - equal: # check database DSN url
           path: spec.template.spec.initContainers[0].env[2].value
-          value: postgres://caraml-authz-ext:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/caraml-authz-ext?sslmode=disable
+          value: postgres://caraml-authz-ext:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/caraml-authz-ext?sslmode=disable&max_conns=0&max_idle_conns=0
 
   - it: should set database secret key and name from values if chart specific db is disabled, external db is disabled
     set:
@@ -133,7 +133,7 @@ tests:
           value: my-release-postgresql.my-namespace.svc.cluster.local
       - equal: # check database DSN url
           path: spec.template.spec.containers[0].env[2].value
-          value: postgres://caraml-authz-global:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/caraml-authz-global?sslmode=disable
+          value: postgres://caraml-authz-global:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/caraml-authz-global?sslmode=disable&max_conns=0&max_idle_conns=0
       - equal: # check database secret name
           path: spec.template.spec.initContainers[0].env[0].valueFrom.secretKeyRef.name
           value: my-release-postgresql
@@ -148,4 +148,4 @@ tests:
           value: my-release-postgresql.my-namespace.svc.cluster.local
       - equal: # check database DSN url
           path: spec.template.spec.initContainers[0].env[2].value
-          value: postgres://caraml-authz-global:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/caraml-authz-global?sslmode=disable
+          value: postgres://caraml-authz-global:$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/caraml-authz-global?sslmode=disable&max_conns=0&max_idle_conns=0


### PR DESCRIPTION
# Motivation
> set MaxIdleConns and MaxOpenConns to 0, which means there will be [no limit to the number of open connections to the database](https://pkg.go.dev/database/sql#DB.SetMaxOpenConns)

To restrict the number of open and idle connections to the database. 

# Modification

# Checklist
- [x] Chart version bumped
- [x] README.md updated
