### PR TITLE
chore(turing): remove conversion of k8sConfig to json

### DIFF
--- a/charts/turing/Chart.lock
+++ b/charts/turing/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.4.20
 - name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.10.21
+  version: 0.11.4
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
-digest: sha256:eba115580b531d18b64cd1d5466d67b66e3ef7e4eb1f748c57c8cb6aad4be668
-generated: "2023-06-26T06:22:00.302970664Z"
+digest: sha256:cd2b32a818895fd4207e259ce5636837e42c137b2eadf8195af61678a51fcfb2
+generated: "2023-07-26T10:09:25.274362+08:00"

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: merlin.enabled
   name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.10.21
+  version: 0.11.4
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.32
+version: 0.2.33

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.32](https://img.shields.io/badge/Version-0.2.32-informational?style=flat-square)
+![Version: 0.2.33](https://img.shields.io/badge/Version-0.2.33-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the Turing chart and th
 | experimentEngines | list | `[]` | Turing Experiment Engines configuration |
 | global.protocol | string | `"http"` |  |
 | imageBuilder.clusterName | string | `"test"` |  |
-| imageBuilder.k8sConfig | string | `""` |  |
+| imageBuilder.k8sConfig | object | `{}` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.class | string | `""` | Ingress class annotation to add to this Ingress rule, useful when there are multiple ingress controllers installed |
 | ingress.enabled | bool | `false` | Enable ingress to provision Ingress resource for external access to Turing API |

--- a/charts/turing/ci/ci-values.yaml
+++ b/charts/turing/ci/ci-values.yaml
@@ -74,8 +74,9 @@ merlin:
       limits:
         cpu: "500m"
         memory: 512Mi
-  authorization:
-    enabled: false
+  config:
+    AuthorizationConfig:
+      AuthorizationEnabled: false
   imageBuilder: *imageBuilder
   environmentConfigs: *environmentConfigs
   merlin-postgresql:

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -184,7 +184,7 @@ ClusterConfig:
   InClusterConfig: {{ .Values.clusterConfig.useInClusterConfig }}
   EnvironmentConfigPath: {{ include "turing.environments.absolutePath" . }}
   EnsemblingServiceK8sConfig: 
-{{ .Values.imageBuilder.k8sConfig | fromJson | toYaml | indent 4}}
+{{ .Values.imageBuilder.k8sConfig | toYaml | indent 4}}
 DbConfig:
   Host: {{ include "common.postgres-host" (list (index .Values "turing-postgresql") .Values.turingExternalPostgresql .Release .Chart ) }}
   Port: 5432

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -85,26 +85,19 @@ clusterConfig:
 
 imageBuilder:
   clusterName: "test"
-  k8sConfig: ''
-  # Example json
-  # '{
-  #   "name": "dev-cluster",
-  #   "cluster": {
-  #     "server": "https://k8s.cluster",
-  #     "certificate-authority-data": "some_cert_data"
-  #   },
-  #   "user": {
-  #     "exec": {
-  #       "apiVersion": "client.authentication.k8s.io/v1beta1",
-  #       "args": [
-  #         "--use_application_default_credentials"
-  #       ],
-  #       "command": "gke-gcloud-auth-plugin",
-  #       "interactiveMode": "IfAvailable",
-  #       "provideClusterInfo": true
-  #     }
-  #   }
-  # }'
+  k8sConfig: {}
+  # Example k8sConfig to connect to cluster using gke-gcloud-auth-plugin
+  # name: dev-cluster
+  # cluster:
+  #   server: https://k8s.cluster
+  #   certificate-authority-data: some_cert_data
+  # user:
+  #   exec:
+  #     apiVersion: client.authentication.k8s.io/v1beta1
+  #     args: ["--use_application_default_credentials"]
+  #     command: gke-gcloud-auth-plugin
+  #     interactiveMode: IfAvailable
+  #     provideClusterInfo: true
 
 # -- Set this field to configure environment configs. See api/environments-dev.yaml for sample structure
 environmentConfigs:

--- a/scripts/generate-cluster-creds.sh
+++ b/scripts/generate-cluster-creds.sh
@@ -97,14 +97,8 @@ EOF
   for APP in merlin turing
   do
     # TODO: REMOVE ALL CONDITIONAL STATEMENTS AND USE ONLY YAML CREDS ONCE TURING HAS BEEN REFACTORED
-    # Write to Merlin/ Turing image builder app chart values
-    if [ $APP == "merlin" ]; then
-      yaml_creds="$yaml_creds" yq ".imageBuilder.k8sConfig |= env(yaml_creds)" -i "${SCRIPT_DIR}/../charts/${APP}/ci/ci-values.yaml"
-    else
-      json_creds="$json_creds" yq ".imageBuilder.k8sConfig |= strenv(json_creds)" -i "${SCRIPT_DIR}/../charts/${APP}/ci/ci-values.yaml"
-    fi
-    # Write to Merlin/ Turing env configs app chart values
-    yq ".environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\")" -i "${SCRIPT_DIR}/../charts/${APP}/ci/ci-values.yaml"
+    # Write to Merlin/ Turing image builder and env configs app chart values
+    yaml_creds="$yaml_creds" yq ".environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\") | .imageBuilder.k8sConfig |= env(yaml_creds)" -i "${SCRIPT_DIR}/../charts/${APP}/ci/ci-values.yaml"
 
     # Write to Merlin/ Turing image builder app in the overarching CaraML chart
     if [ $APP == "merlin" ]; then


### PR DESCRIPTION
# Motivation
The GitHub PR addresses two separate issues, with two separate changes:
- The Merlin chart dependency in Turing is (very) outdated (`0.10.21`)-> Bump up Merlin version (`0.11.4`) 
- Fixing the `cannot overwrite table with non table for merlin.imageBuilder.k8sConfig (map[])` warning when running `helm template .` or `helm lint .` in `helm-charts/charts/turing` -> Convert the `imageBuilder.k8sConfig` struct into a YAML map just like for Merlin 

The first issue's self evident so nothing much to talk there. As for the second, it turns out after some debugging that the recursive `coalesceTablesFullKey` [function](https://github.com/helm/helm/blob/v3.12.2/pkg/chartutil/coalesce.go#L220) (from Helm) called onto the YAML configs in the parent Turing values file actually causes `imageBuilder.k8sConfig` (an empty string) to be matched with `imageBuilder.k8sConfig` (a map) in the Merlin chart, so when it attempts to merge those two values, that warning occurs. However, that's not an issue because in the end `merlin.imageBuilder.k8sConfig` (a map) of the Turing chart values still gets matched with `imageBuilder.k8sConfig` (a map) in the Merlin chart, and the `coalesceTablesFullKey` function works properly as expected and merges both maps.

The bug's ultimately something on Helm's end and it affects reading a main chart's values that also happens to be exactly in the same schema as the subchart but it seems like they might've addressed this in one of their recent commits though it hasn't been released yet: https://github.com/helm/helm/commit/0a5148faffb7110bab58a466a52be0686a69947c (didn't really read into this but it mentioned fixing the priority of merging subchart values). So with that, we can temporarily silence the warning, refactor the schemas of both charts to make them different or, simply make both blocks have the same schema.

Anyway, with the refactoring of the Merlin configs from environment variables to a configs file, the `k8sConfig` struct has already been refactored from a JSON object to a YAML map. Turing however, still uses `k8sConfig` in JSON for consistency though that is no longer needed since Merlin no longer stores any of such structs in JSON. It thus makes complete sense to just modify the Turing chart to expect a `k8sConfig` struct in YAML just like in Merlin to address the second issue and to avoid that bug altogether in the process.

This PR thus implements the fix mentioned above.

No changes are expected downstream to the Turing app since it already expects a YAML map for the `k8sConfig`.

# Modification
- `charts/turing/values.yaml` - Default value for `imageBuilder.k8sConfig` is now changed to an empty map and not an empty string
- `charts/turing/templates/_helpers.tpl` - Since a JSON-string is no longer expected, there's no need for the `fromJson` function
- `scripts/generate-cluster-creds.sh` - Simplification of the cluster credentials generation script since we no longer did conditional handling for both Merlin and Turing

# Checklist
- [x] Chart version bumped
- [x] README.md updated
