### PR TITLE
feat: Update Merlin chart to use keto 0.11 compatible mlp chart

### DIFF
--- a/charts/merlin/Chart.lock
+++ b/charts/merlin/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 7.0.2
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.4.20
+  version: 0.6.2
 - name: generic-dep-installer
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.1
@@ -17,5 +17,5 @@ dependencies:
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
-digest: sha256:54910d3a6ab237a4a2e44269d231344b0a55b7fc7f9e3dcd631e5c001f730360
-generated: "2023-06-26T06:23:58.760654129Z"
+digest: sha256:5b78dc2a5eec1dbcdb08f219faee245a43c9c126f748d1c6bdfe4de5385a5538
+generated: "2023-08-22T17:52:00.090648+08:00"

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.31.0-rc1
+appVersion: v0.32.0
 dependencies:
   - alias: merlin-postgresql
     condition: merlin-postgresql.enabled
@@ -14,7 +14,7 @@ dependencies:
   - condition: mlp.enabled
     name: mlp
     repository: https://caraml-dev.github.io/helm-charts
-    version: 0.4.20
+    version: 0.6.2
   - alias: kserve
     condition: kserve.enabled
     name: generic-dep-installer
@@ -33,4 +33,4 @@ maintainers:
   - email: caraml-dev@caraml.dev
     name: caraml-dev
 name: merlin
-version: 0.11.7
+version: 0.12.0

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,8 +1,8 @@
 # merlin
 
 ---
-![Version: 0.11.7](https://img.shields.io/badge/Version-0.11.7-informational?style=flat-square)
-![AppVersion: v0.31.0-rc1](https://img.shields.io/badge/AppVersion-v0.31.0--rc1-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square)
+![AppVersion: v0.32.0](https://img.shields.io/badge/AppVersion-v0.32.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -63,10 +63,11 @@ The following table lists the configurable parameters of the Merlin chart and th
 | clusterConfig.environmentConfigPath | string | `"environments.yaml"` | environmentConfigPath is a path to a file that contains environmentConfigs. See api/environments-dev.yaml for example contents |
 | clusterConfig.useInClusterConfig | bool | `false` | Configuration to tell Merlin API how it should authenticate with deployment k8s cluster By default, Merlin API expects to use a remote k8s cluster for deployment and to do so, it requires cluster access configurations to be configured as part of values.yaml |
 | config.AuthorizationConfig.AuthorizationEnabled | bool | `true` |  |
-| config.AuthorizationConfig.AuthorizationServerURL | string | `"http://mlp-authorization-keto"` |  |
 | config.AuthorizationConfig.Caching.CacheCleanUpIntervalSeconds | int | `900` | Cache clean up interval, after which expired keys are removed |
 | config.AuthorizationConfig.Caching.Enabled | bool | `false` | Whether local in-memory caching of authorization responses should be enabled |
 | config.AuthorizationConfig.Caching.KeyExpirySeconds | int | `600` | Cache key expiry duration |
+| config.AuthorizationConfig.KetoRemoteRead | string | `"http://mlp-keto-read:80"` |  |
+| config.AuthorizationConfig.KetoRemoteWrite | string | `"http://mlp-keto-write:80"` |  |
 | config.DbConfig.Database | string | `"merlin"` |  |
 | config.DbConfig.Host | string | `"localhost"` |  |
 | config.DbConfig.Password | string | `"merlin"` |  |
@@ -155,7 +156,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.registry | string | `"ghcr.io"` |  |
 | deployment.image.repository | string | `"caraml-dev/merlin"` |  |
-| deployment.image.tag | string | `"0.0.0-271a1277dd8d63acc114ace44310e207b04751dc"` |  |
+| deployment.image.tag | string | `"0.32.0"` |  |
 | deployment.labels | object | `{}` |  |
 | deployment.podLabels | object | `{}` |  |
 | deployment.replicaCount | string | `"2"` |  |
@@ -328,6 +329,9 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlflowExternalPostgresql.username | string | `"mlflow"` | External postgres database user |
 | mlp.enabled | bool | `true` |  |
 | mlp.environmentConfigSecret.name | string | `""` |  |
+| mlp.fullnameOverride | string | `"mlp"` |  |
+| mlp.keto.enabled | bool | `true` |  |
+| mlp.keto.fullnameOverride | string | `"mlp-keto"` |  |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -5,7 +5,7 @@ deployment:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: caraml-dev/merlin
-    tag: 0.0.0-271a1277dd8d63acc114ace44310e207b04751dc
+    tag: 0.32.0
   replicaCount: "2"
   # Additional labels to apply to the deployment
   labels: {}
@@ -102,7 +102,8 @@ config:
     Password: merlin
   AuthorizationConfig:
     AuthorizationEnabled: true
-    AuthorizationServerURL: http://mlp-authorization-keto
+    KetoRemoteRead: "http://mlp-keto-read:80"
+    KetoRemoteWrite: "http://mlp-keto-write:80"
     Caching:
       # -- Whether local in-memory caching of authorization responses should be enabled
       Enabled: false
@@ -426,8 +427,12 @@ merlin-postgresql:
     size: 10Gi
 mlp:
   enabled: true
+  fullnameOverride: mlp
   environmentConfigSecret:
     name: ""
+  keto:
+    enabled: true
+    fullnameOverride: mlp-keto
 mlflow:
   # This should be the actual DNS registered
   trackingURL: "http://www.example.com"


### PR DESCRIPTION
# Motivation
The current Merlin chart does not work out of the box for MLP app version 1.10.0 / chart version 0.6.1  onwards. After this PR, by default, the MLP version bundled together with Merlin will be Keto 0.11 compatible. The default configuration for Merlin has also been updated.

# Modification
- Default Merlin configuration
- Chart dependencies
- Update default image tag

# Checklist
- [x] Chart version bumped
- [x] README.md updated
