### PR TITLE
fix(xp-treatment): Fix incorrect selector in xp treatment

### DIFF
--- a/charts/xp-treatment/Chart.lock
+++ b/charts/xp-treatment/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.7
+  version: 0.2.8
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
-digest: sha256:5717a3fb360feb7b1384d3c8f3366148d6d57f1b4b9043ed34569ea341f24a0e
-generated: "2023-08-28T03:09:48.703045173Z"
+digest: sha256:d007f3834396c9610b6b1ea4356b249f6c751ff0cb3ed9156571d782ca464dab
+generated: "2023-09-05T11:39:15.89989+08:00"

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: xp-management.enabled
   name: xp-management
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.2.7
+  version: 0.2.8
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.21
+version: 0.1.22

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.21](https://img.shields.io/badge/Version-0.1.21-informational?style=flat-square)
+![Version: 0.1.22](https://img.shields.io/badge/Version-0.1.22-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments

--- a/charts/xp-treatment/templates/service-swagger.yaml
+++ b/charts/xp-treatment/templates/service-swagger.yaml
@@ -15,6 +15,6 @@ spec:
       targetPort: {{ .Values.swaggerUi.service.internalPort }}
       protocol: TCP
   selector:
-    app: {{ template "treatment-svc.fullname" .}}
+    app: {{ template "treatment-svc.name" .}}
     release: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
# Motivation
Similar to PR #353, the XP Treatment swagger docs are not functioning correctly if the full name of the XP Treatment app does not happen to be the same as its regular name. That's because the swagger K8s service is using the full name as a label selector whereas the XP Treatment deployment pods are simply using a regular name as a label.

Compare:
- https://github.com/caraml-dev/helm-charts/blob/main/charts/xp-treatment/templates/deployment.yaml#L22
- https://github.com/caraml-dev/helm-charts/blob/main/charts/xp-treatment/templates/service-swagger.yaml#L18

This PR thus updates the selector value to use the regular name of the XP Treatment service.

# Modification
- `charts/xp-treatment/templates/service-swagger.yaml` - Update of the XP swagger service pod selector

# Checklist
- [x] Chart version bumped
- [x] README.md updated
