### PR TITLE
fix(ci): generate cluster credentials in CI test for explicitly caraml, merlin turing charts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,7 +78,7 @@ jobs:
         env:
           CHARTS_CHANGED: ${{ steps.list-changed.outputs.charts_changed }}
         run: |
-          if [[ $(echo $CHARTS_CHANGED | grep 'charts/\(merlin\|turing\|caraml\)') ]]; then
+          if [[ $(echo $CHARTS_CHANGED | grep 'charts/\(merlin\|turing\|caraml\s\)') ]]; then
             CHARTS_CHANGED=$CHARTS_CHANGED ./scripts/generate-cluster-creds.sh kind chart-testing
           fi
 

--- a/scripts/generate-cluster-creds.sh
+++ b/scripts/generate-cluster-creds.sh
@@ -91,16 +91,16 @@ EOF
 
   output=$(yq '.k8s_config' /tmp/temp_k8sconfig.yaml)
   # NOTE: Write to ci/ files as these files will be used in ci tests!
-  for CHART in $(echo $CHARTS_CHANGED | tr ' ' '\n' | grep 'charts/\(merlin\|turing\|caraml\)' | sed -r 's/charts\///')
+  for CHART in $(echo $CHARTS_CHANGED | tr ' ' '\n' | grep 'charts/\(merlin\|turing\|caraml\)')
   do
-    if [ $CHART == "caraml" ]; then
+    if [ $CHART == "charts/caraml" ]; then
       # Write to Merlin/ Turing subchart values in the overarching CaraML chart
       for APP in merlin turing
       do
         output="$output" yq ".${APP}.environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\") | .${APP}.imageBuilder.k8sConfig |= env(output)" -i "${SCRIPT_DIR}/../charts/caraml/ci/ci-values.yaml"
       done
-    else
-      output="$output" yq ".environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\") | .imageBuilder.k8sConfig |= env(output)" -i "${SCRIPT_DIR}/../charts/${CHART}/ci/ci-values.yaml"
+    elif [ $CHART == "charts/merlin" ] || [ $CHART == "charts/turing" ]; then
+      output="$output" yq ".environmentConfigs[0] *= load(\"/tmp/temp_k8sconfig.yaml\") | .imageBuilder.k8sConfig |= env(output)" -i "${SCRIPT_DIR}/../${CHART}/ci/ci-values.yaml"
     fi
   done
 }


### PR DESCRIPTION
# Motivation
During CI tests the generate cluster creds script is being invoked even for charts that have `caraml` in their name explicitly checking for the charts that need to be added. 

This MR will take care of scenarios where only one of the charts have changes or a combination of caraml, merlin, turing and other caram-* charts in the list of changed charts. 


# Modification
* Script changes - condition checks for adding cluster creds.

# Checklist
- [ ] Chart version bumped - NA
- [ ] README.md updated - NA
