### PR TITLE
chore(caraml): Update Turing chart version manually

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,7 +79,10 @@ jobs:
           CHARTS_CHANGED: ${{ steps.list-changed.outputs.charts_changed }}
         run: |
           if [[ $(echo $CHARTS_CHANGED | grep 'charts/\(merlin\|turing\|caraml\)') ]]; then
-            ./scripts/generate-cluster-creds.sh kind chart-testing
+            for CHART in $(echo $CHARTS_CHANGED | tr ' ' '\n' | grep 'charts/\(merlin\|turing\|caraml\)' | sed -r 's/charts\///')
+            do
+              CHART=$CHART ./scripts/generate-cluster-creds.sh kind chart-testing
+            done
           fi
 
       - name: Run chart-testing (install)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,10 +79,7 @@ jobs:
           CHARTS_CHANGED: ${{ steps.list-changed.outputs.charts_changed }}
         run: |
           if [[ $(echo $CHARTS_CHANGED | grep 'charts/\(merlin\|turing\|caraml\)') ]]; then
-            for CHART in $(echo $CHARTS_CHANGED | tr ' ' '\n' | grep 'charts/\(merlin\|turing\|caraml\)' | sed -r 's/charts\///')
-            do
-              CHART=$CHART ./scripts/generate-cluster-creds.sh kind chart-testing
-            done
+            CHARTS_CHANGED=$CHARTS_CHANGED ./scripts/generate-cluster-creds.sh kind chart-testing
           fi
 
       - name: Run chart-testing (install)

--- a/charts/caraml/Chart.lock
+++ b/charts/caraml/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.11.4
 - name: turing
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.32
+  version: 0.2.33
 - name: xp-treatment
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.1.18
@@ -44,5 +44,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.8.2
-digest: sha256:ac0dbb5db9620406e486d6f74546d13b3fc91ff87621bcb059cedabdbb51d184
-generated: "2023-07-25T18:10:47.628573+08:00"
+digest: sha256:006a0f81da5948fbfc6e6f7d06af362028322dca4aedd767b41ba04fbbabd8a4
+generated: "2023-07-27T13:39:49.31788+08:00"

--- a/charts/caraml/Chart.yaml
+++ b/charts/caraml/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 - condition: turing.enabled
   name: turing
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.32
+  version: 0.2.33
 - condition: xp-treatment.enabled
   name: xp-treatment
   repository: https://caraml-dev.github.io/helm-charts
@@ -72,4 +72,4 @@ maintainers:
   name: caraml-dev
 name: caraml
 type: application
-version: 0.6.12
+version: 0.6.13

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -1,6 +1,6 @@
 # caraml
 
-![Version: 0.6.12](https://img.shields.io/badge/Version-0.6.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.6.13](https://img.shields.io/badge/Version-0.6.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML components
 
@@ -23,7 +23,7 @@ A Helm chart for deploying CaraML components
 | https://caraml-dev.github.io/helm-charts | istiod(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | merlin | 0.11.4 |
 | https://caraml-dev.github.io/helm-charts | mlp | 0.5.2 |
-| https://caraml-dev.github.io/helm-charts | turing | 0.2.32 |
+| https://caraml-dev.github.io/helm-charts | turing | 0.2.33 |
 | https://caraml-dev.github.io/helm-charts | xp-management | 0.2.4 |
 | https://caraml-dev.github.io/helm-charts | xp-treatment | 0.1.18 |
 | https://charts.helm.sh/stable | postgresql | 7.0.2 |

--- a/scripts/generate-cluster-creds.sh
+++ b/scripts/generate-cluster-creds.sh
@@ -90,12 +90,11 @@ EOF
   fi
 
   output=$(yq '.k8s_config' /tmp/temp_k8sconfig.yaml)
-  # NOTE: Write to ci/ files as these files will be used in ci tests! Consider looping through all files
-  # in ci dir
+  # NOTE: Write to ci/ files as these files will be used in ci tests!
   for CHART in $(echo $CHARTS_CHANGED | tr ' ' '\n' | grep 'charts/\(merlin\|turing\|caraml\)' | sed -r 's/charts\///')
   do
     if [ $CHART == "caraml" ]; then
-      # Write to Merlin/ Turing image builder app in the overarching CaraML chart
+      # Write to Merlin/ Turing subchart values in the overarching CaraML chart
       for APP in merlin turing
       do
         output="$output" yq ".${APP}.environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\") | .${APP}.imageBuilder.k8sConfig |= env(output)" -i "${SCRIPT_DIR}/../charts/caraml/ci/ci-values.yaml"

--- a/scripts/generate-cluster-creds.sh
+++ b/scripts/generate-cluster-creds.sh
@@ -92,14 +92,18 @@ EOF
   output=$(yq '.k8s_config' /tmp/temp_k8sconfig.yaml)
   # NOTE: Write to ci/ files as these files will be used in ci tests! Consider looping through all files
   # in ci dir
-  if [ $CHART == "caraml" ]; then
-    for APP in merlin turing
-    do
-      output="$output" yq ".${APP}.environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\") | .${APP}.imageBuilder.k8sConfig |= env(output)" -i "${SCRIPT_DIR}/../charts/caraml/ci/ci-values.yaml"
-    done
-  else
-    output="$output" yq ".environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\") | .imageBuilder.k8sConfig |= env(output)" -i "${SCRIPT_DIR}/../charts/${CHART}/ci/ci-values.yaml"
-  fi
+  for CHART in $(echo $CHARTS_CHANGED | tr ' ' '\n' | grep 'charts/\(merlin\|turing\|caraml\)' | sed -r 's/charts\///')
+  do
+    if [ $CHART == "caraml" ]; then
+      # Write to Merlin/ Turing image builder app in the overarching CaraML chart
+      for APP in merlin turing
+      do
+        output="$output" yq ".${APP}.environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\") | .${APP}.imageBuilder.k8sConfig |= env(output)" -i "${SCRIPT_DIR}/../charts/caraml/ci/ci-values.yaml"
+      done
+    else
+      output="$output" yq ".environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\") | .imageBuilder.k8sConfig |= env(output)" -i "${SCRIPT_DIR}/../charts/${CHART}/ci/ci-values.yaml"
+    fi
+  done
 }
 
 main "$@"


### PR DESCRIPTION
# Motivation
This MR updates the version of Turing used in the overarching CaraML chart. In addition, it also cleans up the cluster credential generation script that's intended for both the Merlin and Turing apps, since both of them are now expecting these credentials to be passed in YAML.

# Modification
- `charts/caraml/Chart.yaml` - Bump up of Turing version
- `scripts/generate-cluster-creds.sh` - Clean up of cluster credential generation script

# Checklist
- [x] Chart version bumped
- [x] README.md updated
