### PR TITLE
fix: Update chart-testing-action to 2.6.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
         with:
           version: v3.7.0
 


### PR DESCRIPTION
# Motivation
It looks like the GCS object used by 1 of the internal steps in the `chart-testing-action` step is missing. This causes all testing steps to fail, eg
* https://github.com/caraml-dev/helm-charts/actions/runs/6717324797/job/18254985036
* https://github.com/caraml-dev/helm-charts/actions/runs/6717324794/job/18254985011


# Modification
This MR bumps the `chart-testing-action` to use v2.6.0 from v2.4.0 which bumps the version of `cosign`

# Checklist
- [ ] Chart version bumped
- [ ] README.md updated


cc @tkpd-hafizhan @khorshuheng 