### PR TITLE
fix: Allow overwriting of rendered template in merlin and turing charts

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.1
+version: 0.13.2

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -339,7 +339,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlp.fullnameOverride | string | `"mlp"` |  |
 | mlp.keto.enabled | bool | `true` |  |
 | mlp.keto.fullnameOverride | string | `"mlp-keto"` |  |
-| rendered.overwrites | object | `{}` |  |
+| rendered.overrides | object | `{}` |  |
 | rendered.releasedVersion | string | `"v0.32.0"` |  |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square)
+![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square)
 ![AppVersion: v0.32.0](https://img.shields.io/badge/AppVersion-v0.32.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -339,6 +339,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlp.fullnameOverride | string | `"mlp"` |  |
 | mlp.keto.enabled | bool | `true` |  |
 | mlp.keto.fullnameOverride | string | `"mlp-keto"` |  |
+| rendered.overwrites | object | `{}` |  |
 | rendered.releasedVersion | string | `"v0.32.0"` |  |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -7,7 +7,7 @@
 {{- define "merlin.renderedConfig" -}}
 {{- $ := index . 0 }}
 {{- $rendered := index . 2}}
-{{- if $rendered }}
+{{- if len $rendered | ne 0 }}
 # this is because merlin artifact versions have no v prefix
 # NOTE: Remove the substr once merlin artifacts are released with v prefix
 {{- $tag := $rendered.releasedVersion | substr 1 (len $rendered.releasedVersion) }}

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -304,8 +304,8 @@ MlflowConfig:
 {{/* Generate rendered template if set */}}
 {{- if ne ( len .Values.rendered ) 0 }}
 {{- $renderedConfig := include "merlin.renderedConfig" (list $ . .Values.rendered ) | fromYaml -}}
-{{/* Use overwrites in rendered to overwrite rendered config */}}
-{{- $config := mergeOverwrite $renderedConfig .Values.rendered.overwrites }}
+{{/* Use overrides in rendered to overwrite rendered config */}}
+{{- $config := mergeOverwrite $renderedConfig .Values.rendered.overrides }}
 {{/* Overwrite original with config */}}
 {{- mergeOverwrite $original $config | toYaml }}
 {{- else }}

--- a/charts/merlin/templates/_helpers.tpl
+++ b/charts/merlin/templates/_helpers.tpl
@@ -300,7 +300,9 @@ MlflowConfig:
 {{- define "merlin.config" -}}
 {{- $defaultConfig := include "merlin.defaultConfig" . | fromYaml -}}
 {{- $renderedConfig := include "merlin.renderedConfig" (list $ . .Values.rendered ) | fromYaml -}}
-{{-  merge $renderedConfig $defaultConfig .Values.config | toYaml }}
+{{ $original := merge $defaultConfig .Values.config }}
+{{- $config := mergeOverwrite $renderedConfig .Values.rendered.overwrites}}
+{{- mergeOverwrite $original $config | toYaml }}
 {{- end -}}
 
 

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -162,3 +162,51 @@ tests:
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "BuildContextURI: git://github.com/caraml-dev/merlin.git#refs/branch/test"
+
+  - it: should use rendered version, but allow config to override value
+    set:
+      rendered:
+        releasedVersion: v1.0.0-test-release
+        overwrites:
+          ImageBuilderConfig:
+            BaseImages:
+              3.10.*:
+                ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:0.0.0-some-other-value
+                DockerfilePath: "python/pyfunc-server/docker/Dockerfile"
+                BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/pull/465"
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-merlin-config$
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py37:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py38:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py39:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:0.0.0-some-other-value"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py37:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py38:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py39:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py310:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "BuildContextURI: git://github.com/caraml-dev/merlin.git#refs/pull/465"

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -149,6 +149,7 @@ tests:
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0-test-release"
+
   - it: should use imageBuilder contextRef when set
     set:
       imageBuilder:
@@ -210,3 +211,29 @@ tests:
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "BuildContextURI: git://github.com/caraml-dev/merlin.git#refs/pull/465"
+
+  - it: should fall back to original config when rendered is disabled
+    set:
+      rendered: ""
+      deployment:
+        image:
+          tag: "test-tag"
+      config:
+        ImageBuilderConfig:
+          BaseImages:
+            3.10.*:
+              ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:0.0.0-set-from-config
+              DockerfilePath: "python/pyfunc-server/docker/Dockerfile"
+              BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/pull/123"
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-merlin-config$
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:0.0.0-set-from-config"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "BuildContextURI: git://github.com/caraml-dev/merlin.git#refs/pull/123"

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -168,7 +168,7 @@ tests:
     set:
       rendered:
         releasedVersion: v1.0.0-test-release
-        overwrites:
+        overrides:
           ImageBuilderConfig:
             BaseImages:
               3.10.*:

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -7,7 +7,7 @@ global:
 rendered:
   # releasedVersion refers to the git release or tag
   releasedVersion: v0.32.0
-  overwrites: {}
+  overrides: {}
 
 # set deployment.image.tag to non-nil to overwrite
 # .rendered.releasedVersion

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -7,6 +7,7 @@ global:
 rendered:
   # releasedVersion refers to the git release or tag
   releasedVersion: v0.32.0
+  overwrites: {}
 
 # set deployment.image.tag to non-nil to overwrite
 # .rendered.releasedVersion

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.3.1
+version: 0.3.2

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square)
 ![AppVersion: 1.14.2](https://img.shields.io/badge/AppVersion-1.14.2-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
@@ -103,6 +103,7 @@ The following table lists the configurable parameters of the Turing chart and th
 | mlp.environmentConfigSecret.name | string | `""` |  |
 | openApiSpecOverrides | object | `{}` | Override OpenAPI spec as long as it follows the OAS3 specifications. A common use for this is to set the enums of the ExperimentEngineType. See api/api/override-sample.yaml for an example. |
 | rendered.ensemblerTag | string | `"v0.0.0-build.321-78ca7b3"` | ensemblerTag refers to the docker image tag |
+| rendered.overwrites | object | `{}` |  |
 | rendered.releasedVersion | string | `"v1.14.2"` | releasedVersion refers to the git release or tag |
 | sentry.dsn | string | `""` | Sentry DSN value used by both Turing API and Turing UI |
 | service.externalPort | int | `8080` | Turing API Kubernetes service port number |

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -103,7 +103,7 @@ The following table lists the configurable parameters of the Turing chart and th
 | mlp.environmentConfigSecret.name | string | `""` |  |
 | openApiSpecOverrides | object | `{}` | Override OpenAPI spec as long as it follows the OAS3 specifications. A common use for this is to set the enums of the ExperimentEngineType. See api/api/override-sample.yaml for an example. |
 | rendered.ensemblerTag | string | `"v0.0.0-build.321-78ca7b3"` | ensemblerTag refers to the docker image tag |
-| rendered.overwrites | object | `{}` |  |
+| rendered.overrides | object | `{}` |  |
 | rendered.releasedVersion | string | `"v1.14.2"` | releasedVersion refers to the git release or tag |
 | sentry.dsn | string | `""` | Sentry DSN value used by both Turing API and Turing UI |
 | service.externalPort | int | `8080` | Turing API Kubernetes service port number |

--- a/charts/turing/templates/_helpers.tpl
+++ b/charts/turing/templates/_helpers.tpl
@@ -259,7 +259,7 @@ OpenapiConfig:
 {{/* Generate rendered template if set */}}
 {{- if ne ( len .Values.rendered ) 0 }}
 {{- $renderedConfig := include "turing.renderedConfig" (list $ . .Values.rendered ) | fromYaml -}}
-{{- $config := mergeOverwrite $renderedConfig .Values.rendered.overwrites }}
+{{- $config := mergeOverwrite $renderedConfig .Values.rendered.overrides }}
 {{/* Overwrite original with config */}}
 {{- mergeOverwrite $original $config | toYaml }}
 {{- else }}

--- a/charts/turing/tests/turing_config_secret_test.yaml
+++ b/charts/turing/tests/turing_config_secret_test.yaml
@@ -170,3 +170,53 @@ tests:
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "3.10\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.10:some-ensembler-tag"
+  - it: should use rendered version, but allow config to override value
+    set:
+      rendered:
+        releasedVersion: v1.0.0-test-release
+        ensemblerTag: some-ensembler-tag
+        overwrites:
+          BatchEnsemblingConfig:
+            ImageBuilderConfig:
+              BaseImages:
+                3.10.*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.10:test-tag-123
+      config:
+        BatchEnsemblingConfig:
+          Enabled: true
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: my-release-turing-config$
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "BuildContextURI: git://github.com/caraml-dev/turing.git#refs/tags/v1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.7\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.7:some-ensembler-tag"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.8\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.8:some-ensembler-tag"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.9\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.9:some-ensembler-tag"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.10\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.10:some-ensembler-tag"
+      #
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.7\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.7:some-ensembler-tag"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.8\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.8:some-ensembler-tag"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.9\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.9:some-ensembler-tag"
+      - matchRegex:
+          path: stringData.[config.yaml]
+          pattern: "3.10\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.10:test-tag-123"

--- a/charts/turing/tests/turing_config_secret_test.yaml
+++ b/charts/turing/tests/turing_config_secret_test.yaml
@@ -175,7 +175,7 @@ tests:
       rendered:
         releasedVersion: v1.0.0-test-release
         ensemblerTag: some-ensembler-tag
-        overwrites:
+        overrides:
           BatchEnsemblingConfig:
             ImageBuilderConfig:
               BaseImages:

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -6,7 +6,7 @@ rendered:
   releasedVersion: v1.14.2
   # -- ensemblerTag refers to the docker image tag
   ensemblerTag: v0.0.0-build.321-78ca7b3
-  overwrites: {}
+  overrides: {}
 
 deployment:
   image:

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -6,6 +6,7 @@ rendered:
   releasedVersion: v1.14.2
   # -- ensemblerTag refers to the docker image tag
   ensemblerTag: v0.0.0-build.321-78ca7b3
+  overwrites: {}
 
 deployment:
   image:


### PR DESCRIPTION
# Motivation
* Current implementation of rendering templates of merlin and turing using `render` field is incomplete. This MR introduces a new field `overwrites`, to overwrite specific fields that the render produces. 

# Modification
* New `render.overwrites` field to overwrite portions of the rendered template
* If render is empty, falls back to original mechanism of using `.Values.config` and `$defaultConfig`

For example, the current implementation does not allow the following config to be rendered in merlin:
```
      BaseImages:
        3.7.*:
          ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py37:0.34.0-rc1
          DockerfilePath: "python/pyfunc-server/docker/Dockerfile"
          BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v0.34.0-rc1"
        ...
        # Test MLFlow upgrade
        3.10.*:
          ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:0.0.0-f9fda74f934ebf546e4581495d93120e37f6a36b
          DockerfilePath: "python/pyfunc-server/docker/Dockerfile"
          BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/pull/465"
```
without setting `rendered` to an empty dictionary. This is because the existing config will be overwritten by the rendered template if `rendered` is set. 

In order to get around this, a new field `overwrites` is added to the `rendered` dictionary, which allows users to specify which fields in the rendered template should be overwritten. The same can be applied to turing. 

overwrites is like an escape hatch, it's not expected to be used except for testing purposes. 
`defaultConfig` uses some values from `.Values.config` which makes it quite hard to use `.Values.config` to overwrite the rendered template sometimes, and have the rendered template overwrite other parts

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
