### PR TITLE
feat: Add new top level field rendered for template variables

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.12.3
+version: 0.13.0

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.12.2
+version: 0.12.3

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -213,6 +213,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | imageBuilder.builderConfig.SafeToEvict | bool | `false` |  |
 | imageBuilder.builderConfig.Tolerations | list | `[]` |  |
 | imageBuilder.clusterName | string | `"test"` |  |
+| imageBuilder.contextRef | string | `""` |  |
 | imageBuilder.k8sConfig | object | `{}` |  |
 | imageBuilder.serviceAccount.annotations | object | `{}` |  |
 | imageBuilder.serviceAccount.create | bool | `true` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -331,7 +331,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlp.fullnameOverride | string | `"mlp"` |  |
 | mlp.keto.enabled | bool | `true` |  |
 | mlp.keto.fullnameOverride | string | `"mlp-keto"` |  |
-| releasedVersion | string | `"0.32.0"` |  |
+| rendered.releasedVersion | string | `"0.32.0"` |  |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -55,11 +55,10 @@ The command removes all the Kubernetes components associated with the chart and 
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
 ### Rendered field
-* The purpose of `.Values.rendered.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
-`.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
-If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
-Values.  Rendered values will overwrite values in `.Values.config`
-Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
+* The purpose of `.Values.rendered.*` is to configure parts of the helm chart that use the field * from 1 place
+* For example, `.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+* If `.Values.deployment.image.tag` is specified, it will overwrite the value in `.Values.releasedVersion`
+* The values in `.Values.rendered` will overwrite values in `.Values.config`
 
 ## Configuration
 The following table lists the configurable parameters of the Merlin chart and their default values.

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -141,6 +141,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.StandardTransformerConfig.FeastServingURLs[1].Icon | string | `"bigtable"` |  |
 | config.StandardTransformerConfig.FeastServingURLs[1].Label | string | `"Online Serving with BigTable"` |  |
 | config.StandardTransformerConfig.FeastServingURLs[1].SourceType | string | `"BIGTABLE"` |  |
+| config.StandardTransformerConfig.ImageName | string | `"ghcr.io/caraml-dev/merlin-transformer:1.0.0"` |  |
 | config.StandardTransformerConfig.Jaeger.CollectorURL | string | `"http://jaeger-tracing-collector.infrastructure:14268/api/traces"` |  |
 | config.StandardTransformerConfig.Jaeger.Disabled | bool | `false` |  |
 | config.StandardTransformerConfig.Jaeger.SamplerParam | int | `1` |  |
@@ -197,14 +198,20 @@ The following table lists the configurable parameters of the Merlin chart and th
 | environmentConfigs[0].queue_resource_percentage | string | `"20"` |  |
 | environmentConfigs[0].region | string | `"id"` |  |
 | global.protocol | string | `"http"` |  |
-| imageBuilder.builderConfig.BaseImages | object | `{}` |  |
+| imageBuilder.builderConfig.BaseImages."3.7.*".BuildContextURI | string | `"git://github.com/gojek/merlin.git#refs/tags/v0.1"` |  |
+| imageBuilder.builderConfig.BaseImages."3.7.*".DockerfilePath | string | `"docker/Dockerfile"` |  |
+| imageBuilder.builderConfig.BaseImages."3.7.*".ImageName | string | `"pyfunc-py37:v0.1.0"` |  |
+| imageBuilder.builderConfig.BaseImages."3.7.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
 | imageBuilder.builderConfig.BuildNamespace | string | `"mlp"` |  |
 | imageBuilder.builderConfig.BuildTimeout | string | `"30m"` |  |
 | imageBuilder.builderConfig.DockerRegistry | string | `"dockerRegistry"` |  |
 | imageBuilder.builderConfig.KanikoImage | string | `"gcr.io/kaniko-project/executor:v1.6.0"` |  |
 | imageBuilder.builderConfig.MaximumRetry | int | `3` |  |
 | imageBuilder.builderConfig.NodeSelectors | object | `{}` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImages | object | `{}` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".BuildContextURI | string | `"git://github.com/gojek/merlin.git#refs/tags/v0.1"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".DockerfilePath | string | `"docker/app.Dockerfile"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".ImageName | string | `"pyspark-py37:v0.1.0"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
 | imageBuilder.builderConfig.Resources.Limits.CPU | string | `"1"` |  |
 | imageBuilder.builderConfig.Resources.Limits.Memory | string | `"1Gi"` |  |
 | imageBuilder.builderConfig.Resources.Requests.CPU | string | `"1"` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.12.2](https://img.shields.io/badge/Version-0.12.2-informational?style=flat-square)
+![Version: 0.12.3](https://img.shields.io/badge/Version-0.12.3-informational?style=flat-square)
 ![AppVersion: v0.32.0](https://img.shields.io/badge/AppVersion-v0.32.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
@@ -54,8 +54,14 @@ $ helm uninstall merlin
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
-## Configuration
+### ReleasedVersion
+* The purpose of `.Values.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
+`.Values.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
+Values .Values.config will overwrite the generated that _config.tpl creates
+Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
 
+## Configuration
 The following table lists the configurable parameters of the Merlin chart and their default values.
 
 | Key | Type | Default | Description |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -57,6 +57,7 @@ This includes the dependencies that were installed by the chart. Note that, any 
 ### Rendered field
 * The purpose of `.Values.rendered.*` is to configure parts of the helm chart that use the field * from 1 place
 * For example, `.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+* `.Values.rendered.releasedVersion` should be a git release or tag. If the git release is `v1.0.4` then the `.Values.rendered.releasedVersion` should be `v1.0.4` (keep the v prefix)
 * If `.Values.deployment.image.tag` is specified, it will overwrite the value in `.Values.releasedVersion`
 * The values in `.Values.rendered` will overwrite values in `.Values.config`
 
@@ -338,7 +339,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlp.fullnameOverride | string | `"mlp"` |  |
 | mlp.keto.enabled | bool | `true` |  |
 | mlp.keto.fullnameOverride | string | `"mlp-keto"` |  |
-| rendered.releasedVersion | string | `"0.32.0"` |  |
+| rendered.releasedVersion | string | `"v0.32.0"` |  |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -135,7 +135,6 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.StandardTransformerConfig.FeastServingURLs[1].Icon | string | `"bigtable"` |  |
 | config.StandardTransformerConfig.FeastServingURLs[1].Label | string | `"Online Serving with BigTable"` |  |
 | config.StandardTransformerConfig.FeastServingURLs[1].SourceType | string | `"BIGTABLE"` |  |
-| config.StandardTransformerConfig.ImageName | string | `"ghcr.io/caraml-dev/merlin-transformer:1.0.0"` |  |
 | config.StandardTransformerConfig.Jaeger.CollectorURL | string | `"http://jaeger-tracing-collector.infrastructure:14268/api/traces"` |  |
 | config.StandardTransformerConfig.Jaeger.Disabled | bool | `false` |  |
 | config.StandardTransformerConfig.Jaeger.SamplerParam | int | `1` |  |
@@ -156,7 +155,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.registry | string | `"ghcr.io"` |  |
 | deployment.image.repository | string | `"caraml-dev/merlin"` |  |
-| deployment.image.tag | string | `"0.32.0"` |  |
+| deployment.image.tag | string | `""` |  |
 | deployment.labels | object | `{}` |  |
 | deployment.podLabels | object | `{}` |  |
 | deployment.replicaCount | string | `"2"` |  |
@@ -192,20 +191,14 @@ The following table lists the configurable parameters of the Merlin chart and th
 | environmentConfigs[0].queue_resource_percentage | string | `"20"` |  |
 | environmentConfigs[0].region | string | `"id"` |  |
 | global.protocol | string | `"http"` |  |
-| imageBuilder.builderConfig.BaseImages."3.7.*".BuildContextURI | string | `"git://github.com/gojek/merlin.git#refs/tags/v0.1"` |  |
-| imageBuilder.builderConfig.BaseImages."3.7.*".DockerfilePath | string | `"docker/Dockerfile"` |  |
-| imageBuilder.builderConfig.BaseImages."3.7.*".ImageName | string | `"pyfunc-py37:v0.1.0"` |  |
-| imageBuilder.builderConfig.BaseImages."3.7.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
+| imageBuilder.builderConfig.BaseImages | object | `{}` |  |
 | imageBuilder.builderConfig.BuildNamespace | string | `"mlp"` |  |
 | imageBuilder.builderConfig.BuildTimeout | string | `"30m"` |  |
 | imageBuilder.builderConfig.DockerRegistry | string | `"dockerRegistry"` |  |
 | imageBuilder.builderConfig.KanikoImage | string | `"gcr.io/kaniko-project/executor:v1.6.0"` |  |
 | imageBuilder.builderConfig.MaximumRetry | int | `3` |  |
 | imageBuilder.builderConfig.NodeSelectors | object | `{}` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".BuildContextURI | string | `"git://github.com/gojek/merlin.git#refs/tags/v0.1"` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".DockerfilePath | string | `"docker/app.Dockerfile"` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".ImageName | string | `"pyspark-py37:v0.1.0"` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImages | object | `{}` |  |
 | imageBuilder.builderConfig.Resources.Limits.CPU | string | `"1"` |  |
 | imageBuilder.builderConfig.Resources.Limits.Memory | string | `"1Gi"` |  |
 | imageBuilder.builderConfig.Resources.Requests.CPU | string | `"1"` |  |
@@ -332,6 +325,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlp.fullnameOverride | string | `"mlp"` |  |
 | mlp.keto.enabled | bool | `true` |  |
 | mlp.keto.fullnameOverride | string | `"mlp-keto"` |  |
+| releasedVersion | string | `"0.32.0"` |  |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.12.3](https://img.shields.io/badge/Version-0.12.3-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square)
 ![AppVersion: v0.32.0](https://img.shields.io/badge/AppVersion-v0.32.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -54,11 +54,11 @@ $ helm uninstall merlin
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
-### ReleasedVersion
-* The purpose of `.Values.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
-`.Values.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+### Rendered field
+* The purpose of `.Values.rendered.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
+`.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
 If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
-Values .Values.config will overwrite the generated that _config.tpl creates
+Values.  Rendered values will overwrite values in `.Values.config`
 Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
 
 ## Configuration

--- a/charts/merlin/README.md.gotmpl
+++ b/charts/merlin/README.md.gotmpl
@@ -58,6 +58,7 @@ This includes the dependencies that were installed by the chart. Note that, any 
 ### Rendered field
 * The purpose of `.Values.rendered.*` is to configure parts of the helm chart that use the field * from 1 place
 * For example, `.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+* `.Values.rendered.releasedVersion` should be a git release or tag. If the git release is `v1.0.4` then the `.Values.rendered.releasedVersion` should be `v1.0.4` (keep the v prefix)
 * If `.Values.deployment.image.tag` is specified, it will overwrite the value in `.Values.releasedVersion`
 * The values in `.Values.rendered` will overwrite values in `.Values.config`
 

--- a/charts/merlin/README.md.gotmpl
+++ b/charts/merlin/README.md.gotmpl
@@ -55,8 +55,14 @@ $ helm uninstall merlin
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
-## Configuration
+### ReleasedVersion
+* The purpose of `.Values.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
+`.Values.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
+Values .Values.config will overwrite the generated that _config.tpl creates
+Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
 
+## Configuration
 The following table lists the configurable parameters of the Merlin chart and their default values.
 
 {{ template "chart.valuesTable" . }}

--- a/charts/merlin/README.md.gotmpl
+++ b/charts/merlin/README.md.gotmpl
@@ -56,11 +56,10 @@ The command removes all the Kubernetes components associated with the chart and 
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
 ### Rendered field
-* The purpose of `.Values.rendered.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
-`.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
-If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
-Values.  Rendered values will overwrite values in `.Values.config`
-Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
+* The purpose of `.Values.rendered.*` is to configure parts of the helm chart that use the field * from 1 place
+* For example, `.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+* If `.Values.deployment.image.tag` is specified, it will overwrite the value in `.Values.releasedVersion`
+* The values in `.Values.rendered` will overwrite values in `.Values.config`
 
 ## Configuration
 The following table lists the configurable parameters of the Merlin chart and their default values.

--- a/charts/merlin/README.md.gotmpl
+++ b/charts/merlin/README.md.gotmpl
@@ -55,11 +55,11 @@ $ helm uninstall merlin
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
-### ReleasedVersion
-* The purpose of `.Values.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
-`.Values.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+### Rendered field
+* The purpose of `.Values.rendered.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
+`.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
 If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
-Values .Values.config will overwrite the generated that _config.tpl creates
+Values.  Rendered values will overwrite values in `.Values.config`
 Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
 
 ## Configuration

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -1,0 +1,44 @@
+{{- define "merlin.renderedConfig" -}}
+{{- $tag := index . 0 }}
+ImageBuilderConfig:
+  BaseImages:
+    3.7.*:
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py37:{{ printf "%s" $tag }}
+      DockerfilePath: "docker/Dockerfile"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+    3.8.*:
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py38:{{ printf "%s" $tag }}
+      DockerfilePath: "docker/Dockerfile"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+    3.9.*:
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py39:{{ printf "%s" $tag }}
+      DockerfilePath: "docker/Dockerfile"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+    3.10.*:
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:{{ printf "%s" $tag }}
+      DockerfilePath: "docker/Dockerfile"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+  PredictionJobBaseImages:
+    3.7.*:
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py37:{{ printf "%s" $tag }}
+      DockerfilePath: "docker/app.Dockerfile"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      MainAppPath: "/home/spark/merlin-spark-app/main.py"
+    3.8.*:
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py38:{{ printf "%s" $tag }}
+      DockerfilePath: "docker/app.Dockerfile"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      MainAppPath: "/home/spark/merlin-spark-app/main.py"
+    3.9.*:
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py39:{{ printf "%s" $tag }}
+      DockerfilePath: "docker/app.Dockerfile"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      MainAppPath: "/home/spark/merlin-spark-app/main.py"
+    3.10.*:
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py310:{{ printf "%s" $tag }}
+      DockerfilePath: "docker/app.Dockerfile"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      MainAppPath: "/home/spark/merlin-spark-app/main.py"
+StandardTransformerConfig:
+  ImageName: ghcr.io/caraml-dev/merlin-transformer:{{ printf "%s" $tag }}
+{{- end -}}

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -1,15 +1,17 @@
 {{- define "merlin.contextRef" -}}
 {{- $ := index . 0 }}
 {{- $reference := index . 1 }}
-{{ $.Values.imageBuilder.contextRef | default (printf "refs/tags/v%s" $reference) }}
+{{ $.Values.imageBuilder.contextRef | default (printf "refs/tags/%s" $reference) }}
 {{- end -}}
 
 {{- define "merlin.renderedConfig" -}}
 {{- $ := index . 0 }}
 {{- $rendered := index . 2}}
 {{- if $rendered }}
-{{- $tag := $rendered.releasedVersion}}
-{{- $reference := include "merlin.contextRef" (list $ $tag) | trim }}
+# this is because merlin artifact versions have no v prefix
+# NOTE: Remove the substr once merlin artifacts are released with v prefix
+{{- $tag := $rendered.releasedVersion | substr 1 (len $rendered.releasedVersion) }}
+{{- $reference := include "merlin.contextRef" (list $ $rendered.releasedVersion) | trim }}
 {{ with index . 1 }}
 # Now we have access to the "real" root and current contexts
 # just as if we were outside of include/define:

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -1,8 +1,15 @@
+{{- define "merlin.contextRef" -}}
+{{- $ := index . 0 }}
+{{- $reference := index . 1 }}
+{{ $.Values.imageBuilder.contextRef | default (printf "refs/tags/v%s" $reference) }}
+{{- end -}}
+
 {{- define "merlin.renderedConfig" -}}
 {{- $ := index . 0 }}
 {{- $rendered := index . 2}}
 {{- if $rendered }}
 {{- $tag := $rendered.releasedVersion}}
+{{- $reference := include "merlin.contextRef" (list $ $tag) | trim }}
 {{ with index . 1 }}
 # Now we have access to the "real" root and current contexts
 # just as if we were outside of include/define:
@@ -11,39 +18,39 @@ ImageBuilderConfig:
     3.7.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py37:{{ printf "%s" $tag }}
       DockerfilePath: "docker/Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
     3.8.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py38:{{ printf "%s" $tag }}
       DockerfilePath: "docker/Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
     3.9.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py39:{{ printf "%s" $tag }}
       DockerfilePath: "docker/Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
     3.10.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:{{ printf "%s" $tag }}
       DockerfilePath: "docker/Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
   PredictionJobBaseImages:
     3.7.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py37:{{ printf "%s" $tag }}
       DockerfilePath: "docker/app.Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
       MainAppPath: "/home/spark/merlin-spark-app/main.py"
     3.8.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py38:{{ printf "%s" $tag }}
       DockerfilePath: "docker/app.Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
       MainAppPath: "/home/spark/merlin-spark-app/main.py"
     3.9.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py39:{{ printf "%s" $tag }}
       DockerfilePath: "docker/app.Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
       MainAppPath: "/home/spark/merlin-spark-app/main.py"
     3.10.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py310:{{ printf "%s" $tag }}
       DockerfilePath: "docker/app.Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v{{ printf "%s" $tag }}"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
       MainAppPath: "/home/spark/merlin-spark-app/main.py"
 StandardTransformerConfig:
   ImageName: ghcr.io/caraml-dev/merlin-transformer:{{ printf "%s" $tag }}

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -1,6 +1,7 @@
 {{- define "merlin.renderedConfig" -}}
 {{- $ := index . 0 }}
 {{- $rendered := index . 2}}
+{{- if $rendered }}
 {{- $tag := $rendered.releasedVersion}}
 {{ with index . 1 }}
 # Now we have access to the "real" root and current contexts
@@ -46,5 +47,6 @@ ImageBuilderConfig:
       MainAppPath: "/home/spark/merlin-spark-app/main.py"
 StandardTransformerConfig:
   ImageName: ghcr.io/caraml-dev/merlin-transformer:{{ printf "%s" $tag }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -1,5 +1,10 @@
 {{- define "merlin.renderedConfig" -}}
-{{- $tag := index . 0 }}
+{{- $ := index . 0 }}
+{{- $rendered := index . 2}}
+{{- $tag := $rendered.releasedVersion}}
+{{ with index . 1 }}
+# Now we have access to the "real" root and current contexts
+# just as if we were outside of include/define:
 ImageBuilderConfig:
   BaseImages:
     3.7.*:
@@ -41,4 +46,5 @@ ImageBuilderConfig:
       MainAppPath: "/home/spark/merlin-spark-app/main.py"
 StandardTransformerConfig:
   ImageName: ghcr.io/caraml-dev/merlin-transformer:{{ printf "%s" $tag }}
+{{- end -}}
 {{- end -}}

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -299,12 +299,16 @@ MlflowConfig:
 
 {{- define "merlin.config" -}}
 {{- $defaultConfig := include "merlin.defaultConfig" . | fromYaml -}}
-{{- $renderedConfig := include "merlin.renderedConfig" (list .Values.releasedVersion ) | fromYaml -}}
+{{- $renderedConfig := include "merlin.renderedConfig" (list $ . .Values.rendered ) | fromYaml -}}
 {{-  merge .Values.config $renderedConfig $defaultConfig | toYaml }}
 {{- end -}}
 
 
 {{- define "merlin.deploymentTag" -}}
-{{- $tag :=  ternary .Values.deployment.image.tag .Values.releasedVersion (ne .Values.deployment.image.tag "") -}}
-{{- printf "%s%s:%s" (ternary (printf "%s/" .Values.deployment.image.registry) "" (ne .Values.deployment.image.registry "")) .Values.deployment.image.repository $tag -}}
+{{- $ := index . 0 }}
+{{- $rendered := index . 2 }}
+{{- with index . 1}}
+{{- $tag :=  ternary $.Values.deployment.image.tag $rendered.releasedVersion (ne $.Values.deployment.image.tag "") -}}
+{{- printf "%s%s:%s" (ternary (printf "%s/" $.Values.deployment.image.registry) "" (ne $.Values.deployment.image.registry "")) $.Values.deployment.image.repository $tag -}}
+{{- end -}}
 {{- end -}}

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -308,7 +308,7 @@ MlflowConfig:
 {{- $ := index . 0 }}
 {{- $rendered := index . 2 }}
 {{- with index . 1}}
-{{- $tag :=  ternary $.Values.deployment.image.tag $rendered.releasedVersion (ne $.Values.deployment.image.tag "") -}}
+{{- $tag :=  ternary $.Values.deployment.image.tag (substr 1 (len $rendered.releasedVersion) $rendered.releasedVersion) (ne $.Values.deployment.image.tag "") -}}
 {{- printf "%s%s:%s" (ternary (printf "%s/" $.Values.deployment.image.registry) "" (ne $.Values.deployment.image.registry "")) $.Values.deployment.image.repository $tag -}}
 {{- end -}}
 {{- end -}}

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -299,5 +299,12 @@ MlflowConfig:
 
 {{- define "merlin.config" -}}
 {{- $defaultConfig := include "merlin.defaultConfig" . | fromYaml -}}
-{{ .Values.config | merge $defaultConfig | toYaml }}
+{{- $renderedConfig := include "merlin.renderedConfig" (list .Values.releasedVersion ) | fromYaml -}}
+{{  .Values.config | merge ( $renderedConfig | merge $defaultConfig) | toYaml }}
+{{- end -}}
+
+
+{{- define "merlin.deploymentTag" -}}
+{{- $tag :=  ternary .Values.deployment.image.tag .Values.releasedVersion (ne .Values.deployment.image.tag "") -}}
+{{- printf "%s%s:%s" (ternary (printf "%s/" .Values.deployment.image.registry) "" (ne .Values.deployment.image.registry "")) .Values.deployment.image.repository $tag -}}
 {{- end -}}

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -300,7 +300,7 @@ MlflowConfig:
 {{- define "merlin.config" -}}
 {{- $defaultConfig := include "merlin.defaultConfig" . | fromYaml -}}
 {{- $renderedConfig := include "merlin.renderedConfig" (list .Values.releasedVersion ) | fromYaml -}}
-{{  .Values.config | merge ( $renderedConfig | merge $defaultConfig) | toYaml }}
+{{-  merge .Values.config $renderedConfig $defaultConfig | toYaml }}
 {{- end -}}
 
 

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -300,7 +300,7 @@ MlflowConfig:
 {{- define "merlin.config" -}}
 {{- $defaultConfig := include "merlin.defaultConfig" . | fromYaml -}}
 {{- $renderedConfig := include "merlin.renderedConfig" (list $ . .Values.rendered ) | fromYaml -}}
-{{-  merge .Values.config $renderedConfig $defaultConfig | toYaml }}
+{{-  merge $renderedConfig $defaultConfig .Values.config | toYaml }}
 {{- end -}}
 
 

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
       - name: merlin
-        image: "{{- if .Values.deployment.image.registry -}}{{ .Values.deployment.image.registry }}/{{- end -}}{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+        image: {{ template "merlin.deploymentTag" . }}
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         ports:
           - containerPort: {{ .Values.service.internalPort }}

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
       - name: merlin
-        image: {{ template "merlin.deploymentTag" . }}
+        image: {{ include "merlin.deploymentTag" (list $ . .Values.rendered) }}
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         ports:
           - containerPort: {{ .Values.service.internalPort }}

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -111,3 +111,54 @@ tests:
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "KanikoServiceAccount: kaniko-my-release-merlin"
+
+  - it: should use rendered version
+    set:
+      rendered:
+        releasedVersion: 1.0.0-test-release
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-merlin-config$
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py37:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py38:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py39:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py37:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py38:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py39:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py310:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0-test-release"
+  - it: should use imageBuildeer contextRef when set
+    set:
+      imageBuilder:
+        contextRef: "refs/branch/test"
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-merlin-config$
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "BuildContextURI: git://github.com/caraml-dev/merlin.git#refs/branch/test"

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -115,7 +115,7 @@ tests:
   - it: should use rendered version
     set:
       rendered:
-        releasedVersion: 1.0.0-test-release
+        releasedVersion: v1.0.0-test-release
     asserts:
       - isKind:
           of: Secret

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -149,7 +149,7 @@ tests:
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0-test-release"
-  - it: should use imageBuildeer contextRef when set
+  - it: should use imageBuilder contextRef when set
     set:
       imageBuilder:
         contextRef: "refs/branch/test"

--- a/charts/merlin/tests/merlin_deployment_test.yaml
+++ b/charts/merlin/tests/merlin_deployment_test.yaml
@@ -122,3 +122,20 @@ tests:
       - equal: # check database secret key
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
           value: postgresql-password
+
+  - it: should set releasedVersion as deployment image tag if deployment image tag is unset
+    set:
+      deployment:
+        image:
+          tag: ""
+      rendered:
+        releasedVersion: 1.0.0-test-released-version
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-merlin$
+      - equal: # check database secret name
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/caraml-dev/merlin:1.0.0-test-released-version

--- a/charts/merlin/tests/merlin_deployment_test.yaml
+++ b/charts/merlin/tests/merlin_deployment_test.yaml
@@ -129,7 +129,7 @@ tests:
         image:
           tag: ""
       rendered:
-        releasedVersion: 1.0.0-test-released-version
+        releasedVersion: v1.0.0-test-released-version
     asserts:
       - isKind:
           of: Deployment

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -1,10 +1,14 @@
 global:
   protocol: http
 
-# rendered takes precedence over fields defined in config
-# set to empty dictionary to use values in config
+# .rendered takes precedence over fields defined in .config
+# set .rendered to an empty dictionary to use the values specified in
+# .config when generating templates
 rendered:
   releasedVersion: 0.32.0
+
+# set deployment.image.tag to non-nil to overwrite
+# .rendered.releasedVersion
 deployment:
   image:
     pullPolicy: IfNotPresent

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -1,5 +1,8 @@
 global:
   protocol: http
+
+# rendered takes precedence over fields defined in config
+# set to empty dictionary to use values in config
 rendered:
   releasedVersion: 0.32.0
 deployment:
@@ -82,6 +85,7 @@ deployment:
   # - name: varlog
   #   mountPath: /var/log
 
+# if rendered is set, rendered template will overwrite config
 config:
   DeploymentLabelPrefix: "gojek.com/"
   Environment: dev
@@ -150,7 +154,7 @@ config:
     CPUCost:  # Unused
     MemoryCost:  # Unused
   StandardTransformerConfig:
-    # ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0
+    ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0
     SimulationFeast:
       FeastRedisURL: online-serving-redis.feast.dev
       FeastBigtableURL: online-serving-bt.feast.dev
@@ -243,18 +247,18 @@ imageBuilder:
   #     interactiveMode: IfAvailable
   #     provideClusterInfo: true
   builderConfig:
-    BaseImages: {}
-    #   3.7.*:
-    #     ImageName: pyfunc-py37:v0.1.0
-    #     DockerfilePath: "docker/Dockerfile"
-    #     BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
-    #     MainAppPath: /merlin-spark-app/main.py
-    PredictionJobBaseImages: {}
-      # 3.7.*:
-      #   ImageName: pyspark-py37:v0.1.0
-      #   DockerfilePath: "docker/app.Dockerfile"
-      #   BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
-      #   MainAppPath: /merlin-spark-app/main.py
+    BaseImages:
+      3.7.*:
+        ImageName: pyfunc-py37:v0.1.0
+        DockerfilePath: "docker/Dockerfile"
+        BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
+        MainAppPath: /merlin-spark-app/main.py
+    PredictionJobBaseImages:
+      3.7.*:
+        ImageName: pyspark-py37:v0.1.0
+        DockerfilePath: "docker/app.Dockerfile"
+        BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
+        MainAppPath: /merlin-spark-app/main.py
     BuildNamespace: "mlp"
     DockerRegistry: "dockerRegistry"
     BuildTimeout: "30m"

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -1,6 +1,7 @@
 global:
   protocol: http
-releasedVersion: 0.32.0
+rendered:
+  releasedVersion: 0.32.0
 deployment:
   image:
     pullPolicy: IfNotPresent

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -5,7 +5,8 @@ global:
 # set .rendered to an empty dictionary to use the values specified in
 # .config when generating templates
 rendered:
-  releasedVersion: 0.32.0
+  # releasedVersion refers to the git release or tag
+  releasedVersion: v0.32.0
 
 # set deployment.image.tag to non-nil to overwrite
 # .rendered.releasedVersion

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -222,6 +222,7 @@ clusterConfig:
   environmentConfigPath: "environments.yaml"
 
 imageBuilder:
+  contextRef: ""
   serviceAccount:
     create: true
     name: "kaniko"

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -1,11 +1,12 @@
 global:
   protocol: http
+releasedVersion: 0.32.0
 deployment:
   image:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: caraml-dev/merlin
-    tag: 0.32.0
+    tag: ""
   replicaCount: "2"
   # Additional labels to apply to the deployment
   labels: {}
@@ -148,7 +149,7 @@ config:
     CPUCost:  # Unused
     MemoryCost:  # Unused
   StandardTransformerConfig:
-    ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0
+    # ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0
     SimulationFeast:
       FeastRedisURL: online-serving-redis.feast.dev
       FeastBigtableURL: online-serving-bt.feast.dev
@@ -240,18 +241,18 @@ imageBuilder:
   #     interactiveMode: IfAvailable
   #     provideClusterInfo: true
   builderConfig:
-    BaseImages:
-      3.7.*:
-        ImageName: pyfunc-py37:v0.1.0
-        DockerfilePath: "docker/Dockerfile"
-        BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
-        MainAppPath: /merlin-spark-app/main.py
-    PredictionJobBaseImages:
-      3.7.*:
-        ImageName: pyspark-py37:v0.1.0
-        DockerfilePath: "docker/app.Dockerfile"
-        BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
-        MainAppPath: /merlin-spark-app/main.py
+    BaseImages: {}
+    #   3.7.*:
+    #     ImageName: pyfunc-py37:v0.1.0
+    #     DockerfilePath: "docker/Dockerfile"
+    #     BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
+    #     MainAppPath: /merlin-spark-app/main.py
+    PredictionJobBaseImages: {}
+      # 3.7.*:
+      #   ImageName: pyspark-py37:v0.1.0
+      #   DockerfilePath: "docker/app.Dockerfile"
+      #   BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
+      #   MainAppPath: /merlin-spark-app/main.py
     BuildNamespace: "mlp"
     DockerRegistry: "dockerRegistry"
     BuildTimeout: "30m"

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.35
+version: 0.3.0

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -23,4 +23,3 @@ maintainers:
   name: caraml-dev
 name: turing
 version: 0.3.0
-

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.11.0
+appVersion: 1.14.2
 dependencies:
 - alias: turing-postgresql
   condition: turing-postgresql.enabled

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -76,7 +76,6 @@ The following table lists the configurable parameters of the Turing chart and th
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` | HTTP path for liveness check |
 | deployment.readinessProbe.path | string | `"/v1/internal/ready"` | HTTP path for readiness check |
 | deployment.resources | object | `{}` | Resources requests and limits for Turing API. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
-| ensemblerTag | string | `"v0.0.0-build.321-78ca7b3"` |  |
 | environmentConfigs | list | `[{"k8s_config":{"cluster":{},"name":"dev-cluster","user":{}},"name":"dev"}]` | Set this field to configure environment configs. See api/environments-dev.yaml for sample structure |
 | experimentEngines | list | `[]` | Turing Experiment Engines configuration |
 | global.protocol | string | `"http"` |  |
@@ -96,7 +95,8 @@ The following table lists the configurable parameters of the Turing chart and th
 | mlp.enabled | bool | `true` |  |
 | mlp.environmentConfigSecret.name | string | `""` |  |
 | openApiSpecOverrides | object | `{}` | Override OpenAPI spec as long as it follows the OAS3 specifications. A common use for this is to set the enums of the ExperimentEngineType. See api/api/override-sample.yaml for an example. |
-| releasedVersion | string | `"1.11.0"` |  |
+| rendered.ensemblerTag | string | `"v0.0.0-build.321-78ca7b3"` |  |
+| rendered.releasedVersion | string | `"1.11.0"` |  |
 | sentry.dsn | string | `""` | Sentry DSN value used by both Turing API and Turing UI |
 | service.externalPort | int | `8080` | Turing API Kubernetes service port number |
 | service.internalPort | int | `8080` | Turing API container port number |

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,6 @@
 # turing
 
 ---
-
 ![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.35](https://img.shields.io/badge/Version-0.2.35-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -57,6 +57,7 @@ This includes the dependencies that were installed by the chart. Note that, any 
 ### Rendered field
 * The purpose of `.Values.rendered.*` is to configure parts of the helm chart that use the field * from 1 place
 * For example, `.Values.rendered.releasedVersion` is used in rendering `turing.config` partial template and `turing.image` partial template
+* `.Values.rendered.releasedVersion` should be a git release or tag. If the git release is `v1.0.4` then the `.Values.rendered.releasedVersion` should be `v1.0.4` (keep the v prefix)
 * If `.Values.deployment.image.tag` is specified, it will overwrite the value in `.Values.releasedVersion`
 * The values in `.Values.rendered` will overwrite values in `.Values.config`
 
@@ -101,8 +102,8 @@ The following table lists the configurable parameters of the Turing chart and th
 | mlp.enabled | bool | `true` |  |
 | mlp.environmentConfigSecret.name | string | `""` |  |
 | openApiSpecOverrides | object | `{}` | Override OpenAPI spec as long as it follows the OAS3 specifications. A common use for this is to set the enums of the ExperimentEngineType. See api/api/override-sample.yaml for an example. |
-| rendered.ensemblerTag | string | `"v0.0.0-build.321-78ca7b3"` |  |
-| rendered.releasedVersion | string | `"1.11.0"` |  |
+| rendered.ensemblerTag | string | `"v0.0.0-build.321-78ca7b3"` | ensemblerTag refers to the docker image tag |
+| rendered.releasedVersion | string | `"v1.11.0"` | releasedVersion refers to the git release or tag |
 | sentry.dsn | string | `""` | Sentry DSN value used by both Turing API and Turing UI |
 | service.externalPort | int | `8080` | Turing API Kubernetes service port number |
 | service.internalPort | int | `8080` | Turing API container port number |

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -2,7 +2,7 @@
 
 ---
 ![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
-![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
+![AppVersion: 1.14.2](https://img.shields.io/badge/AppVersion-1.14.2-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
 
@@ -103,7 +103,7 @@ The following table lists the configurable parameters of the Turing chart and th
 | mlp.environmentConfigSecret.name | string | `""` |  |
 | openApiSpecOverrides | object | `{}` | Override OpenAPI spec as long as it follows the OAS3 specifications. A common use for this is to set the enums of the ExperimentEngineType. See api/api/override-sample.yaml for an example. |
 | rendered.ensemblerTag | string | `"v0.0.0-build.321-78ca7b3"` | ensemblerTag refers to the docker image tag |
-| rendered.releasedVersion | string | `"v1.11.0"` | releasedVersion refers to the git release or tag |
+| rendered.releasedVersion | string | `"v1.14.2"` | releasedVersion refers to the git release or tag |
 | sentry.dsn | string | `""` | Sentry DSN value used by both Turing API and Turing UI |
 | service.externalPort | int | `8080` | Turing API Kubernetes service port number |
 | service.internalPort | int | `8080` | Turing API container port number |

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -54,6 +54,13 @@ $ helm uninstall turing
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
+### Rendered field
+* The purpose of `.Values.rendered.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
+`.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
+Values.  Rendered values will overwrite values in `.Values.config`
+Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
+
 ## Configuration
 
 The following table lists the configurable parameters of the Turing chart and their default values.

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -76,6 +76,7 @@ The following table lists the configurable parameters of the Turing chart and th
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` | HTTP path for liveness check |
 | deployment.readinessProbe.path | string | `"/v1/internal/ready"` | HTTP path for readiness check |
 | deployment.resources | object | `{}` | Resources requests and limits for Turing API. This should be set according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| ensemblerTag | string | `"v0.0.0-build.321-78ca7b3"` |  |
 | environmentConfigs | list | `[{"k8s_config":{"cluster":{},"name":"dev-cluster","user":{}},"name":"dev"}]` | Set this field to configure environment configs. See api/environments-dev.yaml for sample structure |
 | experimentEngines | list | `[]` | Turing Experiment Engines configuration |
 | global.protocol | string | `"http"` |  |
@@ -95,6 +96,7 @@ The following table lists the configurable parameters of the Turing chart and th
 | mlp.enabled | bool | `true` |  |
 | mlp.environmentConfigSecret.name | string | `""` |  |
 | openApiSpecOverrides | object | `{}` | Override OpenAPI spec as long as it follows the OAS3 specifications. A common use for this is to set the enums of the ExperimentEngineType. See api/api/override-sample.yaml for an example. |
+| releasedVersion | string | `"1.11.0"` |  |
 | sentry.dsn | string | `""` | Sentry DSN value used by both Turing API and Turing UI |
 | service.externalPort | int | `8080` | Turing API Kubernetes service port number |
 | service.internalPort | int | `8080` | Turing API container port number |

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -55,11 +55,10 @@ The command removes all the Kubernetes components associated with the chart and 
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
 ### Rendered field
-* The purpose of `.Values.rendered.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
-`.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
-If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
-Values.  Rendered values will overwrite values in `.Values.config`
-Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
+* The purpose of `.Values.rendered.*` is to configure parts of the helm chart that use the field * from 1 place
+* For example, `.Values.rendered.releasedVersion` is used in rendering `turing.config` partial template and `turing.image` partial template
+* If `.Values.deployment.image.tag` is specified, it will overwrite the value in `.Values.releasedVersion`
+* The values in `.Values.rendered` will overwrite values in `.Values.config`
 
 ## Configuration
 
@@ -78,7 +77,7 @@ The following table lists the configurable parameters of the Turing chart and th
 | deployment.extraVolumes | list | `[]` | Extra volumes to attach to the Pod. For example, you can mount additional secrets to these volumes |
 | deployment.image.registry | string | `"ghcr.io"` | Docker registry for Turing image |
 | deployment.image.repository | string | `"caraml-dev/turing"` | Docker image repository for Turing image |
-| deployment.image.tag | string | `"v1.11.0-build.6-5695fb3"` | Docker image tag for Turing image |
+| deployment.image.tag | string | `""` | Docker image tag for Turing image |
 | deployment.labels | object | `{}` |  |
 | deployment.livenessProbe.path | string | `"/v1/internal/live"` | HTTP path for liveness check |
 | deployment.readinessProbe.path | string | `"/v1/internal/ready"` | HTTP path for readiness check |

--- a/charts/turing/README.md.gotmpl
+++ b/charts/turing/README.md.gotmpl
@@ -58,6 +58,7 @@ This includes the dependencies that were installed by the chart. Note that, any 
 ### Rendered field
 * The purpose of `.Values.rendered.*` is to configure parts of the helm chart that use the field * from 1 place
 * For example, `.Values.rendered.releasedVersion` is used in rendering `turing.config` partial template and `turing.image` partial template
+* `.Values.rendered.releasedVersion` should be a git release or tag. If the git release is `v1.0.4` then the `.Values.rendered.releasedVersion` should be `v1.0.4` (keep the v prefix)
 * If `.Values.deployment.image.tag` is specified, it will overwrite the value in `.Values.releasedVersion`
 * The values in `.Values.rendered` will overwrite values in `.Values.config`
 

--- a/charts/turing/README.md.gotmpl
+++ b/charts/turing/README.md.gotmpl
@@ -55,6 +55,13 @@ $ helm uninstall turing
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
+### Rendered field
+* The purpose of `.Values.rendered.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
+`.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
+If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
+Values.  Rendered values will overwrite values in `.Values.config`
+Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
+
 ## Configuration
 
 The following table lists the configurable parameters of the Turing chart and their default values.

--- a/charts/turing/README.md.gotmpl
+++ b/charts/turing/README.md.gotmpl
@@ -56,11 +56,10 @@ The command removes all the Kubernetes components associated with the chart and 
 This includes the dependencies that were installed by the chart. Note that, any PVCs created by the chart will have to be deleted manually.
 
 ### Rendered field
-* The purpose of `.Values.rendered.releasedVersion` is to update all configs that share this tag using this 1 value in values.yaml
-`.Values.rendered.releasedVersion` is used in rendering `merlin.config` partial template and `merlin.deploymentTag` partial template
-If .Values.deployment.image.tag is specified, it will overwrite the value in .Values.releasedVersion
-Values.  Rendered values will overwrite values in `.Values.config`
-Default value for .Value.deployment.image.tag and .Values.config is set to empty string respectively
+* The purpose of `.Values.rendered.*` is to configure parts of the helm chart that use the field * from 1 place
+* For example, `.Values.rendered.releasedVersion` is used in rendering `turing.config` partial template and `turing.image` partial template
+* If `.Values.deployment.image.tag` is specified, it will overwrite the value in `.Values.releasedVersion`
+* The values in `.Values.rendered` will overwrite values in `.Values.config`
 
 ## Configuration
 

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -1,6 +1,7 @@
 {{- define "turing.renderedConfig" -}}
 {{- $ := index . 0 }}
 {{- $rendered := index . 2}}
+{{- if $rendered }}
 {{- $tag := $rendered.releasedVersion}}
 {{- $ensemblerTag := $rendered.ensemblerTag }}
 {{- $imagePrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py" -}}
@@ -27,4 +28,5 @@ EnsemblerServiceBuilderConfig:
       <<: *kanikoConfig
 RouterDefaults:
   Image: ghcr.io/caraml-dev/turing/turing-router:v{{ printf "%s" $tag }}
+{{- end -}}
 {{- end -}}

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -1,6 +1,8 @@
 {{- define "turing.renderedConfig" -}}
-{{- $tag := index . 0 }}
-{{- $ensemblerTag := index . 1 }}
+{{- $ := index . 0 }}
+{{- $rendered := index . 2}}
+{{- $tag := $rendered.releasedVersion}}
+{{- $ensemblerTag := $rendered.ensemblerTag }}
 {{- $imagePrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py" -}}
 {{- $imagePrefix2 := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py" -}}
 BatchEnsemblingConfig:

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -1,0 +1,28 @@
+{{- define "turing.renderedConfig" -}}
+{{- $tag := index . 0 }}
+{{- $ensemblerTag := index . 1 }}
+{{- $imagePrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py" -}}
+{{- $imagePrefix2 := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py" -}}
+BatchEnsemblingConfig:
+  ImageBuildingConfig: &imageBuildingConfig
+    DestinationRegistry: asia.gcr.io/gods-production/turing/ensemblers
+    BaseImageRef:
+      3.7.*: {{ printf "%s%s:%s" $imagePrefix "3.7" $ensemblerTag }}
+      3.8.*: {{ printf "%s%s:%s" $imagePrefix "3.8" $ensemblerTag }}
+      3.9.*: {{printf "%s%s:%s" $imagePrefix "3.9" $ensemblerTag }}
+      3.10.*: {{ printf "%s%s:%s" $imagePrefix "3.10" $ensemblerTag }}
+  KanikoConfig: &kanikoConfig
+    BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags/v" $tag }}
+EnsemblerServiceBuilderConfig:
+  ClusterName: products-production
+  ImageBuildingConfig:
+    BaseImageRef:
+        3.7.*: {{ printf "%s%s:%s" $imagePrefix2 "3.7" $ensemblerTag }}
+        3.8.*: {{ printf "%s%s:%s" $imagePrefix2 "3.8" $ensemblerTag }}
+        3.9.*: {{printf "%s%s:%s" $imagePrefix2 "3.9" $ensemblerTag }}
+        3.10.*: {{ printf "%s%s:%s" $imagePrefix2 "3.10" $ensemblerTag }}
+    KanikoConfig:
+      <<: *kanikoConfig
+RouterDefaults:
+  Image: ghcr.io/caraml-dev/turing/turing-router:v{{ printf "%s" $tag }}
+{{- end -}}

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -19,7 +19,7 @@ BatchEnsemblingConfig:
       3.9.*: {{printf "%s%s:%s" $ensmblerJobPrefix "3.9" $ensemblerTag }}
       3.10.*: {{ printf "%s%s:%s" $ensmblerJobPrefix "3.10" $ensemblerTag }}
     KanikoConfig:
-      BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags/v" $tag }}
+      BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags" $tag }}
 {{- end -}}
 EnsemblerServiceBuilderConfig:
   ClusterName: products-production
@@ -30,9 +30,9 @@ EnsemblerServiceBuilderConfig:
         3.9.*: {{printf "%s%s:%s" $servicePrefix "3.9" $ensemblerTag }}
         3.10.*: {{ printf "%s%s:%s" $servicePrefix "3.10" $ensemblerTag }}
     KanikoConfig: &kanikoConfig
-      BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags/v" $tag }}
+      BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags" $tag }}
 RouterDefaults:
-  Image: ghcr.io/caraml-dev/turing/turing-router:v{{ printf "%s" $tag }}
+  Image: ghcr.io/caraml-dev/turing/turing-router:{{ printf "%s" $tag }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -6,16 +6,21 @@
 {{- $ensemblerTag := $rendered.ensemblerTag }}
 {{- $imagePrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py" -}}
 {{- $imagePrefix2 := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py" -}}
+# Now we have access to the "real" root and current contexts
+# just as if we were outside of include/define:
+{{ with index . 1 }}
+{{- if $.Values.config.BatchEnsemblingConfig.Enabled }}
 BatchEnsemblingConfig:
-  ImageBuildingConfig: &imageBuildingConfig
+  ImageBuildingConfig:
     DestinationRegistry: asia.gcr.io/gods-production/turing/ensemblers
     BaseImageRef:
       3.7.*: {{ printf "%s%s:%s" $imagePrefix "3.7" $ensemblerTag }}
       3.8.*: {{ printf "%s%s:%s" $imagePrefix "3.8" $ensemblerTag }}
       3.9.*: {{printf "%s%s:%s" $imagePrefix "3.9" $ensemblerTag }}
       3.10.*: {{ printf "%s%s:%s" $imagePrefix "3.10" $ensemblerTag }}
-  KanikoConfig: &kanikoConfig
-    BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags/v" $tag }}
+    KanikoConfig:
+      BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags/v" $tag }}
+{{- end -}}
 EnsemblerServiceBuilderConfig:
   ClusterName: products-production
   ImageBuildingConfig:
@@ -24,9 +29,10 @@ EnsemblerServiceBuilderConfig:
         3.8.*: {{ printf "%s%s:%s" $imagePrefix2 "3.8" $ensemblerTag }}
         3.9.*: {{printf "%s%s:%s" $imagePrefix2 "3.9" $ensemblerTag }}
         3.10.*: {{ printf "%s%s:%s" $imagePrefix2 "3.10" $ensemblerTag }}
-    KanikoConfig:
-      <<: *kanikoConfig
+    KanikoConfig: &kanikoConfig
+      BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags/v" $tag }}
 RouterDefaults:
   Image: ghcr.io/caraml-dev/turing/turing-router:v{{ printf "%s" $tag }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -4,8 +4,8 @@
 {{- if $rendered }}
 {{- $tag := $rendered.releasedVersion}}
 {{- $ensemblerTag := $rendered.ensemblerTag }}
-{{- $imagePrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py" -}}
-{{- $imagePrefix2 := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py" -}}
+{{- $ensmblerJobPrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py" -}}
+{{- $servicePrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py" -}}
 # Now we have access to the "real" root and current contexts
 # just as if we were outside of include/define:
 {{ with index . 1 }}
@@ -14,10 +14,10 @@ BatchEnsemblingConfig:
   ImageBuildingConfig:
     DestinationRegistry: asia.gcr.io/gods-production/turing/ensemblers
     BaseImageRef:
-      3.7.*: {{ printf "%s%s:%s" $imagePrefix "3.7" $ensemblerTag }}
-      3.8.*: {{ printf "%s%s:%s" $imagePrefix "3.8" $ensemblerTag }}
-      3.9.*: {{printf "%s%s:%s" $imagePrefix "3.9" $ensemblerTag }}
-      3.10.*: {{ printf "%s%s:%s" $imagePrefix "3.10" $ensemblerTag }}
+      3.7.*: {{ printf "%s%s:%s" $ensmblerJobPrefix "3.7" $ensemblerTag }}
+      3.8.*: {{ printf "%s%s:%s" $ensmblerJobPrefix "3.8" $ensemblerTag }}
+      3.9.*: {{printf "%s%s:%s" $ensmblerJobPrefix "3.9" $ensemblerTag }}
+      3.10.*: {{ printf "%s%s:%s" $ensmblerJobPrefix "3.10" $ensemblerTag }}
     KanikoConfig:
       BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags/v" $tag }}
 {{- end -}}
@@ -25,10 +25,10 @@ EnsemblerServiceBuilderConfig:
   ClusterName: products-production
   ImageBuildingConfig:
     BaseImageRef:
-        3.7.*: {{ printf "%s%s:%s" $imagePrefix2 "3.7" $ensemblerTag }}
-        3.8.*: {{ printf "%s%s:%s" $imagePrefix2 "3.8" $ensemblerTag }}
-        3.9.*: {{printf "%s%s:%s" $imagePrefix2 "3.9" $ensemblerTag }}
-        3.10.*: {{ printf "%s%s:%s" $imagePrefix2 "3.10" $ensemblerTag }}
+        3.7.*: {{ printf "%s%s:%s" $servicePrefix "3.7" $ensemblerTag }}
+        3.8.*: {{ printf "%s%s:%s" $servicePrefix "3.8" $ensemblerTag }}
+        3.9.*: {{printf "%s%s:%s" $servicePrefix "3.9" $ensemblerTag }}
+        3.10.*: {{ printf "%s%s:%s" $servicePrefix "3.10" $ensemblerTag }}
     KanikoConfig: &kanikoConfig
       BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags/v" $tag }}
 RouterDefaults:

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -38,7 +38,7 @@ heritage: {{ .Release.Service }}
 {{- define "turing.image" -}}
 {{- $registryName := .Values.deployment.image.registry -}}
 {{- $repositoryName := .Values.deployment.image.repository -}}
-{{- $tag :=  (ternary .Values.deployment.image.tag .Values.releasedVersion (ne .Values.deployment.image.tag "")) | toString -}}
+{{- $tag :=  (ternary .Values.deployment.image.tag .Values.rendered.releasedVersion (ne .Values.deployment.image.tag "")) | toString -}}
 {{- if $registryName }}
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- else -}}
@@ -254,6 +254,6 @@ OpenapiConfig:
 
 {{- define "turing.config" -}}
 {{- $defaultConfig := include "turing.defaultConfig" . | fromYaml -}}
-{{- $renderedConfig := include "turing.renderedConfig" (list .Values.releasedVersion .Values.ensemblerTag ) | fromYaml -}}
+{{- $renderedConfig := include "turing.renderedConfig" (list $ . .Values.rendered ) | fromYaml -}}
 {{-  merge .Values.config $renderedConfig $defaultConfig | toYaml }}
 {{- end -}}

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -38,7 +38,7 @@ heritage: {{ .Release.Service }}
 {{- define "turing.image" -}}
 {{- $registryName := .Values.deployment.image.registry -}}
 {{- $repositoryName := .Values.deployment.image.repository -}}
-{{- $tag := .Values.deployment.image.tag | toString -}}
+{{- $tag :=  (ternary .Values.deployment.image.tag .Values.releasedVersion (ne .Values.deployment.image.tag "")) | toString -}}
 {{- if $registryName }}
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- else -}}
@@ -202,7 +202,7 @@ EnsemblerServiceBuilderConfig:
 ClusterConfig:
   InClusterConfig: {{ .Values.clusterConfig.useInClusterConfig }}
   EnvironmentConfigPath: {{ include "turing.environments.absolutePath" . }}
-  EnsemblingServiceK8sConfig: 
+  EnsemblingServiceK8sConfig:
 {{ .Values.imageBuilder.k8sConfig | toYaml | indent 4}}
 DbConfig:
   Host: {{ include "common.postgres-host" (list (index .Values "turing-postgresql") .Values.turingExternalPostgresql .Release .Chart ) }}
@@ -254,5 +254,6 @@ OpenapiConfig:
 
 {{- define "turing.config" -}}
 {{- $defaultConfig := include "turing.defaultConfig" . | fromYaml -}}
-{{ .Values.config | merge $defaultConfig | toYaml }}
+{{- $renderedConfig := include "turing.renderedConfig" (list .Values.releasedVersion .Values.ensemblerTag ) | fromYaml -}}
+{{-  merge .Values.config $renderedConfig $defaultConfig | toYaml }}
 {{- end -}}

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -255,5 +255,5 @@ OpenapiConfig:
 {{- define "turing.config" -}}
 {{- $defaultConfig := include "turing.defaultConfig" . | fromYaml -}}
 {{- $renderedConfig := include "turing.renderedConfig" (list $ . .Values.rendered ) | fromYaml -}}
-{{-  merge .Values.config $renderedConfig $defaultConfig | toYaml }}
+{{-  merge $renderedConfig $defaultConfig .Values.config | toYaml }}
 {{- end -}}

--- a/charts/turing/tests/turing_config_secret_test.yaml
+++ b/charts/turing/tests/turing_config_secret_test.yaml
@@ -115,13 +115,13 @@ tests:
           pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "3.7.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.7:some-ensembler-tag"
+          pattern: "3.7\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.7:some-ensembler-tag"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "3.8.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.8:some-ensembler-tag"
+          pattern: "3.8\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.8:some-ensembler-tag"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "3.9.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.9:some-ensembler-tag"
+          pattern: "3.9\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.9:some-ensembler-tag"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "3.10.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.10:some-ensembler-tag"
+          pattern: "3.10\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.10:some-ensembler-tag"

--- a/charts/turing/tests/turing_config_secret_test.yaml
+++ b/charts/turing/tests/turing_config_secret_test.yaml
@@ -99,7 +99,7 @@ tests:
   - it: should use rendered version
     set:
       rendered:
-        releasedVersion: 1.0.0-test-release
+        releasedVersion: v1.0.0-test-release
         ensemblerTag: some-ensembler-tag
     asserts:
       - isKind:
@@ -109,7 +109,7 @@ tests:
           pattern: my-release-turing-config$
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "BuildContextURI: git://github.com/caraml-dev/turing.git#refs/tags/v/1.0.0-test-release"
+          pattern: "BuildContextURI: git://github.com/caraml-dev/turing.git#refs/tags/v1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"

--- a/charts/turing/tests/turing_config_secret_test.yaml
+++ b/charts/turing/tests/turing_config_secret_test.yaml
@@ -31,7 +31,7 @@ tests:
       - matchRegex: # check database user
           path: stringData.[config.yaml]
           pattern: "User: turing"
-  
+
   - it: should set database secret key and name from values if chart specific db is disabled, external db is enabled, secret name & key are set
     set:
       global: {}
@@ -58,7 +58,7 @@ tests:
       - matchRegex: # check database user
           path: stringData.[config.yaml]
           pattern: "User: turing-ext"
-  
+
   - it: should set authz url from values
     set:
       global: {}
@@ -95,3 +95,33 @@ tests:
       - matchRegex: # check authorization url
           path: stringData.[config.yaml]
           pattern: "AuthConfig:\n  Enabled: false\n  URL: http://caraml-authz"
+
+  - it: should use rendered version
+    set:
+      rendered:
+        releasedVersion: 1.0.0-test-release
+        ensemblerTag: some-ensembler-tag
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-turing-config$
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "BuildContextURI: git://github.com/caraml-dev/turing.git#refs/tags/v/1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.7.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.7:some-ensembler-tag"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.8.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.8:some-ensembler-tag"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.9.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.9:some-ensembler-tag"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.10.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.10:some-ensembler-tag"

--- a/charts/turing/tests/turing_deployment_test.yaml
+++ b/charts/turing/tests/turing_deployment_test.yaml
@@ -28,7 +28,7 @@ tests:
       - equal: # check database secret key
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
           value: postgresql-password
-  
+
   - it: should set database secret key and name from values if chart specific db is disabled, external db is enabled, createSecret is set
     set:
       global: {}
@@ -78,3 +78,19 @@ tests:
       - equal: # check database secret key
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
           value: secret-key
+  - it: should set releasedVersion as deployment image tag if deployment image tag is unset
+    set:
+      deployment:
+        image:
+          tag: ""
+      rendered:
+        releasedVersion: 1.11.0-test-released-version
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-turing$
+      - equal: # check database secret name
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/caraml-dev/turing:1.11.0-test-released-version

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -12,7 +12,7 @@ deployment:
     # -- Docker image repository for Turing image
     repository: caraml-dev/turing
     # -- Docker image tag for Turing image
-    tag: v1.11.0-build.6-5695fb3
+    tag: ""
   labels: {}
   # -- Resources requests and limits for Turing API. This should be set
   # according to your cluster capacity and service level objectives.

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -3,7 +3,7 @@ global:
 
 rendered:
   # -- releasedVersion refers to the git release or tag
-  releasedVersion: v1.11.0
+  releasedVersion: v1.14.2
   # -- ensemblerTag refers to the docker image tag
   ensemblerTag: v0.0.0-build.321-78ca7b3
 

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -1,6 +1,8 @@
 global:
   protocol: http
 
+releasedVersion: 1.11.0
+ensemblerTag: v0.0.0-build.321-78ca7b3
 deployment:
   image:
     # -- Docker registry for Turing image
@@ -180,10 +182,10 @@ config:
       BuildNamespace: default
       BuildTimeoutDuration: 20m
       DestinationRegistry: ghcr.io
-      BaseImageRef:
-        3.7.*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service:latest
+      BaseImageRef: {}
+        # 3.7.*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service:latest
       KanikoConfig:
-        BuildContextURI: git://github.com/caraml-dev/turing.git#refs/heads/main
+        # BuildContextURI: git://github.com/caraml-dev/turing.git#refs/heads/main
         DockerfileFilePath: engines/pyfunc-ensembler-service/app.Dockerfile
         Image: gcr.io/kaniko-project/executor
         ImageVersion: v1.6.0

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -2,7 +2,9 @@ global:
   protocol: http
 
 rendered:
-  releasedVersion: 1.11.0
+  # -- releasedVersion refers to the git release or tag
+  releasedVersion: v1.11.0
+  # -- ensemblerTag refers to the docker image tag
   ensemblerTag: v0.0.0-build.321-78ca7b3
 
 deployment:

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -4,6 +4,7 @@ global:
 rendered:
   releasedVersion: 1.11.0
   ensemblerTag: v0.0.0-build.321-78ca7b3
+
 deployment:
   image:
     # -- Docker registry for Turing image
@@ -183,10 +184,10 @@ config:
       BuildNamespace: default
       BuildTimeoutDuration: 20m
       DestinationRegistry: ghcr.io
-      BaseImageRef: {}
-        # 3.7.*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service:latest
+      BaseImageRef:
+        3.7.*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service:latest
       KanikoConfig:
-        # BuildContextURI: git://github.com/caraml-dev/turing.git#refs/heads/main
+        BuildContextURI: git://github.com/caraml-dev/turing.git#refs/heads/main
         DockerfileFilePath: engines/pyfunc-ensembler-service/app.Dockerfile
         Image: gcr.io/kaniko-project/executor
         ImageVersion: v1.6.0

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -1,8 +1,9 @@
 global:
   protocol: http
 
-releasedVersion: 1.11.0
-ensemblerTag: v0.0.0-build.321-78ca7b3
+rendered:
+  releasedVersion: 1.11.0
+  ensemblerTag: v0.0.0-build.321-78ca7b3
 deployment:
   image:
     # -- Docker registry for Turing image


### PR DESCRIPTION
# Motivation
* This MR modifies merlin helm chart to render all configs and deployment tag using the field `.Values.releasedVersion`
* The purpose is to update all configs that share this tag using 1 value in values.yaml

# Modification
* A new field is added in both Merlin and Turing's `values.yaml` called `rendered`
```yaml
rendered:
    releasedVersion: v1.0.0
    ...

otherFields:
```
* The fields in `rendered` will be used to generate partial templates. The idea is to configure fields that are reused multiple times across different templates in the chart. For example, the image tag field in Merlin is reused in [deployment.yaml](./merlin/templates/merlin-deployment.yaml) and [merlin-config-secret.yaml](./merlin/templates/merlin-deployment.yaml)
* This reduces the number of places to update whenever there is a new release of the component.
* The same has been done for turing chart.
* The `releasedVersion` field is compulsory in the `rendered` dictionary. It should be set to the components exact release name, eg `v1.0.0` not `1.0.0` if the release name is `v1.0.0` (keep the prefix v)

# Checklist
- [x ] Chart version bumped
- [x ] README.md updated
