### PR TITLE
fix: XP Management Service can be deployed with existing SA

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.2.3
+version: 0.2.4

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -32,9 +32,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ include "management-svc.serviceAccountName" . }}
-      {{- end }}
       containers:
       - name: api
         image: "{{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
# Motivation
Currently, it is not possible to deploy the XP Management Service with an existing SA.

# Modification
This PR updates the XP Management Service deployment specs to always associate an SA - it will be created if `serviceAccount.create` is set to true. If not, the chart will expect an existing SA. This is similar to Turing and other charts.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
