### PR TITLE
chore: Update Turing's dependency on Merlin

### DIFF
--- a/charts/turing/Chart.lock
+++ b/charts/turing/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.4.20
 - name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.11.7
+  version: 0.13.3
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
-digest: sha256:0f2292d431db3dad3c2a2314097adbc9a42ae9b0f3db6f40501ca66a3b6ad59f
-generated: "2023-08-15T02:17:35.579300596Z"
+digest: sha256:94833158d8fef0a318db4042d57b0f5b782d4d6b7d4757d91d09112df5a3d073
+generated: "2023-11-02T11:42:09.836837+08:00"

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.14.2
+appVersion: v1.16.0
 dependencies:
 - alias: turing-postgresql
   condition: turing-postgresql.enabled
@@ -13,7 +13,7 @@ dependencies:
 - condition: merlin.enabled
   name: merlin
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.11.7
+  version: 0.13.3
 - name: common
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.2.9
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.3.4
+version: 0.3.5

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,8 +1,8 @@
 # turing
 
 ---
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square)
-![AppVersion: 1.14.2](https://img.shields.io/badge/AppVersion-1.14.2-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square)
+![AppVersion: v1.16.0](https://img.shields.io/badge/AppVersion-v1.16.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
 


### PR DESCRIPTION
# Motivation
Turing's dependency on Merlin is outdated

# Modification
* `charts/turing/Chart.yaml` - Updating Turing's dependency on Merlin

# Checklist
- [x] Chart version bumped
- [x] README.md updated
