### PR TITLE
fix(xp): extraEnvs rendering has wron indentation

### DIFF
--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.12.2
+appVersion: 0.12.1
 dependencies:
 - alias: xp-management-postgresql
   condition: xp-management-postgresql.enabled
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.2.6
+version: 0.2.7

--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.12.1
+appVersion: 0.12.2
 dependencies:
 - alias: xp-management-postgresql
   condition: xp-management-postgresql.enabled

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -2,7 +2,7 @@
 
 ---
 ![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square)
-![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
+![AppVersion: 0.12.2](https://img.shields.io/badge/AppVersion-0.12.2-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments
 

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,8 +1,8 @@
 # xp-management
 
 ---
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square)
-![AppVersion: 0.12.2](https://img.shields.io/badge/AppVersion-0.12.2-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square)
+![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments
 

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: {{ include "common.postgres-password-secret-name" (list (index .Values "xp-management-postgresql") .Values.xpManagementExternalPostgresql .Release .Chart ) }}
                 key: {{ include "common.postgres-password-secret-key" (list .Values.xpManagementExternalPostgresql) }}
           {{- with .Values.deployment.extraEnvs }}
-          {{- toYaml . | nindent 12 }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
         ports:
           - name: http


### PR DESCRIPTION
# Motivation
`extraEnvs` aren't rendered correctly that cause helm to fail 

# Modification
fix indentation

# Checklist
- [x] Chart version bumped
- [x] README.md updated
