### PR TITLE
chore(turing): Add Kaniko service account to Turing chart

### DIFF
--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.33
+version: 0.2.34

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.33](https://img.shields.io/badge/Version-0.2.33-informational?style=flat-square)
+![Version: 0.2.34](https://img.shields.io/badge/Version-0.2.34-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
@@ -81,6 +81,10 @@ The following table lists the configurable parameters of the Turing chart and th
 | global.protocol | string | `"http"` |  |
 | imageBuilder.clusterName | string | `"test"` |  |
 | imageBuilder.k8sConfig | object | `{}` |  |
+| imageBuilder.serviceAccount.annotations | object | `{}` |  |
+| imageBuilder.serviceAccount.create | bool | `true` |  |
+| imageBuilder.serviceAccount.labels | object | `{}` |  |
+| imageBuilder.serviceAccount.name | string | `"kaniko"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.class | string | `""` | Ingress class annotation to add to this Ingress rule, useful when there are multiple ingress controllers installed |
 | ingress.enabled | bool | `false` | Enable ingress to provision Ingress resource for external access to Turing API |

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -186,7 +186,7 @@ API config related
 {{- $globMlpApiHost := include "turing.get-workload-host" (list .Values.global .Release.Namespace "mlp")}}
 AuthConfig:
   URL: {{ include "turing.authorization.server.url" . | quote }}
-{{ if .Values.imageBuilder.serviceAccount.name }}
+{{ if and (eq (toString .Values.config.BatchEnsemblingConfig.Enabled) "true") (.Values.imageBuilder.serviceAccount.name)}}
 BatchEnsemblingConfig:
   ImageBuildingConfig:
     KanikoConfig:

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -186,7 +186,7 @@ API config related
 {{- $globMlpApiHost := include "turing.get-workload-host" (list .Values.global .Release.Namespace "mlp")}}
 AuthConfig:
   URL: {{ include "turing.authorization.server.url" . | quote }}
-{{ if and (eq (toString .Values.config.BatchEnsemblingConfig.Enabled) "true") (.Values.imageBuilder.serviceAccount.name)}}
+{{ if and (eq (toString .Values.config.BatchEnsemblingConfig.Enabled) "true") (or .Values.imageBuilder.serviceAccount.create .Values.imageBuilder.serviceAccount.name) }}
 BatchEnsemblingConfig:
   ImageBuildingConfig:
     KanikoConfig:
@@ -194,7 +194,7 @@ BatchEnsemblingConfig:
 {{ end }}
 EnsemblerServiceBuilderConfig:
   ClusterName: {{ .Values.imageBuilder.clusterName }}
-{{ if .Values.imageBuilder.serviceAccount.name }}
+{{ if (or .Values.imageBuilder.serviceAccount.create .Values.imageBuilder.serviceAccount.name) }}
   ImageBuildingConfig:
     KanikoConfig:
       ServiceAccount: {{ include "turing.kaniko-sa" . }}

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -186,7 +186,7 @@ API config related
 {{- $globMlpApiHost := include "turing.get-workload-host" (list .Values.global .Release.Namespace "mlp")}}
 AuthConfig:
   URL: {{ include "turing.authorization.server.url" . | quote }}
-{{ if and (eq (toString .Values.config.BatchEnsemblingConfig.Enabled) "true") (or .Values.imageBuilder.serviceAccount.create .Values.imageBuilder.serviceAccount.name) }}
+{{ if and (.Values.config.BatchEnsemblingConfig.Enabled) (or .Values.imageBuilder.serviceAccount.create .Values.imageBuilder.serviceAccount.name) }}
 BatchEnsemblingConfig:
   ImageBuildingConfig:
     KanikoConfig:

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -123,6 +123,14 @@ initContainers:
 {{- printf "%s/%s" $base $path -}}
 {{- end -}}
 
+{{- define "turing.kaniko-sa" -}}
+{{- if .Values.imageBuilder.serviceAccount.create }}
+{{- printf  "%s-%s" (default "kaniko" .Values.imageBuilder.serviceAccount.name) (include "turing.fullname" . ) }}
+{{- else }}
+{{- printf "%s" .Values.imageBuilder.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
 {{- define "turing.get-workload-host" }}
 {{- $global := index . 0}}
 {{- $relNs := index . 1}}
@@ -178,8 +186,19 @@ API config related
 {{- $globMlpApiHost := include "turing.get-workload-host" (list .Values.global .Release.Namespace "mlp")}}
 AuthConfig:
   URL: {{ include "turing.authorization.server.url" . | quote }}
+{{ if .Values.imageBuilder.serviceAccount.name }}
+BatchEnsemblingConfig:
+  ImageBuildingConfig:
+    KanikoConfig:
+      ServiceAccount: {{ include "turing.kaniko-sa" . }}
+{{ end }}
 EnsemblerServiceBuilderConfig:
   ClusterName: {{ .Values.imageBuilder.clusterName }}
+{{ if .Values.imageBuilder.serviceAccount.name }}
+  ImageBuildingConfig:
+    KanikoConfig:
+      ServiceAccount: {{ include "turing.kaniko-sa" . }}
+{{ end }}
 ClusterConfig:
   InClusterConfig: {{ .Values.clusterConfig.useInClusterConfig }}
   EnvironmentConfigPath: {{ include "turing.environments.absolutePath" . }}

--- a/charts/turing/templates/kaniko-service-account.yaml
+++ b/charts/turing/templates/kaniko-service-account.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.imageBuilder.serviceAccount .Values.imageBuilder.serviceAccount.create }}
+{{- if .Values.imageBuilder.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/turing/templates/kaniko-service-account.yaml
+++ b/charts/turing/templates/kaniko-service-account.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml .Values.imageBuilder.serviceAccount.annotations | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "merlin.labels" . | nindent 4 }}
+    {{- include "turing.labels" . | nindent 4 }}
     {{- if .Values.imageBuilder.serviceAccount.labels }}
     {{- toYaml .Values.imageBuilder.serviceAccount.labels | nindent 4 }}
     {{- end }}

--- a/charts/turing/templates/kaniko-service-account.yaml
+++ b/charts/turing/templates/kaniko-service-account.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.imageBuilder.serviceAccount .Values.imageBuilder.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "turing.kaniko-sa" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.imageBuilder.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.imageBuilder.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "merlin.labels" . | nindent 4 }}
+    {{- if .Values.imageBuilder.serviceAccount.labels }}
+    {{- toYaml .Values.imageBuilder.serviceAccount.labels | nindent 4 }}
+    {{- end }}
+{{ end }}

--- a/charts/turing/templates/turing-deployment.yaml
+++ b/charts/turing/templates/turing-deployment.yaml
@@ -24,7 +24,9 @@ spec:
 {{ toYaml .Values.deployment.labels | indent 8 -}}
 {{- end }}
     spec:
+      {{- if (or .Values.serviceAccount.create .Values.serviceAccount.name) }}
       serviceAccountName: {{ template "turing.serviceAccountName" . }}
+      {{- end }}
       {{- with (include "turing.initContainers" . | fromYaml) }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -84,6 +84,11 @@ clusterConfig:
   environmentConfigPath: "environments.yaml"
 
 imageBuilder:
+  serviceAccount:
+    create: true
+    name: "kaniko"
+    annotations: {}
+    labels: {}
   clusterName: "test"
   k8sConfig: {}
   # Example k8sConfig to connect to cluster using gke-gcloud-auth-plugin


### PR DESCRIPTION
# Motivation
Similar to how https://github.com/caraml-dev/merlin/pull/352 introduced a Kubernetes service account to be used for Kaniko jobs orchestrated by Merlin, this PR similarly introduces a similar change for Turing in its chart. 

Note that this PR has to be merged first (for the chart to be published before being used in this PR https://github.com/caraml-dev/turing/pull/357 in the Turing repo that includes the API server changes).

# Modification
- `charts/turing/templates/_helpers.tpl` - Addition of the Turing Kaniko service account in the default Turing configs
- `charts/turing/templates/kaniko-service-account.yaml` - Addition of the new Turing Kaniko Kubernetes service account manifest
- `charts/turing/values.yaml` - Addition of default Turing image builder service account values

# Checklist
- [x] Chart version bumped
- [x] README.md updated
