### PR TITLE
chore(merlin): Update PredictionJobBaseImage.MainAppPath in _config.tpl

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.16
+version: 0.13.17

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.13.16](https://img.shields.io/badge/Version-0.13.16-informational?style=flat-square)
+![Version: 0.13.17](https://img.shields.io/badge/Version-0.13.17-informational?style=flat-square)
 ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/templates/_config.tpl
+++ b/charts/merlin/templates/_config.tpl
@@ -26,7 +26,7 @@ ImageBuilderConfig:
     DockerfilePath: "batch-predictor/docker/app.Dockerfile"
     BuildContextURI: "git://github.com/caraml-dev/merlin.git#{{ printf "%s" $reference }}"
     BuildContextSubPath: "python"
-    MainAppPath: "/home/spark/merlin-spark-app/main.py"
+    MainAppPath: "/home/spark/main.py"
 StandardTransformerConfig:
   ImageName: {{ .Values.deployment.image.registry }}/caraml-dev/merlin-transformer:{{ printf "%s" $tag }}
 ObservabilityPublisher:


### PR DESCRIPTION
# Motivation

Previous PR (https://github.com/caraml-dev/helm-charts/pull/408) removed PredictionJobBaseImage.MainAppPath from Merlin default values.yaml, however, if it's empty it will use the value from _config.tpl.

# Modification

This PR updates the default PredictionJobBaseImage.MainAppPath in _config.tpl

# Checklist
- [x] Chart version bumped
- [x] README.md updated
