### PR TITLE
fix(turing,xp-management): Fix swagger k8s service routes

### DIFF
--- a/charts/routes/Chart.yaml
+++ b/charts/routes/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
   name: caraml-dev
 name: caraml-routes
 type: application
-version: 0.2.2
+version: 0.2.3

--- a/charts/routes/README.md
+++ b/charts/routes/README.md
@@ -1,7 +1,7 @@
 # caraml-routes
 
 ---
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square)
 ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML networking resources
@@ -133,7 +133,7 @@ The following table lists the configurable parameters of the Routes chart and th
 | turing.docs.destHost | string | `"turing"` |  |
 | turing.docs.destPort | int | `8080` |  |
 | turing.docs.redirectMatch | string | `"/turing/rest-api"` |  |
-| turing.docs.rewriteUri | string | `"/api-docs"` |  |
+| turing.docs.rewriteUri | string | `"/api-docs/"` |  |
 | turing.enabled | bool | `true` |  |
 | xp.api.appName | string | `"xp"` |  |
 | xp.api.authHeader | bool | `false` |  |

--- a/charts/routes/values.yaml
+++ b/charts/routes/values.yaml
@@ -88,7 +88,7 @@ turing:
   docs:
     app: turing
     redirectMatch: /turing/rest-api
-    rewriteUri: "/api-docs"
+    rewriteUri: "/api-docs/"
     destHost: turing
     destPort: 8080
 

--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.2.5
+version: 0.2.6

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/service-swagger.yaml
+++ b/charts/xp-management/templates/service-swagger.yaml
@@ -1,8 +1,9 @@
+{{- $globServiceName := include "common.get-component-value" (list .Values.global "xp" (list "serviceName")) }}
 {{- if .Values.swaggerUi.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "management-svc.fullname" .}}-swagger
+  name: {{ include "common.set-value" (list (include "management-svc.fullname" .) $globServiceName) }}-swagger
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "management-svc.labels" . | nindent 4 }}


### PR DESCRIPTION
# Motivation
This PR fixes 2 separate issues that affect the swagger docs of the Turing and XP Management charts:

1. The Turing swagger docs endpoint is not supposed to be accessed without a trailing slash (see [this](https://github.com/caraml-dev/turing/blob/78ca7b32f36e4cb3095346262c63f928c54f82d3/api/turing/config/config.go#L638) for the default value set). This PR adds a slash to the default value of the Turing swagger UI endpoint.
2. The XP Management swagger UI service was unfortunately using the full name of the release as its resource name, unlike most other CaraML components which were simply using the component name. This PR introduces a new template variable to be used for the swagger UI service name (of the form `[component-name]-swagger`) instead. (see [this](https://github.com/caraml-dev/helm-charts/blob/fc7832120197f2c478a10d051cc28054f6e1579d/charts/merlin/templates/_helpers.tpl#L47) for how Merlin currently does it).

Note that the XP Treatment chart similarly needs to be updated to correct these inconsistencies, though it'll only be updated in a separate PR since it is dependent on the XP Management chart (we'll merge this PR, release a new version of the XP Management chart, before updating the dependencies and fixing the bug in the XP Treatment chart).

# Modification
- Fixed Turing swagger doc endpoint path
- Fixed XP Management swagger docs service UI name

# Checklist
- [x] Chart version bumped
- [x] README.md updated
