### PR TITLE
chore: Update Turing and Merlin charts with latest release specs

### DIFF
--- a/.github/workflows/chart-bumper.yaml
+++ b/.github/workflows/chart-bumper.yaml
@@ -33,7 +33,7 @@ jobs:
           sudo apt install /tmp/updatecli_amd64.deb
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
         with:
           version: v3.7.0
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
         with:
           version: v3.7.0
 

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.32.0
+appVersion: v0.35.0
 dependencies:
 - alias: merlin-postgresql
   condition: merlin-postgresql.enabled

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.2
+version: 0.13.3

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -340,7 +340,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlp.keto.enabled | bool | `true` |  |
 | mlp.keto.fullnameOverride | string | `"mlp-keto"` |  |
 | rendered.overrides | object | `{}` |  |
-| rendered.releasedVersion | string | `"v0.32.0"` |  |
+| rendered.releasedVersion | string | `"v0.35.0"` |  |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -2,7 +2,7 @@
 
 ---
 ![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square)
-![AppVersion: v0.32.0](https://img.shields.io/badge/AppVersion-v0.32.0-informational?style=flat-square)
+![AppVersion: v0.35.0](https://img.shields.io/badge/AppVersion-v0.35.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -198,20 +198,20 @@ The following table lists the configurable parameters of the Merlin chart and th
 | environmentConfigs[0].queue_resource_percentage | string | `"20"` |  |
 | environmentConfigs[0].region | string | `"id"` |  |
 | global.protocol | string | `"http"` |  |
-| imageBuilder.builderConfig.BaseImages."3.7.*".BuildContextURI | string | `"git://github.com/gojek/merlin.git#refs/tags/v0.1"` |  |
-| imageBuilder.builderConfig.BaseImages."3.7.*".DockerfilePath | string | `"docker/Dockerfile"` |  |
-| imageBuilder.builderConfig.BaseImages."3.7.*".ImageName | string | `"pyfunc-py37:v0.1.0"` |  |
-| imageBuilder.builderConfig.BaseImages."3.7.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
+| imageBuilder.builderConfig.BaseImages."3.8.*".BuildContextURI | string | `"git://github.com/gojek/merlin.git#refs/tags/v0.1"` |  |
+| imageBuilder.builderConfig.BaseImages."3.8.*".DockerfilePath | string | `"docker/Dockerfile"` |  |
+| imageBuilder.builderConfig.BaseImages."3.8.*".ImageName | string | `"pyfunc-py38:v0.1.0"` |  |
+| imageBuilder.builderConfig.BaseImages."3.8.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
 | imageBuilder.builderConfig.BuildNamespace | string | `"mlp"` |  |
 | imageBuilder.builderConfig.BuildTimeout | string | `"30m"` |  |
 | imageBuilder.builderConfig.DockerRegistry | string | `"dockerRegistry"` |  |
 | imageBuilder.builderConfig.KanikoImage | string | `"gcr.io/kaniko-project/executor:v1.6.0"` |  |
 | imageBuilder.builderConfig.MaximumRetry | int | `3` |  |
 | imageBuilder.builderConfig.NodeSelectors | object | `{}` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".BuildContextURI | string | `"git://github.com/gojek/merlin.git#refs/tags/v0.1"` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".DockerfilePath | string | `"docker/app.Dockerfile"` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".ImageName | string | `"pyspark-py37:v0.1.0"` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImages."3.7.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImages."3.8.*".BuildContextURI | string | `"git://github.com/gojek/merlin.git#refs/tags/v0.1"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImages."3.8.*".DockerfilePath | string | `"docker/app.Dockerfile"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImages."3.8.*".ImageName | string | `"pyspark-py38:v0.1.0"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImages."3.8.*".MainAppPath | string | `"/merlin-spark-app/main.py"` |  |
 | imageBuilder.builderConfig.Resources.Limits.CPU | string | `"1"` |  |
 | imageBuilder.builderConfig.Resources.Limits.Memory | string | `"1Gi"` |  |
 | imageBuilder.builderConfig.Resources.Requests.CPU | string | `"1"` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square)
+![Version: 0.13.3](https://img.shields.io/badge/Version-0.13.3-informational?style=flat-square)
 ![AppVersion: v0.35.0](https://img.shields.io/badge/AppVersion-v0.35.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -17,10 +17,6 @@
 # just as if we were outside of include/define:
 ImageBuilderConfig:
   BaseImages:
-    3.7.*:
-      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py37:{{ printf "%s" $tag }}
-      DockerfilePath: "python/pyfunc-server/docker/Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
     3.8.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py38:{{ printf "%s" $tag }}
       DockerfilePath: "python/pyfunc-server/docker/Dockerfile"
@@ -34,11 +30,6 @@ ImageBuilderConfig:
       DockerfilePath: "python/pyfunc-server/docker/Dockerfile"
       BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
   PredictionJobBaseImages:
-    3.7.*:
-      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py37:{{ printf "%s" $tag }}
-      DockerfilePath: "python/batch-predictor/docker/app.Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
-      MainAppPath: "/home/spark/merlin-spark-app/main.py"
     3.8.*:
       ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py38:{{ printf "%s" $tag }}
       DockerfilePath: "python/batch-predictor/docker/app.Dockerfile"

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -124,9 +124,6 @@ tests:
           pattern: my-release-merlin-config$
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py37:1.0.0-test-release"
-      - matchRegex:
-          path: stringData.[config.yaml]
           pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py38:1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
@@ -134,9 +131,6 @@ tests:
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:1.0.0-test-release"
-      - matchRegex:
-          path: stringData.[config.yaml]
-          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py37:1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py38:1.0.0-test-release"
@@ -183,9 +177,6 @@ tests:
           pattern: my-release-merlin-config$
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py37:1.0.0-test-release"
-      - matchRegex:
-          path: stringData.[config.yaml]
           pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py38:1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
@@ -193,9 +184,6 @@ tests:
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-py310:0.0.0-some-other-value"
-      - matchRegex:
-          path: stringData.[config.yaml]
-          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py37:1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base-py38:1.0.0-test-release"

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -6,7 +6,7 @@ global:
 # .config when generating templates
 rendered:
   # releasedVersion refers to the git release or tag
-  releasedVersion: v0.32.0
+  releasedVersion: v0.35.0
   overrides: {}
 
 # set deployment.image.tag to non-nil to overwrite

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -254,14 +254,14 @@ imageBuilder:
   #     provideClusterInfo: true
   builderConfig:
     BaseImages:
-      3.7.*:
-        ImageName: pyfunc-py37:v0.1.0
+      3.8.*:
+        ImageName: pyfunc-py38:v0.1.0
         DockerfilePath: "docker/Dockerfile"
         BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
         MainAppPath: /merlin-spark-app/main.py
     PredictionJobBaseImages:
-      3.7.*:
-        ImageName: pyspark-py37:v0.1.0
+      3.8.*:
+        ImageName: pyspark-py38:v0.1.0
         DockerfilePath: "docker/app.Dockerfile"
         BuildContextURI: "git://github.com/gojek/merlin.git#refs/tags/v0.1"
         MainAppPath: /merlin-spark-app/main.py

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.16.0
+appVersion: 1.14.2
 dependencies:
 - alias: turing-postgresql
   condition: turing-postgresql.enabled
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.3.3
+version: 0.3.4

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.14.2
+appVersion: 1.16.0
 dependencies:
 - alias: turing-postgresql
   condition: turing-postgresql.enabled

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -2,7 +2,7 @@
 
 ---
 ![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square)
-![AppVersion: 1.14.2](https://img.shields.io/badge/AppVersion-1.14.2-informational?style=flat-square)
+![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
 

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,8 +1,8 @@
 # turing
 
 ---
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square)
-![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square)
+![AppVersion: 1.14.2](https://img.shields.io/badge/AppVersion-1.14.2-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
 

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -102,9 +102,9 @@ The following table lists the configurable parameters of the Turing chart and th
 | mlp.enabled | bool | `true` |  |
 | mlp.environmentConfigSecret.name | string | `""` |  |
 | openApiSpecOverrides | object | `{}` | Override OpenAPI spec as long as it follows the OAS3 specifications. A common use for this is to set the enums of the ExperimentEngineType. See api/api/override-sample.yaml for an example. |
-| rendered.ensemblerTag | string | `"v0.0.0-build.321-78ca7b3"` | ensemblerTag refers to the docker image tag |
+| rendered.ensemblerTag | string | `"v0.0.0-build.327-ca712a6"` | ensemblerTag refers to the docker image tag |
 | rendered.overrides | object | `{}` |  |
-| rendered.releasedVersion | string | `"v1.14.2"` | releasedVersion refers to the git release or tag |
+| rendered.releasedVersion | string | `"v1.16.0"` | releasedVersion refers to the git release or tag |
 | sentry.dsn | string | `""` | Sentry DSN value used by both Turing API and Turing UI |
 | service.externalPort | int | `8080` | Turing API Kubernetes service port number |
 | service.internalPort | int | `8080` | Turing API container port number |

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -14,7 +14,6 @@
 BatchEnsemblingConfig:
   ImageBuildingConfig:
     BaseImageRef:
-      3.7.*: {{ printf "%s%s:%s" $ensemblerJobPrefix "3.7" $ensemblerTag }}
       3.8.*: {{ printf "%s%s:%s" $ensemblerJobPrefix "3.8" $ensemblerTag }}
       3.9.*: {{printf "%s%s:%s" $ensemblerJobPrefix "3.9" $ensemblerTag }}
       3.10.*: {{ printf "%s%s:%s" $ensemblerJobPrefix "3.10" $ensemblerTag }}
@@ -24,7 +23,6 @@ BatchEnsemblingConfig:
 EnsemblerServiceBuilderConfig:
   ImageBuildingConfig:
     BaseImageRef:
-      3.7.*: {{ printf "%s%s:%s" $servicePrefix "3.7" $ensemblerServiceTag }}
       3.8.*: {{ printf "%s%s:%s" $servicePrefix "3.8" $ensemblerServiceTag }}
       3.9.*: {{printf "%s%s:%s" $servicePrefix "3.9" $ensemblerServiceTag }}
       3.10.*: {{ printf "%s%s:%s" $servicePrefix "3.10" $ensemblerServiceTag }}

--- a/charts/turing/tests/turing_config_secret_test.yaml
+++ b/charts/turing/tests/turing_config_secret_test.yaml
@@ -115,9 +115,6 @@ tests:
           pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "3.7\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.7:some-ensembler-tag"
-      - matchRegex:
-          path: stringData.[config.yaml]
           pattern: "3.8\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.8:some-ensembler-tag"
       - matchRegex:
           path: stringData.[config.yaml]
@@ -147,9 +144,6 @@ tests:
           pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "3.7\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.7:some-ensembler-tag"
-      - matchRegex:
-          path: stringData.[config.yaml]
           pattern: "3.8\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.8:some-ensembler-tag"
       - matchRegex:
           path: stringData.[config.yaml]
@@ -158,9 +152,6 @@ tests:
           path: stringData.[config.yaml]
           pattern: "3.10\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.10:some-ensembler-tag"
       #
-      - matchRegex:
-          path: stringData.[config.yaml]
-          pattern: "3.7\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.7:some-ensembler-tag"
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "3.8\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.8:some-ensembler-tag"
@@ -197,9 +188,6 @@ tests:
           pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "3.7\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.7:some-ensembler-tag"
-      - matchRegex:
-          path: stringData.[config.yaml]
           pattern: "3.8\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.8:some-ensembler-tag"
       - matchRegex:
           path: stringData.[config.yaml]
@@ -208,9 +196,6 @@ tests:
           path: stringData.[config.yaml]
           pattern: "3.10\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py3.10:some-ensembler-tag"
       #
-      - matchRegex:
-          path: stringData.[config.yaml]
-          pattern: "3.7\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.7:some-ensembler-tag"
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "3.8\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.8:some-ensembler-tag"

--- a/charts/turing/values.yaml
+++ b/charts/turing/values.yaml
@@ -3,9 +3,9 @@ global:
 
 rendered:
   # -- releasedVersion refers to the git release or tag
-  releasedVersion: v1.14.2
+  releasedVersion: v1.16.0
   # -- ensemblerTag refers to the docker image tag
-  ensemblerTag: v0.0.0-build.321-78ca7b3
+  ensemblerTag: v0.0.0-build.327-ca712a6
   overrides: {}
 
 deployment:
@@ -188,7 +188,7 @@ config:
       BuildTimeoutDuration: 20m
       DestinationRegistry: ghcr.io
       BaseImageRef:
-        3.7.*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service:latest
+        3.8.*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service:latest
       KanikoConfig:
         BuildContextURI: git://github.com/caraml-dev/turing.git#refs/heads/main
         DockerfileFilePath: engines/pyfunc-ensembler-service/app.Dockerfile


### PR DESCRIPTION
# Motivation
The latest release of Turing ([v1.16.0](https://github.com/caraml-dev/turing/releases/tag/v1.16.0)) and Merlin ([v0.35.0](https://github.com/caraml-dev/merlin/releases/tag/v0.35.0)) drop support for Python 3.7 altogether. This PR updates the chart specs accordingly.

# Modification
* Update app versions for Turing and Merlin
* `charts/merlin/templates/_config.tpl`, `charts/turing/templates/_config.tpl` - Drop Python 3.7 from the helper template functions for the Pyfunc server images
* Update unit tests

# Checklist
- [x] Chart version bumped
- [x] README.md updated
