### PR TITLE
chore(merlin): Fix merlin batch job node selector default value

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.15
+version: 0.13.16

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.13.15](https://img.shields.io/badge/Version-0.13.15-informational?style=flat-square)
+![Version: 0.13.16](https://img.shields.io/badge/Version-0.13.16-informational?style=flat-square)
 ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
@@ -74,7 +74,6 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.AuthorizationConfig.Caching.KeyExpirySeconds | int | `600` | Cache key expiry duration |
 | config.AuthorizationConfig.KetoRemoteRead | string | `"http://mlp-keto-read:80"` |  |
 | config.AuthorizationConfig.KetoRemoteWrite | string | `"http://mlp-keto-write:80"` |  |
-| config.BatchConfig.NodeSelectors.node-workload-type | string | `"batch"` |  |
 | config.BatchConfig.Tolerations[0].Effect | string | `"NoSchedule"` |  |
 | config.BatchConfig.Tolerations[0].Key | string | `"batch-job"` |  |
 | config.BatchConfig.Tolerations[0].Operator | string | `"Equal"` |  |
@@ -237,7 +236,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | imageBuilder.builderConfig.PredictionJobBaseImage.BuildContextURI | string | `"git://github.com/caraml-dev/merlin.git#refs/tags/v0.38.0-rc1"` |  |
 | imageBuilder.builderConfig.PredictionJobBaseImage.DockerfilePath | string | `"batch-predictor/docker/app.Dockerfile"` |  |
 | imageBuilder.builderConfig.PredictionJobBaseImage.ImageName | string | `"ghcr.io/caraml-dev/merlin/merlin-pyspark-base:0.38.0-rc1"` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImage.MainAppPath | string | `"/home/spark/merlin-spark-app/main.py"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImage.MainAppPath | string | `"/home/spark/main.py"` |  |
 | imageBuilder.builderConfig.Retention | string | `"48h"` |  |
 | imageBuilder.builderConfig.SafeToEvict | bool | `false` |  |
 | imageBuilder.builderConfig.Tolerations | list | `[]` |  |

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -153,10 +153,10 @@ config:
     MaxAllowedReplica: 20
     MerlinURL: /api/merlin/v1
     MlpURL: /api
-    OauthClientID: # to be set via CICD pipeline
+    OauthClientID:  # to be set via CICD pipeline
     UPIDocumentation: "https://github.com/caraml-dev/universal-prediction-interface/blob/main/docs/api_markdown/caraml/upi/v1/index.md"
-    CPUCost: # Unused
-    MemoryCost: # Unused
+    CPUCost:  # Unused
+    MemoryCost:  # Unused
   BatchConfig:
     Tolerations:
       - Effect: NoSchedule
@@ -349,13 +349,7 @@ ui:
   upiDocURL: "https://github.com/caraml-dev/universal-prediction-interface/blob/main/docs/api_markdown/caraml/upi/v1/index.md"
   mlp:
     apiHost: /api
-  docsURL:
-    [
-      {
-        "href": "https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md",
-        "label": "Getting Started with Merlin",
-      },
-    ]
+  docsURL: [{"href": "https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md", "label": "Getting Started with Merlin"}]
   # -- Comma-separated value of Docker registries that can be chosen in deployment page
   dockerRegistries: ghcr.io/gojek,ghcr.io/your-company
   maxAllowedReplica: 20

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -153,18 +153,16 @@ config:
     MaxAllowedReplica: 20
     MerlinURL: /api/merlin/v1
     MlpURL: /api
-    OauthClientID:  # to be set via CICD pipeline
+    OauthClientID: # to be set via CICD pipeline
     UPIDocumentation: "https://github.com/caraml-dev/universal-prediction-interface/blob/main/docs/api_markdown/caraml/upi/v1/index.md"
-    CPUCost:  # Unused
-    MemoryCost:  # Unused
+    CPUCost: # Unused
+    MemoryCost: # Unused
   BatchConfig:
     Tolerations:
       - Effect: NoSchedule
         Key: batch-job
         Operator: Equal
         Value: "true"
-    NodeSelectors:
-      node-workload-type: "batch"
   StandardTransformerConfig:
     ImageName: ghcr.io/caraml-dev/merlin-transformer:1.0.0
     SimulationFeast:
@@ -279,7 +277,7 @@ imageBuilder:
       DockerfilePath: "batch-predictor/docker/app.Dockerfile"
       BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v0.38.0-rc1"
       BuildContextSubPath: "python"
-      MainAppPath: "/home/spark/merlin-spark-app/main.py"
+      MainAppPath: "/home/spark/main.py"
     BuildNamespace: "mlp"
     DockerRegistry: "dockerRegistry"
     BuildTimeout: "30m"
@@ -351,7 +349,13 @@ ui:
   upiDocURL: "https://github.com/caraml-dev/universal-prediction-interface/blob/main/docs/api_markdown/caraml/upi/v1/index.md"
   mlp:
     apiHost: /api
-  docsURL: [{"href": "https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md", "label": "Getting Started with Merlin"}]
+  docsURL:
+    [
+      {
+        "href": "https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md",
+        "label": "Getting Started with Merlin",
+      },
+    ]
   # -- Comma-separated value of Docker registries that can be chosen in deployment page
   dockerRegistries: ghcr.io/gojek,ghcr.io/your-company
   maxAllowedReplica: 20


### PR DESCRIPTION
# Motivation

Merlin's default `values.yaml` has BatchConfig.NodeSelectors value configured which will no be overwritten if user modify the value on their own values file.

# Modification

1. Remove BatchConfig.NodeSelectors default value
2. Update default value for imageBuilder.builderConfig.PredictionJobBaseImage.MainAppPath

# Checklist
- [x] Chart version bumped
- [x] README.md updated
