### PR TITLE
fix(merlin): passing extraEnvs causing helm rendering error

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.11.4
+version: 0.11.5

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.11.4](https://img.shields.io/badge/Version-0.11.4-informational?style=flat-square)
+![Version: 0.11.5](https://img.shields.io/badge/Version-0.11.5-informational?style=flat-square)
 ![AppVersion: v0.31.0-rc1](https://img.shields.io/badge/AppVersion-v0.31.0--rc1-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -74,7 +74,7 @@ spec:
                 name: {{ include "common.postgres-password-secret-name" (list (index .Values "merlin-postgresql") .Values.merlinExternalPostgresql .Release .Chart ) }}
                 key: {{ include "common.postgres-password-secret-key" (list .Values.merlinExternalPostgresql) }}
           {{- with .Values.deployment.extraEnvs }}
-          {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
         volumeMounts:
         - name: config


### PR DESCRIPTION
# Motivation
Passing `extraEnvs`:
```yaml
deployment:
  extraEnvs: 
    - name: NAME
      value: VALUE
```
Causing rendering error:
```
Error: YAML parse error on caraml/charts/merlin/templates/merlin-deployment.yaml: error converting YAML to JSON: yaml: line 77: did not find expected key
```

# Modification
Fixing by changing `nindent` parameter from 8 to 10

# Checklist
- [x] Chart version bumped
- [x] README.md updated
