### PR TITLE
fix(turing,xp-management): Fix Turing and XP app labels

### DIFF
--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.2.35
+version: 0.2.36

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.2.35](https://img.shields.io/badge/Version-0.2.35-informational?style=flat-square)
+![Version: 0.2.36](https://img.shields.io/badge/Version-0.2.36-informational?style=flat-square)
 ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -9,7 +9,7 @@
 {{- end -}}
 
 {{- define "turing.labels" -}}
-app: {{ include "turing.fullname" . }}
+app: {{ include "turing.name" . }}
 chart: {{ include "turing.chart" . }}
 release: {{ .Release.Name }}
 heritage: {{ .Release.Service }}

--- a/charts/turing/templates/turing-deployment.yaml
+++ b/charts/turing/templates/turing-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: {{ .Values.deployment.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "turing.fullname" . }}
+      app: {{ template "turing.name" . }}
       release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "turing.fullname" . }}
+        app: {{ template "turing.name" . }}
         release: {{ .Release.Name }}
 {{- if .Values.deployment.labels }}
 {{ toYaml .Values.deployment.labels | indent 8 -}}

--- a/charts/turing/templates/turing-service.yaml
+++ b/charts/turing/templates/turing-service.yaml
@@ -5,13 +5,7 @@ metadata:
   name: {{ include "common.set-value" (list (include "turing.fullname" .) $globServiceName) }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "turing.fullname" . }}
-    chart: {{ template "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-{{ if .Values.deployment.labels -}}
-{{ toYaml .Values.deployment.labels | indent 4 -}}
-{{- end }}
+    {{- include "turing.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/turing/templates/turing-service.yaml
+++ b/charts/turing/templates/turing-service.yaml
@@ -20,5 +20,5 @@ spec:
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
   selector:
-    app: {{ template "turing.fullname" . }}
+    app: {{ template "turing.name" . }}
     release: {{ .Release.Name }}

--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.2.7
+version: 0.2.8

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/templates/_helpers.tpl
+++ b/charts/xp-management/templates/_helpers.tpl
@@ -43,6 +43,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "management-svc.labels" -}}
+app: {{ template "management-svc.name" .}}
 release: {{ .Release.Name }}
 app.kubernetes.io/name: {{ template "management-svc.name" . }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote}}
@@ -52,7 +53,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: caraml
-{{ if .Values.extraLabels -}}
+{{- if .Values.extraLabels -}}
     {{ toYaml .Values.extraLabels -}}
 {{- end }}
 {{- end }}

--- a/charts/xp-management/templates/deployment.yaml
+++ b/charts/xp-management/templates/deployment.yaml
@@ -22,7 +22,9 @@ spec:
       labels:
         app: {{ template "management-svc.name" .}}
         release: {{ .Release.Name }}
-        {{- include "management-svc.labels" . | nindent 8 }}
+        {{- if .Values.deployment.labels }}
+          {{- toYaml .Values.deployment.labels | nindent 8 -}}
+        {{- end }}
       {{- with .Values.deployment.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}

--- a/charts/xp-management/templates/service-swagger.yaml
+++ b/charts/xp-management/templates/service-swagger.yaml
@@ -15,6 +15,6 @@ spec:
       targetPort: {{ .Values.swaggerUi.service.internalPort }}
       protocol: TCP
   selector:
-    app: {{ template "management-svc.fullname" .}}
+    app: {{ template "management-svc.name" .}}
     release: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
# Motivation
This PR introduces fixes to the Turing and XP Management charts:

### XP Management 
The XP Management swagger docs are not functioning correctly if the full name of the XP management app does not happen to be the same as its regular name. That's because the swagger K8s service is using the full name as a label selector whereas the XP Management deployment pods are simply using a regular name as a label. 

Compare:
- https://github.com/caraml-dev/helm-charts/blob/main/charts/xp-management/templates/service-swagger.yaml#L18
- https://github.com/caraml-dev/helm-charts/blob/main/charts/xp-management/templates/deployment.yaml#L23

This PR thus updates the selector value to use the regular name of the XP Management service.

### Turing
The Turing deployment pod labels and service pod selectors are using the full name of the Turing app, which isn't in sync with the other CaraML apps like Merlin and XP where we are using the regular name of the app as part of the app label. This PR thus updates the app label of the Turing deployment pod labels and service pod selectors to make it consistent with the other CaraML apps.

# Modification
- `charts/turing/templates/turing-deployment.yaml` - Update of the Turing deployment pod label and selectors
- `charts/turing/templates/turing-service.yaml` - Update of the Turing service pod selector
- `charts/xp-management/templates/service-swagger.yaml` - Update of the XP swagger service pod selector

# Checklist
- [x] Chart version bumped
- [x] README.md updated
