### PR TITLE
feat(merlin): Add observability publisher image in the config partial template

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.40.0
+appVersion: v0.41.0
 dependencies:
 - alias: merlin-postgresql
   condition: merlin-postgresql.enabled
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.14
+version: 0.13.15

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,8 +1,8 @@
 # merlin
 
 ---
-![Version: 0.13.14](https://img.shields.io/badge/Version-0.13.14-informational?style=flat-square)
-![AppVersion: v0.40.0](https://img.shields.io/badge/AppVersion-v0.40.0-informational?style=flat-square)
+![Version: 0.13.15](https://img.shields.io/badge/Version-0.13.15-informational?style=flat-square)
+![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
 

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -29,6 +29,8 @@ ImageBuilderConfig:
     MainAppPath: "/home/spark/merlin-spark-app/main.py"
 StandardTransformerConfig:
   ImageName: {{ .Values.deployment.image.registry }}/caraml-dev/merlin-transformer:{{ printf "%s" $tag }}
+ObservabilityPublisher:
+  ImageName: {{ .Values.deployment.image.registry }}/caraml-dev/merlin/merlin-observation-publisher:{{ printf "%s" $tag }}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Motivation
In this [PR](https://github.com/caraml-dev/merlin/pull/550) we introduce ObservabilityPublisher config. This config have `imageName` field which is the value is depend on the released version that defined by the administrator
# Modification
Set ObservabilityPublisher.ImageName value based on rendered  released version
# Checklist
- [ ] Chart version bumped
- [ ] README.md updated
