### PR TITLE
fix(merlin): Fix default merlin standard transformer image

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
   - email: caraml-dev@caraml.dev
     name: caraml-dev
 name: merlin
-version: 0.12.0
+version: 0.12.1

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square)
+![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square)
 ![AppVersion: v0.32.0](https://img.shields.io/badge/AppVersion-v0.32.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
@@ -135,7 +135,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.StandardTransformerConfig.FeastServingURLs[1].Icon | string | `"bigtable"` |  |
 | config.StandardTransformerConfig.FeastServingURLs[1].Label | string | `"Online Serving with BigTable"` |  |
 | config.StandardTransformerConfig.FeastServingURLs[1].SourceType | string | `"BIGTABLE"` |  |
-| config.StandardTransformerConfig.ImageName | string | `"merlin-transformer:1.0.0"` |  |
+| config.StandardTransformerConfig.ImageName | string | `"ghcr.io/caraml-dev/merlin-transformer:1.0.0"` |  |
 | config.StandardTransformerConfig.Jaeger.CollectorURL | string | `"http://jaeger-tracing-collector.infrastructure:14268/api/traces"` |  |
 | config.StandardTransformerConfig.Jaeger.Disabled | bool | `false` |  |
 | config.StandardTransformerConfig.Jaeger.SamplerParam | int | `1` |  |

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -268,7 +268,7 @@ ImageBuilderConfig:
   ClusterName: {{ .Values.imageBuilder.clusterName }}
   K8sConfig:
 {{ .Values.imageBuilder.k8sConfig | toYaml | indent 4 }}
-  {{- if .Values.imageBuilder.serviceAccount.name }}
+  {{- if (or .Values.imageBuilder.serviceAccount.create .Values.imageBuilder.serviceAccount.name) }}
   KanikoServiceAccount: {{ include "merlin.kaniko-sa" . }}
   {{- end }}
 {{ .Values.imageBuilder.builderConfig | toYaml | indent 2 }}

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -37,7 +37,9 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "{{ .Values.service.internalPort }}"
     spec:
+      {{- if (or .Values.serviceAccount.create .Values.serviceAccount.name) }}
       serviceAccountName: {{ template "merlin.serviceAccountName" . }}
+      {{- end }}
       {{- with (include "merlin.initContainers" . | fromYaml) }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -148,7 +148,7 @@ config:
     CPUCost:  # Unused
     MemoryCost:  # Unused
   StandardTransformerConfig:
-    ImageName: merlin-transformer:1.0.0
+    ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0
     SimulationFeast:
       FeastRedisURL: online-serving-redis.feast.dev
       FeastBigtableURL: online-serving-bt.feast.dev


### PR DESCRIPTION
# Motivation
This PR replaces the default merlin standard transformer image in its chart values file because it does not follow the usual convention of a container image name, which creates potential errors if any deployment depends on that default value working correctly.

This PR also fixes 3 other bugs:
- inserting a Kaniko service account name into the Merlin configs if we are not expecting one to be created or if the name is not specified anywhere
- inserting a service account name into the Merlin deployment if we are not expecting one to be created or if the name is not specified anywhere
- ~~misleading `app.kubernetes.io/version=[app version]` label for Merlin resources when the app version is rarely updated (and not necessarily expected to be updated all the time)~~ (removed and to be decided upon again at a later time)

# Modification
- `charts/merlin/templates/_helpers.tpl` - Addition of extra checks to ensure the Kaniko service account is only added when necessary and removal of the misleading version label
- `charts/merlin/templates/merlin-deployment.yaml` - Addition of extra checks to ensure the Merlin service account is only added when necessary
- `charts/merlin/values.yaml` - Modification to the default standard transformer image value

# Checklist
- [x] Chart version bumped
- [x] README.md updated
