### PR TITLE
feat(merlin): Add default tolerations and node selectors for Merlin batch jobs 

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.38.0-rc1
+appVersion: v0.39.1
 dependencies:
 - alias: merlin-postgresql
   condition: merlin-postgresql.enabled
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.13
+version: 0.13.14

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.39.1
+appVersion: v0.40.0
 dependencies:
 - alias: merlin-postgresql
   condition: merlin-postgresql.enabled

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,8 +1,8 @@
 # merlin
 
 ---
-![Version: 0.13.13](https://img.shields.io/badge/Version-0.13.13-informational?style=flat-square)
-![AppVersion: v0.38.0-rc1](https://img.shields.io/badge/AppVersion-v0.38.0--rc1-informational?style=flat-square)
+![Version: 0.13.14](https://img.shields.io/badge/Version-0.13.14-informational?style=flat-square)
+![AppVersion: v0.39.1](https://img.shields.io/badge/AppVersion-v0.39.1-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 
@@ -74,6 +74,11 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.AuthorizationConfig.Caching.KeyExpirySeconds | int | `600` | Cache key expiry duration |
 | config.AuthorizationConfig.KetoRemoteRead | string | `"http://mlp-keto-read:80"` |  |
 | config.AuthorizationConfig.KetoRemoteWrite | string | `"http://mlp-keto-write:80"` |  |
+| config.BatchConfig.NodeSelectors.node-workload-type | string | `"batch"` |  |
+| config.BatchConfig.Tolerations[0].Effect | string | `"NoSchedule"` |  |
+| config.BatchConfig.Tolerations[0].Key | string | `"batch-job"` |  |
+| config.BatchConfig.Tolerations[0].Operator | string | `"Equal"` |  |
+| config.BatchConfig.Tolerations[0].Value | string | `"true"` |  |
 | config.DbConfig.Database | string | `"merlin"` |  |
 | config.DbConfig.Host | string | `"localhost"` |  |
 | config.DbConfig.Password | string | `"merlin"` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -2,7 +2,7 @@
 
 ---
 ![Version: 0.13.14](https://img.shields.io/badge/Version-0.13.14-informational?style=flat-square)
-![AppVersion: v0.39.1](https://img.shields.io/badge/AppVersion-v0.39.1-informational?style=flat-square)
+![AppVersion: v0.40.0](https://img.shields.io/badge/AppVersion-v0.40.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -157,6 +157,14 @@ config:
     UPIDocumentation: "https://github.com/caraml-dev/universal-prediction-interface/blob/main/docs/api_markdown/caraml/upi/v1/index.md"
     CPUCost:  # Unused
     MemoryCost:  # Unused
+  BatchConfig:
+    Tolerations:
+      - Effect: NoSchedule
+        Key: batch-job
+        Operator: Equal
+        Value: "true"
+    NodeSelectors:
+      node-workload-type: "batch"
   StandardTransformerConfig:
     ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0
     SimulationFeast:


### PR DESCRIPTION
# Motivation
In line with the changes introduced in https://github.com/caraml-dev/merlin/pull/539 to expose tolerations and node selectors on pods where Merlin batch jobs are run, we are introducing default values for these fields in the default Merlin Helm values file. These values were previously hardcoded in the Merlin API server files as variables.

# Modification
- Add default tolerations and node selectors for Merlin batch jobs

# Checklist
- [x] Chart version bumped
- [x] README.md updated
