### PR TITLE
feat: add ability to provision oathkeeper rules

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.11.4
+version: 0.12.0

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.11.4](https://img.shields.io/badge/Version-0.11.4-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square)
 ![AppVersion: v0.31.0-rc1](https://img.shields.io/badge/AppVersion-v0.31.0--rc1-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
@@ -329,6 +329,8 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlflowExternalPostgresql.username | string | `"mlflow"` | External postgres database user |
 | mlp.enabled | bool | `true` |  |
 | mlp.environmentConfigSecret.name | string | `""` |  |
+| rules.apiPrefixRegex | string | `".+"` |  |
+| rules.enabled | bool | `false` | Enable this to provision Oathkeeper Rule CRDs for Merlin API endpoints |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/merlin/templates/merlin-rules.yaml
+++ b/charts/merlin/templates/merlin-rules.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.rules.enabled }}
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: {{ template "merlin.fullname" . }}-project-sub-resources
+  namespace: {{ .Release.Namespace }}
+spec:
+  match:
+    url: <{{ .Values.rules.apiPrefixRegex }}>/projects/<[0-9]+><(/.+)?>
+    methods:
+      - "GET"
+      - "POST"
+      - "PUT"
+      - "DELETE"
+      - "PATCH"
+  authenticators:
+    - handler: jwt
+  authorizer:
+    handler: remote_json
+    config:
+      payload: |
+        {
+          "namespace": "Permission",
+          "object": {{`"mlp.projects.{{ printIndex .MatchContext.RegexpCaptureGroups 1 }}.{{ (print .MatchContext.Method) | lower }}"`}},
+          "relation": "granted",
+            "subject_set": {
+                "namespace": "Subject",
+                "object": {{`"{{ print .Extra.email }}"`}}
+            }
+        }
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: {{ template "merlin.fullname" . }}-standard-transformer-simulate
+  namespace: {{ .Release.Namespace }}
+spec:
+  match:
+    url: <{{ .Values.rules.apiPrefixRegex }}>/standard-transformer/simulate
+    methods:
+      - "GET"
+  authenticators:
+    - handler: jwt
+  authorizer:
+    handler: allow
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: {{ template "merlin.fullname" . }}-models
+  namespace: {{ .Release.Namespace }}
+spec:
+  match:
+    url: <{{ .Values.rules.apiPrefixRegex }}>/models<(/.+)?>
+    methods:
+      - "GET"
+      - "POST"
+      - "PATCH"
+      - "PUT"
+      - "DELETE"
+  authenticators:
+    - handler: jwt
+  authorizer:
+    handler: allow
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: {{ template "merlin.fullname" . }}-team-alerts
+  namespace: {{ .Release.Namespace }}
+spec:
+  match:
+    url: <{{ .Values.rules.apiPrefixRegex }}>/alerts/teams
+    methods:
+      - "GET"
+  authenticators:
+    - handler: jwt
+  authorizer:
+    handler: allow
+{{- end -}}

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -654,3 +654,8 @@ kserve:
         istioIngressGateway:
           helmChart:
             namespace: "istio-system"
+
+rules:
+  # -- Enable this to provision Oathkeeper Rule CRDs for Merlin API endpoints
+  enabled: false
+  apiPrefixRegex: ".+"

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.32
+version: 0.3.1

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.32](https://img.shields.io/badge/Version-0.2.32-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
@@ -91,6 +91,8 @@ The following table lists the configurable parameters of the Turing chart and th
 | mlp.enabled | bool | `true` |  |
 | mlp.environmentConfigSecret.name | string | `""` |  |
 | openApiSpecOverrides | object | `{}` | Override OpenAPI spec as long as it follows the OAS3 specifications. A common use for this is to set the enums of the ExperimentEngineType. See api/api/override-sample.yaml for an example. |
+| rules.apiPrefixRegex | string | `".+"` |  |
+| rules.enabled | bool | `false` | Enable this to provision Oathkeeper Rule CRDs for Turing API endpoints |
 | sentry.dsn | string | `""` | Sentry DSN value used by both Turing API and Turing UI |
 | service.externalPort | int | `8080` | Turing API Kubernetes service port number |
 | service.internalPort | int | `8080` | Turing API container port number |

--- a/charts/turing/templates/turing-rules.yaml
+++ b/charts/turing/templates/turing-rules.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.rules.enabled }}
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: {{ template "turing.fullname" . }}-project-sub-resources
+  namespace: {{ .Release.Namespace }}
+spec:
+  match:
+    url: <{{ .Values.rules.apiPrefixRegex }}>/projects/<[0-9]+><(/.+)?>
+    methods:
+      - "GET"
+      - "POST"
+      - "PUT"
+      - "DELETE"
+      - "PATCH"
+  authenticators:
+    - handler: jwt
+  authorizer:
+    handler: remote_json
+    config:
+      payload: |
+        {
+          "namespace": "Permission",
+          "object": {{`"mlp.projects.{{ printIndex .MatchContext.RegexpCaptureGroups 1 }}.{{ (print .MatchContext.Method) | lower }}"`}},
+          "relation": "granted",
+            "subject_set": {
+                "namespace": "Subject",
+                "object": {{`"{{ print .Extra.email }}"`}}
+            }
+        }
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: {{ template "turing.fullname" . }}-experimental-engines
+  namespace: {{ .Release.Namespace }}
+spec:
+  match:
+    url: <{{ .Values.rules.apiPrefixRegex }}>/experiment-engines<(/.+)?>
+    methods:
+      - "GET"
+  authenticators:
+    - handler: jwt
+  authorizer:
+    handler: allow
+{{- end -}}

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -311,3 +311,8 @@ merlin:
   enabled: true
   mlp:
     enabled: false
+
+rules:
+  # -- Enable this to provision Oathkeeper Rule CRDs for Turing API endpoints
+  enabled: false
+  apiPrefixRegex: ".+"

--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.2.4
+version: 0.3.0

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments
@@ -69,6 +69,8 @@ The following table lists the configurable parameters of the XP Management Servi
 | global.mlp.useServiceFqdn | bool | `true` |  |
 | global.protocol | string | `"http"` |  |
 | global.sentry.dsn | string | `nil` | Global Sentry DSN value |
+| rules.apiPrefixRegex | string | `".+"` |  |
+| rules.enabled | bool | `false` | Enable this to provision Oathkeeper Rule CRDs for XP management service API endpoints |
 | swaggerUi.apiServer | string | `"http://127.0.0.1/v1"` | URL of API server |
 | swaggerUi.enabled | bool | `true` |  |
 | swaggerUi.image | object | `{"tag":"v3.47.1"}` | Docker tag for Swagger UI https://hub.docker.com/r/swaggerapi/swagger-ui |

--- a/charts/xp-management/templates/rules.yaml
+++ b/charts/xp-management/templates/rules.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.rules.enabled }}
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: {{ template "management-svc.fullname" . }}-project-sub-resources
+  namespace: {{ .Release.Namespace }}
+spec:
+  match:
+    url: <{{ .Values.rules.apiPrefixRegex }}>/projects/<[0-9]+><(/.+)?>
+    methods:
+      - "GET"
+      - "POST"
+      - "PUT"
+      - "DELETE"
+      - "PATCH"
+  authenticators:
+    - handler: jwt
+  authorizer:
+    handler: remote_json
+    config:
+      payload: |
+        {
+          "namespace": "Permission",
+          "object": {{`"mlp.projects.{{ printIndex .MatchContext.RegexpCaptureGroups 1 }}.{{ (print .MatchContext.Method) | lower }}"`}},
+          "relation": "granted",
+            "subject_set": {
+                "namespace": "Subject",
+                "object": {{`"{{ print .Extra.email }}"`}}
+            }
+        }
+---
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: {{ template "management-svc.fullname" . }}-public-resources
+  namespace: {{ .Release.Namespace }}
+spec:
+  match:
+    url: <{{ .Values.rules.apiPrefixRegex }}>/<(treatment-service-config|validate)>
+    methods:
+      - "GET"
+      - "POST"
+      - "PATCH"
+      - "PUT"
+      - "DELETE"
+  authenticators:
+    - handler: jwt
+  authorizer:
+    handler: allow
+{{- end -}}

--- a/charts/xp-management/values.yaml
+++ b/charts/xp-management/values.yaml
@@ -227,3 +227,8 @@ swaggerUi:
     internalPort: 8081
     # -- Swagger UI Kubernetes service port number
     externalPort: 3000
+
+rules:
+  # -- Enable this to provision Oathkeeper Rule CRDs for XP management service API endpoints
+  enabled: false
+  apiPrefixRegex: ".+"

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.18
+version: 0.2.0

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments
@@ -67,6 +67,8 @@ The following table lists the configurable parameters of the XP Treatment Servic
 | ingress.class | string | `""` | Ingress class annotation to add to this Ingress rule, useful when there are multiple ingress controllers installed |
 | ingress.enabled | bool | `false` | Enable ingress to provision Ingress resource for external access to XP Treatment Service |
 | ingress.host | string | `""` | Set host value to enable name based virtual hosting. This allows routing HTTP traffic to multiple host names at the same IP address. If no host is specified, the ingress rule applies to all inbound HTTP traffic through the IP address specified. https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting |
+| rules.apiPrefixRegex | string | `".+"` |  |
+| rules.enabled | bool | `false` | Enable this to provision Oathkeeper Rule CRDs for Treatment service API endpoints |
 | swaggerUi.apiServer | string | `"http://127.0.0.1/v1"` | URL of API server |
 | swaggerUi.enabled | bool | `false` |  |
 | swaggerUi.image | object | `{"tag":"v3.47.1"}` | Docker tag for Swagger UI https://hub.docker.com/r/swaggerapi/swagger-ui |

--- a/charts/xp-treatment/templates/rules.yaml
+++ b/charts/xp-treatment/templates/rules.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.rules.enabled }}
+apiVersion: oathkeeper.ory.sh/v1alpha1
+kind: Rule
+metadata:
+  name: {{ template "treatment-svc.fullname" . }}-project-sub-resources
+  namespace: {{ .Release.Namespace }}
+spec:
+  match:
+    url: <{{ .Values.rules.apiPrefixRegex }}>/projects/<[0-9]+><(/.+)?>
+    methods:
+      - "GET"
+      - "POST"
+      - "PUT"
+      - "DELETE"
+      - "PATCH"
+  authenticators:
+    - handler: jwt
+  authorizer:
+    handler: remote_json
+    config:
+      payload: |
+        {
+          "namespace": "Permission",
+          "object": {{`"mlp.projects.{{ printIndex .MatchContext.RegexpCaptureGroups 1 }}.{{ (print .MatchContext.Method) | lower }}"`}},
+          "relation": "granted",
+            "subject_set": {
+                "namespace": "Subject",
+                "object": {{`"{{ print .Extra.email }}"`}}
+            }
+        }
+{{- end -}}

--- a/charts/xp-treatment/values.yaml
+++ b/charts/xp-treatment/values.yaml
@@ -124,3 +124,8 @@ swaggerUi:
     internalPort: 8081
     # -- Swagger UI Kubernetes service port number
     externalPort: 8080
+
+rules:
+  # -- Enable this to provision Oathkeeper Rule CRDs for Treatment service API endpoints
+  enabled: false
+  apiPrefixRegex: ".+"


### PR DESCRIPTION
# Motivation
This allows Turing, XP and Merlin services to integrate with Oathkeeper, by providing an option to generate Oathkeeper Rule CRDs when enabled.

Related PRs: https://github.com/caraml-dev/helm-charts/pull/318

# Modification
The Oathkeeper rules is by default disabled, so this should be compatible with old app versions that is still using Keto 0.5.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
