### PR TITLE
fix(merlin): Use include to get merlin.kaniko-sa value

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,36 +1,36 @@
 apiVersion: v2
 appVersion: v0.31.0-rc1
 dependencies:
-- alias: merlin-postgresql
-  condition: merlin-postgresql.enabled
-  name: postgresql
-  repository: https://charts.helm.sh/stable
-  version: 7.0.2
-- alias: mlflow-postgresql
-  condition: mlflow-postgresql.enabled
-  name: postgresql
-  repository: https://charts.helm.sh/stable
-  version: 7.0.2
-- condition: mlp.enabled
-  name: mlp
-  repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.20
-- alias: kserve
-  condition: kserve.enabled
-  name: generic-dep-installer
-  repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.1
-- alias: minio
-  condition: minio.enabled
-  name: generic-dep-installer
-  repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.1
-- name: common
-  repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.9
+  - alias: merlin-postgresql
+    condition: merlin-postgresql.enabled
+    name: postgresql
+    repository: https://charts.helm.sh/stable
+    version: 7.0.2
+  - alias: mlflow-postgresql
+    condition: mlflow-postgresql.enabled
+    name: postgresql
+    repository: https://charts.helm.sh/stable
+    version: 7.0.2
+  - condition: mlp.enabled
+    name: mlp
+    repository: https://caraml-dev.github.io/helm-charts
+    version: 0.4.20
+  - alias: kserve
+    condition: kserve.enabled
+    name: generic-dep-installer
+    repository: https://caraml-dev.github.io/helm-charts
+    version: 0.2.1
+  - alias: minio
+    condition: minio.enabled
+    name: generic-dep-installer
+    repository: https://caraml-dev.github.io/helm-charts
+    version: 0.2.1
+  - name: common
+    repository: https://caraml-dev.github.io/helm-charts
+    version: 0.2.9
 description: Kubernetes-friendly ML model management, deployment, and serving.
 maintainers:
-- email: caraml-dev@caraml.dev
-  name: caraml-dev
+  - email: caraml-dev@caraml.dev
+    name: caraml-dev
 name: merlin
-version: 0.11.5
+version: 0.11.6

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.11.5](https://img.shields.io/badge/Version-0.11.5-informational?style=flat-square)
+![Version: 0.11.6](https://img.shields.io/badge/Version-0.11.6-informational?style=flat-square)
 ![AppVersion: v0.31.0-rc1](https://img.shields.io/badge/AppVersion-v0.31.0--rc1-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -269,7 +269,7 @@ ImageBuilderConfig:
   K8sConfig:
 {{ .Values.imageBuilder.k8sConfig | toYaml | indent 4 }}
   {{- if .Values.imageBuilder.serviceAccount.name }}
-  KanikoServiceAccount: "{{ template "merlin.kaniko-sa" . }}"
+  KanikoServiceAccount: {{ include "merlin.kaniko-sa" . }}
   {{- end }}
 {{ .Values.imageBuilder.builderConfig | toYaml | indent 2 }}
 AuthorizationConfig:

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -110,4 +110,4 @@ tests:
           pattern: my-release-merlin-config$
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "KanikoServiceAccount: kaniko-merlin"
+          pattern: "KanikoServiceAccount: kaniko-my-release-merlin"

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -101,6 +101,7 @@ tests:
       imageBuilder:
         serviceAccount:
           create: true
+          name: kaniko
     asserts:
       - isKind:
           of: Secret

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -58,7 +58,7 @@ tests:
       - matchRegex: # check database user
           path: stringData.[config.yaml]
           pattern: "User: merlin-ext"
-  
+
   - it: should set authz url from values
     set:
       global: {}
@@ -95,3 +95,18 @@ tests:
       - matchRegex: # check authorization url
           path: stringData.[config.yaml]
           pattern: "AuthorizationConfig:\n  AuthorizationEnabled: false\n  AuthorizationServerURL: http://caraml-authz"
+
+  - it: should set image builder's kaniko service account to kaniko-merlin
+    set:
+      imageBuilder:
+        serviceAccount:
+          create: true
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-merlin-config$
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageBuilderConfig:\n  KanikoServiceAccount: kaniko-merlin"

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -109,4 +109,4 @@ tests:
           pattern: my-release-merlin-config$
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "ImageBuilderConfig:\n  KanikoServiceAccount: kaniko-merlin"
+          pattern: "KanikoServiceAccount: kaniko-merlin"

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -142,10 +142,10 @@ config:
     MaxAllowedReplica: 20
     MerlinURL: /api/merlin/v1
     MlpURL: /api
-    OauthClientID:  # to be set via CICD pipeline
+    OauthClientID: # to be set via CICD pipeline
     UPIDocumentation: "https://github.com/caraml-dev/universal-prediction-interface/blob/main/docs/api_markdown/caraml/upi/v1/index.md"
-    CPUCost:  # Unused
-    MemoryCost:  # Unused
+    CPUCost: # Unused
+    MemoryCost: # Unused
   StandardTransformerConfig:
     ImageName: merlin-transformer:1.0.0
     SimulationFeast:
@@ -265,7 +265,6 @@ imageBuilder:
     Tolerations: []
     NodeSelectors: {}
     MaximumRetry: 3
-    KanikoServiceAccount: "kaniko"
     Retention: "48h"
     SafeToEvict: false
 

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -142,10 +142,10 @@ config:
     MaxAllowedReplica: 20
     MerlinURL: /api/merlin/v1
     MlpURL: /api
-    OauthClientID: # to be set via CICD pipeline
+    OauthClientID:  # to be set via CICD pipeline
     UPIDocumentation: "https://github.com/caraml-dev/universal-prediction-interface/blob/main/docs/api_markdown/caraml/upi/v1/index.md"
-    CPUCost: # Unused
-    MemoryCost: # Unused
+    CPUCost:  # Unused
+    MemoryCost:  # Unused
   StandardTransformerConfig:
     ImageName: merlin-transformer:1.0.0
     SimulationFeast:


### PR DESCRIPTION
# Motivation

Fix getting Kaniko service account name

# Modification

Use include instead of template in _helpers.tpl

# Checklist
- [x] Chart version bumped
- [x] README.md updated
