### PR TITLE
chore: Update CaraML's dependency on Turing

### DIFF
--- a/charts/caraml/Chart.lock
+++ b/charts/caraml/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.13.3
 - name: turing
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.3.4
+  version: 0.3.5
 - name: xp-treatment
   repository: https://caraml-dev.github.io/helm-charts
   version: 0.1.24
@@ -44,5 +44,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.8.2
-digest: sha256:e74f23de862f8330474b2332fb6a980217a8dd422c94bf842ccdca710a0553f8
-generated: "2023-11-02T03:29:20.64511466Z"
+digest: sha256:fb7b245b402e6a7720030430155351a9d3d9fce5445539358c5fabcd6c155239
+generated: "2023-11-02T13:19:54.964239+08:00"

--- a/charts/caraml/Chart.yaml
+++ b/charts/caraml/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 - condition: turing.enabled
   name: turing
   repository: https://caraml-dev.github.io/helm-charts
-  version: 0.3.4
+  version: 0.3.5
 - condition: xp-treatment.enabled
   name: xp-treatment
   repository: https://caraml-dev.github.io/helm-charts
@@ -72,4 +72,4 @@ maintainers:
   name: caraml-dev
 name: caraml
 type: application
-version: 0.8.12
+version: 0.8.13

--- a/charts/caraml/README.md
+++ b/charts/caraml/README.md
@@ -1,6 +1,6 @@
 # caraml
 
-![Version: 0.8.12](https://img.shields.io/badge/Version-0.8.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.8.13](https://img.shields.io/badge/Version-0.8.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML components
 
@@ -23,7 +23,7 @@ A Helm chart for deploying CaraML components
 | https://caraml-dev.github.io/helm-charts | istiod(generic-dep-installer) | 0.2.1 |
 | https://caraml-dev.github.io/helm-charts | merlin | 0.13.3 |
 | https://caraml-dev.github.io/helm-charts | mlp | 0.6.3 |
-| https://caraml-dev.github.io/helm-charts | turing | 0.3.4 |
+| https://caraml-dev.github.io/helm-charts | turing | 0.3.5 |
 | https://caraml-dev.github.io/helm-charts | xp-management | 0.2.9 |
 | https://caraml-dev.github.io/helm-charts | xp-treatment | 0.1.24 |
 | https://charts.helm.sh/stable | postgresql | 7.0.2 |


### PR DESCRIPTION
# Motivation

Update CaraML's dependency on Turing. This shouldn't be required to do manually, but I had to delete the CaraML chart release `0.8.12` to let this CI pass: https://github.com/caraml-dev/helm-charts/actions/runs/6728475864/job/18287888753#step:6:58

![Screenshot 2023-11-02 at 1 47 29 PM](https://github.com/caraml-dev/helm-charts/assets/23465343/88539f48-a6d7-4e7c-9c5b-1b3055bb848e)

That likely messed up the automatic dep update.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
