### PR TITLE
fix(xp-treatment): Fix xp treatment swagger ui service

### DIFF
--- a/charts/xp-treatment/Chart.lock
+++ b/charts/xp-treatment/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.5
+  version: 0.2.6
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
-digest: sha256:c67035d8cd4ddfc24dffd8bfec3639d691bc40d3cb457dc312cded12e0927e33
-generated: "2023-08-14T18:15:23.150624+08:00"
+digest: sha256:92c0234c1ebb8e1a476492ad102626f2e27334f308f94945e1e6be725af9e1f6
+generated: "2023-08-22T10:23:37.234446+08:00"

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: xp-management.enabled
   name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.5
+  version: 0.2.6
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.19
+version: 0.1.20

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square)
+![Version: 0.1.20](https://img.shields.io/badge/Version-0.1.20-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments

--- a/charts/xp-treatment/ci/ci-values.yaml
+++ b/charts/xp-treatment/ci/ci-values.yaml
@@ -8,6 +8,8 @@ global:
     useServiceFqdn: true
     uiPrefix: "/xp"
     uiServiceName: xp-management
+  xp-treatment:
+    serviceName: xp-treatment
 deployment:
   replicaCount: "1"
   resources:

--- a/charts/xp-treatment/templates/service-swagger.yaml
+++ b/charts/xp-treatment/templates/service-swagger.yaml
@@ -1,4 +1,4 @@
-{{- $globServiceName := include "common.get-component-value" (list .Values.global "xp" (list "serviceName")) }}
+{{- $globServiceName := include "common.get-component-value" (list .Values.global "xp-treatment" (list "serviceName")) }}
 {{- if .Values.swaggerUi.enabled }}
 apiVersion: v1
 kind: Service

--- a/charts/xp-treatment/templates/service-swagger.yaml
+++ b/charts/xp-treatment/templates/service-swagger.yaml
@@ -1,8 +1,9 @@
+{{- $globServiceName := include "common.get-component-value" (list .Values.global "xp" (list "serviceName")) }}
 {{- if .Values.swaggerUi.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "treatment-svc.fullname" . }}-swagger
+  name: {{ include "common.set-value" (list (include "treatment-svc.fullname" .) $globServiceName) }}-swagger
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "treatment-svc.labels" . | nindent 4 }}

--- a/charts/xp-treatment/templates/service.yaml
+++ b/charts/xp-treatment/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- $globServiceName := include "common.get-component-value" (list .Values.global "xp" (list "serviceName")) }}
+{{- $globServiceName := include "common.get-component-value" (list .Values.global "xp-treatment" (list "serviceName")) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/xp-treatment/templates/service.yaml
+++ b/charts/xp-treatment/templates/service.yaml
@@ -1,7 +1,8 @@
+{{- $globServiceName := include "common.get-component-value" (list .Values.global "xp" (list "serviceName")) }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "treatment-svc.fullname" . }}
+  name: {{ include "common.set-value" (list (include "treatment-svc.fullname" .) $globServiceName) }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "treatment-svc.labels" . | nindent 4 }}


### PR DESCRIPTION
# Motivation
Similar to the second bug fix in PR #339, this PR replaces the swagger UI service name with the same name for the XP Treatment K8s service resource with the suffix `-swagger` appended to it.

# Modification
- Fixed XP Treatment swagger docs service UI name

# Checklist
- [x] Chart version bumped
- [X] README.md updated
