### PR TITLE
fix: remove extra values in helm rendered template

### DIFF
--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.3.2
+version: 0.3.3

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square)
 ![AppVersion: 1.14.2](https://img.shields.io/badge/AppVersion-1.14.2-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -3,8 +3,9 @@
 {{- $rendered := index . 2}}
 {{- if $rendered }}
 {{- $tag := $rendered.releasedVersion}}
-{{- $ensemblerTag := $rendered.ensemblerTag }}
-{{- $ensmblerJobPrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py" -}}
+{{- $ensemblerTag := default $tag $rendered.ensemblerTag }}
+{{- $ensemblerServiceTag := default $ensemblerTag $rendered.ensemblerServiceTag }}
+{{- $ensemblerJobPrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py" -}}
 {{- $servicePrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py" -}}
 # Now we have access to the "real" root and current contexts
 # just as if we were outside of include/define:
@@ -13,20 +14,20 @@
 BatchEnsemblingConfig:
   ImageBuildingConfig:
     BaseImageRef:
-      3.7.*: {{ printf "%s%s:%s" $ensmblerJobPrefix "3.7" $ensemblerTag }}
-      3.8.*: {{ printf "%s%s:%s" $ensmblerJobPrefix "3.8" $ensemblerTag }}
-      3.9.*: {{printf "%s%s:%s" $ensmblerJobPrefix "3.9" $ensemblerTag }}
-      3.10.*: {{ printf "%s%s:%s" $ensmblerJobPrefix "3.10" $ensemblerTag }}
+      3.7.*: {{ printf "%s%s:%s" $ensemblerJobPrefix "3.7" $ensemblerTag }}
+      3.8.*: {{ printf "%s%s:%s" $ensemblerJobPrefix "3.8" $ensemblerTag }}
+      3.9.*: {{printf "%s%s:%s" $ensemblerJobPrefix "3.9" $ensemblerTag }}
+      3.10.*: {{ printf "%s%s:%s" $ensemblerJobPrefix "3.10" $ensemblerTag }}
     KanikoConfig:
       BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags" $tag }}
 {{- end }}
 EnsemblerServiceBuilderConfig:
   ImageBuildingConfig:
     BaseImageRef:
-      3.7.*: {{ printf "%s%s:%s" $servicePrefix "3.7" $ensemblerTag }}
-      3.8.*: {{ printf "%s%s:%s" $servicePrefix "3.8" $ensemblerTag }}
-      3.9.*: {{printf "%s%s:%s" $servicePrefix "3.9" $ensemblerTag }}
-      3.10.*: {{ printf "%s%s:%s" $servicePrefix "3.10" $ensemblerTag }}
+      3.7.*: {{ printf "%s%s:%s" $servicePrefix "3.7" $ensemblerServiceTag }}
+      3.8.*: {{ printf "%s%s:%s" $servicePrefix "3.8" $ensemblerServiceTag }}
+      3.9.*: {{printf "%s%s:%s" $servicePrefix "3.9" $ensemblerServiceTag }}
+      3.10.*: {{ printf "%s%s:%s" $servicePrefix "3.10" $ensemblerServiceTag }}
     KanikoConfig: &kanikoConfig
       BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags" $tag }}
 RouterDefaults:

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -12,7 +12,6 @@
 {{- if $.Values.config.BatchEnsemblingConfig.Enabled }}
 BatchEnsemblingConfig:
   ImageBuildingConfig:
-    DestinationRegistry: asia.gcr.io/gods-production/turing/ensemblers
     BaseImageRef:
       3.7.*: {{ printf "%s%s:%s" $ensmblerJobPrefix "3.7" $ensemblerTag }}
       3.8.*: {{ printf "%s%s:%s" $ensmblerJobPrefix "3.8" $ensemblerTag }}
@@ -22,7 +21,6 @@ BatchEnsemblingConfig:
       BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags" $tag }}
 {{- end }}
 EnsemblerServiceBuilderConfig:
-  ClusterName: products-production
   ImageBuildingConfig:
     BaseImageRef:
       3.7.*: {{ printf "%s%s:%s" $servicePrefix "3.7" $ensemblerTag }}


### PR DESCRIPTION
# Motivation
This MR removes unnecessary values in turing's rendered template. It adds an optional field in `rendered` to specify the EnsemblerService tag, which defaults to the ensemberTag if left unspecified.
# Modification

# Checklist
- [x] Chart version bumped
- [x] README.md updated