### PR TITLE
chore(merlin|turing): Use configured image registry to generate default image names

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.11
+version: 0.13.12

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.13.11](https://img.shields.io/badge/Version-0.13.11-informational?style=flat-square)
+![Version: 0.13.12](https://img.shields.io/badge/Version-0.13.12-informational?style=flat-square)
 ![AppVersion: v0.38.0-rc1](https://img.shields.io/badge/AppVersion-v0.38.0--rc1-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -17,18 +17,18 @@
 # just as if we were outside of include/define:
 ImageBuilderConfig:
   BaseImage:
-    ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base:{{ printf "%s" $tag }}
+    ImageName: {{ .Values.deployment.image.registry }}/caraml-dev/merlin/merlin-pyfunc-base:{{ printf "%s" $tag }}
     DockerfilePath: "pyfunc-server/docker/Dockerfile"
     BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
     BuildContextSubPath: "python"
   PredictionJobBaseImage:
-    ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base:{{ printf "%s" $tag }}
+    ImageName: {{ .Values.deployment.image.registry }}/caraml-dev/merlin/merlin-pyspark-base:{{ printf "%s" $tag }}
     DockerfilePath: "batch-predictor/docker/app.Dockerfile"
     BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
     BuildContextSubPath: "python"
     MainAppPath: "/home/spark/merlin-spark-app/main.py"
 StandardTransformerConfig:
-  ImageName: ghcr.io/caraml-dev/merlin-transformer:{{ printf "%s" $tag }}
+  ImageName: {{ .Values.deployment.image.registry }}/caraml-dev/merlin-transformer:{{ printf "%s" $tag }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -153,7 +153,7 @@ tests:
         overrides:
           ImageBuilderConfig:
             BaseImage:
-              ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base:0.0.0-some-other-value
+              ImageName: docker.io/caraml-dev/merlin/merlin-pyfunc-base:0.0.0-some-other-value
               DockerfilePath: "python/pyfunc-server/docker/Dockerfile"
               BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/pull/465"
     asserts:
@@ -164,7 +164,7 @@ tests:
           pattern: my-release-merlin-config$
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base:0.0.0-some-other-value"
+          pattern: "ImageName: docker.io/caraml-dev/merlin/merlin-pyfunc-base:0.0.0-some-other-value"
       - matchRegex:
           path: stringData.[config.yaml]
           pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base:1.0.0-test-release"

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.3.12
+version: 0.3.13

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.3.12](https://img.shields.io/badge/Version-0.3.12-informational?style=flat-square)
+![Version: 0.3.13](https://img.shields.io/badge/Version-0.3.13-informational?style=flat-square)
 ![AppVersion: v1.16.0](https://img.shields.io/badge/AppVersion-v1.16.0-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -5,8 +5,8 @@
 {{- $tag := $rendered.releasedVersion}}
 {{- $ensemblerTag := default $tag $rendered.ensemblerTag }}
 {{- $ensemblerServiceTag := default $ensemblerTag $rendered.ensemblerServiceTag }}
-{{- $ensemblerJobPrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py" -}}
-{{- $servicePrefix := "ghcr.io/caraml-dev/turing/pyfunc-ensembler-service-py" -}}
+{{- $ensemblerJobPrefix := printf "%s/caraml-dev/turing/pyfunc-ensembler-job-py" $.Values.deployment.image.registry -}}
+{{- $servicePrefix := printf "%s/caraml-dev/turing/pyfunc-ensembler-service-py" $.Values.deployment.image.registry -}}
 # Now we have access to the "real" root and current contexts
 # just as if we were outside of include/define:
 {{ with index . 1 }}

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -29,7 +29,7 @@ EnsemblerServiceBuilderConfig:
     KanikoConfig: &kanikoConfig
       BuildContextURI: {{ printf "%s/%s" "git://github.com/caraml-dev/turing.git#refs/tags" $tag }}
 RouterDefaults:
-  Image: ghcr.io/caraml-dev/turing/turing-router:{{ printf "%s" $tag }}
+  Image: {{ .Values.deployment.image.registry }}/caraml-dev/turing/turing-router:{{ printf "%s" $tag }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/turing/tests/turing_config_secret_test.yaml
+++ b/charts/turing/tests/turing_config_secret_test.yaml
@@ -170,7 +170,7 @@ tests:
           BatchEnsemblingConfig:
             ImageBuilderConfig:
               BaseImages:
-                3.10.*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.10:test-tag-123
+                3.10.*: docker.io/caraml-dev/turing/pyfunc-ensembler-job-py3.10:test-tag-123
       config:
         BatchEnsemblingConfig:
           Enabled: true
@@ -204,4 +204,4 @@ tests:
           pattern: "3.9\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.9:some-ensembler-tag"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "3.10\\.\\*: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job-py3.10:test-tag-123"
+          pattern: "3.10\\.\\*: docker.io/caraml-dev/turing/pyfunc-ensembler-job-py3.10:test-tag-123"


### PR DESCRIPTION
# Motivation

It's a common use case to use a private mirror for docker images. This PR updates Turing and Merlin charts so that the image names that are generated based on the released version will leverage the configured `deployment.image.registry` value.

# Modification
* `charts/merlin/templates/_config.tpl` - Use `{{ .Values.deployment.image.registry }}` for the Pyfunc base images and standard transformer
* charts/turing/templates/_config.tpl - Use `{{ .Values.deployment.image.registry }}` for the Pyfunc base images and router
* Update unit tests to distinguish the override test case better

# Checklist
- [x] Chart version bumped
- [x] README.md updated

CC: @ariefrahmansyah @leonlnj 