### PR TITLE
chore(xp-treatment): Update HPA configs for xp-treatment chart

### DIFF
--- a/charts/xp-treatment/Chart.yaml
+++ b/charts/xp-treatment/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: xp-treatment
-version: 0.1.24
+version: 0.1.25

--- a/charts/xp-treatment/README.md
+++ b/charts/xp-treatment/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square)
+![Version: 0.1.25](https://img.shields.io/badge/Version-0.1.25-informational?style=flat-square)
 ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Treatment service - A part of XP system that is used to obtain the treatment configuration from active experiments

--- a/charts/xp-treatment/templates/hpa.yaml
+++ b/charts/xp-treatment/templates/hpa.yaml
@@ -13,14 +13,6 @@ spec:
   minReplicas: {{ .Values.deployment.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.deployment.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.deployment.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.deployment.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
     {{- if .Values.deployment.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -28,5 +20,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.deployment.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.deployment.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.deployment.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
# Motivation
ArgoCD shows the HPA configs to be out of order. It expects `memory` to appear first and then `cpu`. This is a known issue:  https://github.com/argoproj/argo-cd/issues/1079

![Screenshot 2023-11-03 at 12 29 29 PM](https://github.com/caraml-dev/helm-charts/assets/23465343/a6a5c35b-537a-46ac-9c9e-967ea83e13e7)

# Modification

Reordering the HPA metrics.

# Checklist
- [x] Chart version bumped
- [x] README.md updated
