### PR TITLE
chore(xp-treatment): Add k8s service account to XP Treatment chart

### DIFF
--- a/charts/xp-treatment/Chart.lock
+++ b/charts/xp-treatment/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.4
+  version: 0.2.5
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
-digest: sha256:be5bf0498bc34412d129a6fccd399549588d5a6e5bd72b0b6669d3970d920f1b
-generated: "2023-07-03T03:32:04.474031351Z"
+digest: sha256:c67035d8cd4ddfc24dffd8bfec3639d691bc40d3cb457dc312cded12e0927e33
+generated: "2023-08-14T18:15:23.150624+08:00"

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.18
+version: 0.1.19

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: xp-management.enabled
   name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.4
+  version: 0.2.5
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square)
+![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments
@@ -63,6 +63,9 @@ The following table lists the configurable parameters of the XP Treatment Servic
 | deployment.service.externalPort | int | `8080` | XP Treatment Service Kubernetes service port number |
 | deployment.service.internalPort | int | `8080` | XP Treatment Service container port number |
 | deployment.service.type | string | `"ClusterIP"` |  |
+| deployment.serviceAccount.annotations | object | `{}` |  |
+| deployment.serviceAccount.create | bool | `true` |  |
+| deployment.serviceAccount.name | string | `""` |  |
 | global.protocol | string | `"http"` |  |
 | ingress.class | string | `""` | Ingress class annotation to add to this Ingress rule, useful when there are multiple ingress controllers installed |
 | ingress.enabled | bool | `false` | Enable ingress to provision Ingress resource for external access to XP Treatment Service |

--- a/charts/xp-treatment/templates/_helpers.tpl
+++ b/charts/xp-treatment/templates/_helpers.tpl
@@ -66,6 +66,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "treatment-svc.serviceAccountName" -}}
+{{- if .Values.deployment.serviceAccount.create }}
+{{- default (include "treatment-svc.fullname" .) .Values.deployment.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.deployment.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 API config related
 */}}
 

--- a/charts/xp-treatment/templates/_helpers.tpl
+++ b/charts/xp-treatment/templates/_helpers.tpl
@@ -69,11 +69,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "treatment-svc.serviceAccountName" -}}
-{{- if .Values.deployment.serviceAccount.create }}
 {{- default (include "treatment-svc.fullname" .) .Values.deployment.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.deployment.serviceAccount.name }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/xp-treatment/templates/deployment.yaml
+++ b/charts/xp-treatment/templates/deployment.yaml
@@ -31,7 +31,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name) }}
       serviceAccountName: {{ include "treatment-svc.serviceAccountName" . }}
+      {{- end }}
       containers:
       - name: api
         image: "{{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"

--- a/charts/xp-treatment/templates/deployment.yaml
+++ b/charts/xp-treatment/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "treatment-svc.serviceAccountName" . }}
       containers:
       - name: api
         image: "{{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"

--- a/charts/xp-treatment/templates/service-account.yaml
+++ b/charts/xp-treatment/templates/service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.deployment.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "treatment-svc.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "treatment-svc.labels" . | nindent 4 }}
+  {{- with .Values.deployment.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{ end }}

--- a/charts/xp-treatment/values.yaml
+++ b/charts/xp-treatment/values.yaml
@@ -99,6 +99,15 @@ deployment:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
 ingress:
   # -- Enable ingress to provision Ingress resource for external access to XP Treatment Service
   enabled: false


### PR DESCRIPTION
# Motivation
This PR introduces a Kubernetes service account for the XP Treatment Service that will allow it to use Google service account credentials via workload identity instead of them being mounted as a volume.

# Modification
- `charts/xp-treatment/templates/_helpers.tpl` - Addition of the XP Treatment Service service account block in the default XP Treatment Service configs
- `charts/xp-treatment/templates/service-account.yaml` - Addition of the new XP Treatment Service Kubernetes service account manifest
- `charts/xp-treatment/values.yaml` - Addition of default XP Treatment Service service account values

# Checklist
- [x] Chart version bumped
- [x] README.md updated
