### PR TITLE
feat: Update caraml umbrella chart to be Keto 0.11 compatible

### DIFF
--- a/charts/caraml/Chart.lock
+++ b/charts/caraml/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.5.2
+  version: 0.6.2
 - name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.11.7
+  version: 0.12.0
 - name: turing
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.35
@@ -22,7 +22,7 @@ dependencies:
   version: 0.1.12
 - name: caraml-routes
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.3
+  version: 0.3.0
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
@@ -44,5 +44,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.8.2
-digest: sha256:bdaf431fadd6091cd9de0c4d8fc4a54bab4cf33ccea8ce90a7673137fd2e119b
-generated: "2023-08-22T10:11:06.389991906Z"
+digest: sha256:06a25aa43354d8e62db75a171b64dd032990003b8714d3474a20d02e49eb8b75
+generated: "2023-08-23T09:52:52.633741+08:00"

--- a/charts/caraml/Chart.yaml
+++ b/charts/caraml/Chart.yaml
@@ -4,11 +4,11 @@ dependencies:
 - condition: mlp.enabled
   name: mlp
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.5.2
+  version: 0.6.2
 - condition: merlin.enabled
   name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.11.7
+  version: 0.12.0
 - condition: turing.enabled
   name: turing
   repository: https://caraml-dev.github.io/helm-charts
@@ -33,7 +33,7 @@ dependencies:
 - condition: caraml-routes.enabled
   name: caraml-routes
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.3
+  version: 0.3.0
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
@@ -72,4 +72,4 @@ maintainers:
   name: caraml-dev
 name: caraml
 type: application
-version: 0.6.24
+version: 0.7.0

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -1,6 +1,6 @@
 # caraml
 
-![Version: 0.6.24](https://img.shields.io/badge/Version-0.6.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML components
 
@@ -15,14 +15,14 @@ A Helm chart for deploying CaraML components
 | Repository | Name | Version |
 |------------|------|---------|
 | https://caraml-dev.github.io/helm-charts | caraml-authz(authz) | 0.1.12 |
-| https://caraml-dev.github.io/helm-charts | caraml-routes | 0.2.3 |
+| https://caraml-dev.github.io/helm-charts | caraml-routes | 0.3.0 |
 | https://caraml-dev.github.io/helm-charts | certManagerBase(cert-manager-base) | 1.8.1 |
 | https://caraml-dev.github.io/helm-charts | common | 0.2.9 |
 | https://caraml-dev.github.io/helm-charts | clusterLocalGateway(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | istioIngressGateway(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | istiod(generic-dep-installer) | 0.2.1 |
-| https://caraml-dev.github.io/helm-charts | merlin | 0.11.7 |
-| https://caraml-dev.github.io/helm-charts | mlp | 0.5.2 |
+| https://caraml-dev.github.io/helm-charts | merlin | 0.12.0 |
+| https://caraml-dev.github.io/helm-charts | mlp | 0.6.2 |
 | https://caraml-dev.github.io/helm-charts | turing | 0.2.35 |
 | https://caraml-dev.github.io/helm-charts | xp-management | 0.2.6 |
 | https://caraml-dev.github.io/helm-charts | xp-treatment | 0.1.20 |
@@ -37,10 +37,7 @@ A Helm chart for deploying CaraML components
 | base.enabled | bool | `true` | Set to false if there is an existing istio deployment |
 | base.global.istioNamespace | string | `"istio-system"` |  |
 | base.validationURL | string | `""` |  |
-| caraml-authz.bootstrap.policies | list | `[{"actions":["actions:**"],"description":"Administrator policy to gain access to all resources","effect":"allow","id":"policies:admin","resources":["resources:**"],"subjects":["roles:admin"]},{"actions":["actions:read"],"description":"Allow reading of all mlp projects","effect":"allow","id":"policies:allow-read-all-projects","resources":["resources:mlp:projects:**"],"subjects":["roles:project-reader"]},{"actions":["actions:read"],"description":"Allow all users to list merlin environment","effect":"allow","id":"policies:allow-all-list-environments","resources":["resources:mlp:environments"],"subjects":["roles:**","users:**"]},{"actions":["actions:read","actions:create"],"description":"Allow all users to list and create mlp project","effect":"allow","id":"policies:allow-all-list-create-projects","resources":["resources:mlp:projects"],"subjects":["roles:**","users:**"]},{"actions":["actions:read"],"description":"Allow all users to list applications","effect":"allow","id":"policies:allow-all-list-applications","resources":["resources:mlp:applications"],"subjects":["roles:**","users:**"]},{"actions":["actions:read"],"description":"Allow all users to access API related to the user","effect":"allow","id":"policies:allow-access-users-resources","resources":["resources:mlp:users","resources:mlp:users:**"],"subjects":["roles:**","users:**"]},{"actions":["actions:create"],"description":"Allow all users to simulate standard transformer","effect":"allow","id":"policies:allow-all-standard-transformer-simulate","resources":["resources:mlp:standard_transformer:simulate"],"subjects":["roles:**","users:**"]}]` | Following are the keto policies that are used in CaraML components. |
-| caraml-authz.bootstrap.roles | list | `[{"id":"roles:admin","members":["users:caram.user@caraml.dev"]}]` | You can add keto roles that can give access to CaraML components. |
-| caraml-authz.caraml-authz-postgresql.enabled | bool | `false` |  |
-| caraml-authz.enabled | bool | `true` |  |
+| caraml-authz.enabled | bool | `false` |  |
 | caraml-routes.cert-manager.enabled | bool | `false` |  |
 | caraml-routes.certManagerBase.enabled | bool | `false` |  |
 | caraml-routes.enabled | bool | `true` |  |
@@ -73,8 +70,6 @@ A Helm chart for deploying CaraML components
 | clusterLocalGateway.helmChart.repository | string | `"https://istio-release.storage.googleapis.com/charts"` |  |
 | clusterLocalGateway.helmChart.version | string | `"1.13.9"` |  |
 | clusterLocalGateway.hook.weight | int | `1` |  |
-| global.authz.postgresqlDatabase | string | `"authz"` |  |
-| global.authz.serviceName | string | `"caraml-authz"` |  |
 | global.dbSecretKey | string | `"postgresql-password"` |  |
 | global.hosts.mlflow[0] | string | `"mlflow"` |  |
 | global.hosts.mlp[0] | string | `"console"` |  |
@@ -188,6 +183,12 @@ A Helm chart for deploying CaraML components
 | merlin.mlp.enabled | bool | `false` |  |
 | mlp.deployment.authorization.enabled | bool | `true` |  |
 | mlp.enabled | bool | `true` | To enable/disable MLP chart installation. |
+| mlp.fullnameOverride | string | `"mlp"` |  |
+| mlp.keto.deployment.resources.limits.memory | string | `"256Mi"` |  |
+| mlp.keto.deployment.resources.requests.cpu | string | `"250m"` |  |
+| mlp.keto.deployment.resources.requests.memory | string | `"256Mi"` |  |
+| mlp.keto.enabled | bool | `true` |  |
+| mlp.keto.fullnameOverride | string | `"mlp-keto"` |  |
 | mlp.postgresql.enabled | bool | `false` | To enable/disable MLP specific postgres |
 | postgresql.enabled | bool | `true` | To enable/disable CaraML specific postgres |
 | postgresql.initdbScripts."init.sql" | string | `"CREATE DATABASE mlp;\nCREATE DATABASE merlin;\nCREATE DATABASE mlflow;\nCREATE DATABASE authz;\nCREATE DATABASE turing;\nCREATE DATABASE xp;\n"` |  |
@@ -195,7 +196,7 @@ A Helm chart for deploying CaraML components
 | postgresql.postgresqlDatabase | string | `"caraml"` | To set the database schema name created in postgres |
 | postgresql.postgresqlUsername | string | `"caraml"` | To set the user name for the database instance |
 | postgresql.resources | object | `{}` | Configure resource requests and limits, Ref: http://kubernetes.io/docs/user-guide/compute-resources/ |
-| turing.config | object | `{}` |  |
+| turing.config.AuthConfig.Enabled | bool | `false` |  |
 | turing.deployment.resources.limits.cpu | string | `"500m"` |  |
 | turing.deployment.resources.limits.memory | string | `"512Mi"` |  |
 | turing.deployment.resources.requests.cpu | string | `"250m"` |  |

--- a/charts/caraml/ci/ci-values.yaml
+++ b/charts/caraml/ci/ci-values.yaml
@@ -1,29 +1,3 @@
-caraml-authz:
-  enabled: true
-  deployment:
-    replicaCount: "1"
-    resources: &resources
-      requests:
-        cpu: 25m
-        memory: 256Mi
-      limits:
-        cpu: "50m"
-        memory: 512Mi
-    initResources:
-      requests:
-        cpu: 25m
-        memory: 256Mi
-      limits:
-        cpu: "50m"
-        memory: 512Mi
-  bootstrap:
-    resources:
-      requests:
-        cpu: 25m
-        memory: 256Mi
-      limits:
-        cpu: "50m"
-        memory: 512Mi
 mlp:
   deployment:
     replicaCount: "1"
@@ -193,3 +167,9 @@ xp-management:
       limits:
         cpu: "50m"
         memory: 512Mi
+
+caraml-routes:
+  oathkeeper:
+    enabled: true
+  oathkeeperRules:
+    enabled: true

--- a/charts/caraml/values.yaml
+++ b/charts/caraml/values.yaml
@@ -15,9 +15,6 @@ global:
     mlp: ["console"]
     mlpdocs: ["docs"]
     mlflow: ["mlflow"]
-  authz:
-    postgresqlDatabase: authz
-    serviceName: caraml-authz
   mlp:
     postgresqlDatabase: mlp
     apiPrefix: ""  # path prefix to where mlp endpoints lie if running on localhost
@@ -55,6 +52,7 @@ global:
 
 
 mlp:
+  fullnameOverride: mlp
   # -- To enable/disable MLP chart installation.
   enabled: true
   postgresql:
@@ -63,6 +61,16 @@ mlp:
   deployment:
     authorization:
       enabled: true
+  keto:
+    enabled: true
+    fullnameOverride: mlp-keto
+    deployment:
+      resources:
+        requests:
+          cpu: "250m"
+          memory: 256Mi
+        limits:
+          memory: 256Mi
 merlin:
   # -- To enable/disable merlin chart installation.
   enabled: true
@@ -155,59 +163,7 @@ merlin:
       cert-manager:
         enabled: true
 caraml-authz:
-  enabled: true
-  caraml-authz-postgresql:
-    enabled: false
-  bootstrap:
-    # -- You can add keto roles that can give access to CaraML components.
-    roles:
-      - id: "roles:admin"
-        members:
-          - "users:caram.user@caraml.dev"
-    # -- Following are the keto policies that are used in CaraML components.
-    policies:
-      - id: "policies:admin"
-        description: Administrator policy to gain access to all resources
-        subjects: ["roles:admin"]
-        resources: ["resources:**"]
-        actions: ["actions:**"]
-        effect: allow
-      - id: "policies:allow-read-all-projects"
-        description: Allow reading of all mlp projects
-        subjects: ["roles:project-reader"]
-        resources: ["resources:mlp:projects:**"]
-        actions: ["actions:read"]
-        effect: allow
-      - id: "policies:allow-all-list-environments"
-        description: Allow all users to list merlin environment
-        subjects: ["roles:**", "users:**"]
-        resources: ["resources:mlp:environments"]
-        actions: ["actions:read"]
-        effect: allow
-      - id: "policies:allow-all-list-create-projects"
-        description: Allow all users to list and create mlp project
-        subjects: ["roles:**", "users:**"]
-        resources: ["resources:mlp:projects"]
-        actions: ["actions:read", "actions:create"]
-        effect: allow
-      - id: "policies:allow-all-list-applications"
-        description: Allow all users to list applications
-        subjects: ["roles:**", "users:**"]
-        resources: ["resources:mlp:applications"]
-        actions: ["actions:read"]
-        effect: allow
-      - id: "policies:allow-access-users-resources"
-        description: Allow all users to access API related to the user
-        subjects: ["roles:**", "users:**"]
-        resources: ["resources:mlp:users", "resources:mlp:users:**"]
-        actions: ["actions:read"]
-        effect: allow
-      - id: "policies:allow-all-standard-transformer-simulate"
-        description: Allow all users to simulate standard transformer
-        subjects: ["roles:**", "users:**"]
-        resources: ["resources:mlp:standard_transformer:simulate"]
-        actions: ["actions:create"]
-        effect: allow
+  enabled: false
 caraml-routes:
   enabled: true
   certManagerBase:
@@ -433,7 +389,9 @@ turing:
       limits:
         cpu: "500m"
         memory: 512Mi
-  config: {}
+  config:
+    AuthConfig:
+      Enabled: false
 
 ###################################################################
 # xp dependency


### PR DESCRIPTION
# Motivation
Merlin and MLP charts have been updated to be compatible with Keto 0.11. The umbrella chart is updated to use the newer version of the charts.

There are some follow up to be done after this PR is merged:
- Clean up caraml-authz completely
- Clean up the helper functions that are associated with caraml-authz
- Clean up the global variables
- (Good to have) install ext authz extension on Istio by default, install istio authorization policy using route chart

# Modification
- Disable authorization on Turing by default (not done for XP, as authorization is already turned off by default in XP chart)
- Install MLP together with Keto by default
- Disable caraml-authz chart

# Checklist
- [x] Chart version bumped
- [x] README.md updated
