### PR TITLE
fix: fix incorrect mlp console regex in oathkeeper rule

### DIFF
--- a/charts/routes/Chart.yaml
+++ b/charts/routes/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
   name: caraml-dev
 name: caraml-routes
 type: application
-version: 0.3.0
+version: 0.3.1

--- a/charts/routes/README.md
+++ b/charts/routes/README.md
@@ -1,7 +1,7 @@
 # caraml-routes
 
 ---
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square)
 ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML networking resources

--- a/charts/routes/templates/_helpers.tpl
+++ b/charts/routes/templates/_helpers.tpl
@@ -120,7 +120,11 @@ Function to add generate Uri Match and redirect match for routess
 {{- end }}
 
 {{- define "caraml-routes.oathkeeper.mlp.hostRegex" -}}
-https?://({{ (join "|" .Values.global.hosts.mlp) | replace "." "\\." }})
+{{- $hosts := list -}}
+{{- range .Values.global.hosts.mlp -}}
+{{- $hosts = print (include "common.localiseDomain" (list . (include "common.get-external-hostname" $.Values.global))) | append $hosts -}}
+https?://({{ (join "|" $hosts) | replace "." "\\." }})
+{{- end -}}
 {{- end }}
 
 {{- define "caraml-routes.oathkeeper.mlp.regexPrefix" -}}

--- a/charts/routes/tests/oathkeeper_rules_test.yaml
+++ b/charts/routes/tests/oathkeeper_rules_test.yaml
@@ -14,8 +14,9 @@ tests:
       oathkeeperRules:
         enabled: true
       global:
+        domain: "caraml.com"
         hosts:
-          mlp: ["console.com", "console.org"]
+          mlp: ["console"]
         mlp:
           vsPrefix: "/mlp"
           apiPrefix: "/v2"
@@ -26,7 +27,7 @@ tests:
           of: Rule
       - matchRegex:
           path: spec.match.url
-          pattern: ^<https\?://\(console\\\.com\|console\\\.org\)/mlp/v\[0\-9\]\+>/applications$
+          pattern: ^<https\?://\(console\\\.caraml\\\.com\)/mlp/v\[0\-9\]\+>/applications$
   - it: should create mlp rule only if mlp is enabled
     set:
       oathkeeperRules:
@@ -40,8 +41,9 @@ tests:
       oathkeeperRules:
         enabled: true
       global:
+        domain: "caraml.com"
         hosts:
-          mlp: ["console.com", "console.org"]
+          mlp: ["console"]
         turing:
           vsPrefix: "/turing"
           apiPrefix: "/v2"
@@ -52,4 +54,4 @@ tests:
           of: Rule
       - matchRegex:
           path: spec.match.url
-          pattern: ^<https\?://\(console\\\.com\|console\\\.org\)/turing/v\[0\-9\]\+>/experiment-engines<\(/\.\+\)\?>$
+          pattern: ^<https\?://\(console\\\.caraml\\\.com\)/turing/v\[0\-9\]\+>/experiment-engines<\(/\.\+\)\?>$


### PR DESCRIPTION
# Motivation
The oathkeeper rules template currently don't consider the global domain when constructing the regex to match the MLP host name. After this fix, the regex constructed will now be consistent with the MLP virtual service host name.

# Modification
- Update oathkeeper rule

# Checklist
- [x] Chart version bumped
- [x] README.md updated
