### PR TITLE
fix(xp): template whitespace issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/norwoodj/helm-docs
-    rev: v1.11.0
+    rev: v1.11.2
     hooks:
       - id: helm-docs
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.17
+    rev: v0.1.22
     hooks:
       - id: helmlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/norwoodj/helm-docs
-    rev: v1.11.2
+    rev: v1.11.0
     hooks:
       - id: helm-docs
   - repo: https://github.com/gruntwork-io/pre-commit

--- a/charts/xp-management/Chart.yaml
+++ b/charts/xp-management/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-management
-version: 0.2.8
+version: 0.2.9

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -1,7 +1,7 @@
 # xp-management
 
 ---
-![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square)
+![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Management service - A part of XP system that is used to configure experiments

--- a/charts/xp-management/README.md
+++ b/charts/xp-management/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the XP Management Servi
 | deployment.serviceAccount.annotations | object | `{}` |  |
 | deployment.serviceAccount.create | bool | `true` |  |
 | deployment.serviceAccount.name | string | `""` |  |
+| extraLabels | object | `{}` |  |
 | global.environment | string | `"dev"` | Environment of Management Service deployment |
 | global.mlp.apiPrefix | string | `""` |  |
 | global.mlp.externalPort | string | `"8080"` |  |

--- a/charts/xp-management/ci/ci-values.yaml
+++ b/charts/xp-management/ci/ci-values.yaml
@@ -10,6 +10,8 @@ global:
     uiPrefix: "/"
     uiServiceName: mlp
 
+extraLabels:
+  test: 123
 deployment:
   replicaCount: "1"
   resources:

--- a/charts/xp-management/ci/ci-values.yaml
+++ b/charts/xp-management/ci/ci-values.yaml
@@ -11,7 +11,7 @@ global:
     uiServiceName: mlp
 
 extraLabels:
-  test: 123
+  test: "123"
 deployment:
   replicaCount: "1"
   resources:

--- a/charts/xp-management/templates/_helpers.tpl
+++ b/charts/xp-management/templates/_helpers.tpl
@@ -53,8 +53,8 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: caraml
-{{- if .Values.extraLabels -}}
-    {{ toYaml .Values.extraLabels -}}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels }}
 {{- end }}
 {{- end }}
 

--- a/charts/xp-management/values.yaml
+++ b/charts/xp-management/values.yaml
@@ -11,6 +11,7 @@ global:
     externalPort: "8080"
     useServiceFqdn: true
 
+extraLabels: {}
 
 deployment:
   image:

--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.22
+version: 0.1.23

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.22](https://img.shields.io/badge/Version-0.1.22-informational?style=flat-square)
+![Version: 0.1.23](https://img.shields.io/badge/Version-0.1.23-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments

--- a/charts/xp-treatment/ci/ci-values.yaml
+++ b/charts/xp-treatment/ci/ci-values.yaml
@@ -10,6 +10,8 @@ global:
     uiServiceName: xp-management
   xp-treatment:
     serviceName: xp-treatment
+extraLabels:
+  test: 123
 deployment:
   replicaCount: "1"
   resources:

--- a/charts/xp-treatment/ci/ci-values.yaml
+++ b/charts/xp-treatment/ci/ci-values.yaml
@@ -11,7 +11,7 @@ global:
   xp-treatment:
     serviceName: xp-treatment
 extraLabels:
-  test: 123
+  test: "123"
 deployment:
   replicaCount: "1"
   resources:

--- a/charts/xp-treatment/templates/_helpers.tpl
+++ b/charts/xp-treatment/templates/_helpers.tpl
@@ -52,8 +52,8 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: caraml
-{{ if .Values.extraLabels -}}
-    {{ toYaml .Values.extraLabels -}}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels }}
 {{- end }}
 {{- end }}
 

--- a/scripts/helm-docs.sh
+++ b/scripts/helm-docs.sh
@@ -8,4 +8,4 @@ echo "Running Helm-Docs"
 docker run \
     -v "$CHART_DIR:/helm-docs" \
     -u $(id -u) \
-    jnorwood/helm-docs:latest
+    jnorwood/helm-docs:v1.11.0


### PR DESCRIPTION
# Motivation
The existing xp helper templates do not handle extraLabels correctly.
Before:
```
 108   │   labels:
 109   │     app: xp-management
 110   │     release: xp-management
 111   │     app.kubernetes.io/name: xp-management
 112   │     helm.sh/chart: "xp-management-0.2.8"
 113   │     app.kubernetes.io/version: "0.12.1"
 114   │     app.kubernetes.io/instance: xp-management
 115   │     app.kubernetes.io/managed-by: Helm
 116   │     app.kubernetes.io/part-of: caramlsdfoo: 123 <--

```
white space on the right gets chomped, which causes the rendering to fail.

After:
```
  24   │   labels:
  25   │     app: xp-management
  26   │     release: xp-management
  27   │     app.kubernetes.io/name: xp-management
  28   │     helm.sh/chart: "xp-management-0.2.8"
  29   │     app.kubernetes.io/version: "0.12.1"
  30   │     app.kubernetes.io/instance: xp-management
  31   │     app.kubernetes.io/managed-by: Helm
  32   │     app.kubernetes.io/part-of: caraml
  33   │     sdfoo: 123

```

# Modification
* Modified _helpers.tpl for xp-management and xp-treatment
* Added extraLabels field in ci-values for testing

# Checklist
- [x] Chart version bumped
- [x] README.md updated