### PR TITLE
feat(merlin): Remove unused key and add new one for jaeger collector URL

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.27.0-rc1
+appVersion: v0.31.0-rc1
 dependencies:
 - alias: merlin-postgresql
   condition: merlin-postgresql.enabled
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.11.3
+version: 0.11.4

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,8 +1,8 @@
 # merlin
 
 ---
-![Version: 0.11.3](https://img.shields.io/badge/Version-0.11.3-informational?style=flat-square)
-![AppVersion: v0.27.0-rc1](https://img.shields.io/badge/AppVersion-v0.27.0--rc1-informational?style=flat-square)
+![Version: 0.11.4](https://img.shields.io/badge/Version-0.11.4-informational?style=flat-square)
+![AppVersion: v0.31.0-rc1](https://img.shields.io/badge/AppVersion-v0.31.0--rc1-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -135,11 +135,9 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.StandardTransformerConfig.FeastServingURLs[1].Label | string | `"Online Serving with BigTable"` |  |
 | config.StandardTransformerConfig.FeastServingURLs[1].SourceType | string | `"BIGTABLE"` |  |
 | config.StandardTransformerConfig.ImageName | string | `"merlin-transformer:1.0.0"` |  |
-| config.StandardTransformerConfig.Jaeger.AgentHost | string | `"localhost"` |  |
-| config.StandardTransformerConfig.Jaeger.AgentPort | int | `6831` |  |
+| config.StandardTransformerConfig.Jaeger.CollectorURL | string | `"http://jaeger-tracing-collector.infrastructure:14268/api/traces"` |  |
 | config.StandardTransformerConfig.Jaeger.Disabled | bool | `false` |  |
 | config.StandardTransformerConfig.Jaeger.SamplerParam | int | `1` |  |
-| config.StandardTransformerConfig.Jaeger.SamplerType | string | `"const"` |  |
 | config.StandardTransformerConfig.Kafka.Brokers | string | `"kafka-brokers"` |  |
 | config.StandardTransformerConfig.Kafka.MaxMessageSizeBytes | string | `"1048588"` |  |
 | config.StandardTransformerConfig.ModelClientKeepAlive.Enabled | bool | `false` |  |

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -201,9 +201,7 @@ config:
     FeastCoreAuthAudience: core.feast.dev
     EnableAuth: false
     Jaeger:
-      AgentHost: localhost
-      AgentPort: 6831
-      SamplerType: const
+      CollectorURL: "http://jaeger-tracing-collector.infrastructure:14268/api/traces"
       SamplerParam: 1
       Disabled: false
     Kafka:


### PR DESCRIPTION
# Motivation
Since standard transformer use opentelemetry for tracing, previous env variable for jaeger tracing is not usable. Hence this PR remove unused keys and add new collector endpoint url

# Modification
* Remove unused jaeger env variable
* Adding colector endpoint url 

# Checklist
- [x] Chart version bumped
- [x] README.md updated
