### PR TITLE
fix(xp-treatment): Fix indentation in helm chart

### DIFF
--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.18
+version: 0.1.19

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square)
+![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments

--- a/charts/xp-treatment/templates/deployment.yaml
+++ b/charts/xp-treatment/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         env:
           {{- with .Values.deployment.extraEnvs }}
-          {{- toYaml . | nindent 12 }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
         ports:
           - name: http
@@ -62,7 +62,7 @@ spec:
           successThreshold: {{ .Values.deployment.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
         resources:
-          {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- toYaml .Values.deployment.resources | nindent 10 }}
         # Give time for running pods to terminate existing connection before letting
         # Kubernetes terminate the pods.
         # https://blog.sebastian-daschner.com/entries/zero-downtime-updates-kubernetes


### PR DESCRIPTION
# Motivation
This PR fixes some over-indentation issues with the chart values in the `xp-treatment` chart.

# Modification
- `charts/xp-treatment/Chart.yaml` - Bump up chart version
- `charts/xp-treatment/README.md` - Bump up chart version
- `charts/xp-treatment/templates/deployment.yaml` - Reduce indentation units

# Checklist
- [x] Chart version bumped
- [x] README.md updated
