### PR TITLE
fix(xp-management): Make XP Management chart use service account selectively

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.2.4
+version: 0.2.5

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/_helpers.tpl
+++ b/charts/xp-management/templates/_helpers.tpl
@@ -69,11 +69,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "management-svc.serviceAccountName" -}}
-{{- if .Values.deployment.serviceAccount.create }}
 {{- default (include "management-svc.fullname" .) .Values.deployment.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.deployment.serviceAccount.name }}
-{{- end }}
 {{- end }}
 
 {{- define "management-svc.environment" -}}

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -32,7 +32,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name) }}
       serviceAccountName: {{ include "management-svc.serviceAccountName" . }}
+      {{- end }}
       containers:
       - name: api
         image: "{{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
# Motivation
Similar to one of the changes in PR #334, a tiny fix is introduced to the XP Management chart such that the service account name is only injected into the XP Management Service deployment only when we are expecting one to be created or if its name is specified explicitly.

# Modification
- `charts/xp-management/templates/deployment.yaml` - Addition of logical check before the service account name is added
- `charts/xp-management/templates/_helpers.tpl` - Simplification of the definition for `serviceAccountName` (there is no way the `"default"` name will ever be used, since `serviceAccountName` is never used unless `.Values.deployment.serviceAccount.create` or `.Values.deployment.serviceAccount.name` is true; see the fix above)

# Checklist
- [x] Chart version bumped
- [x] README.md updated
