### PR TITLE
chore(turing): Update Turing app version to v1.17.2

### DIFF
--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.3.15
+version: 0.3.16

--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.16.0
+appVersion: v1.17.2
 dependencies:
 - alias: turing-postgresql
   condition: turing-postgresql.enabled

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -2,7 +2,7 @@
 
 ---
 ![Version: 0.3.15](https://img.shields.io/badge/Version-0.3.15-informational?style=flat-square)
-![AppVersion: v1.16.0](https://img.shields.io/badge/AppVersion-v1.16.0-informational?style=flat-square)
+![AppVersion: v1.17.2](https://img.shields.io/badge/AppVersion-v1.17.2-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.
 

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.3.15](https://img.shields.io/badge/Version-0.3.15-informational?style=flat-square)
+![Version: 0.3.16](https://img.shields.io/badge/Version-0.3.16-informational?style=flat-square)
 ![AppVersion: v1.17.2](https://img.shields.io/badge/AppVersion-v1.17.2-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.


### PR DESCRIPTION
# Motivation
The Turing app version has been updated v1.17.2 though the default version in the chart remained at v1.16.0. This PR simply updates the `appVersion` value so the latest version of Turing is used by default when installing it via its Helm chart.

# Modification
- `charts/turing/Chart.yaml` - Bumping up of Turing from v1.16.0 to v1.17.2

# Checklist
- [x] Chart version bumped
- [x] README.md updated
