### PR TITLE
chore: avoid setting replica when HPA is defined

### DIFF
--- a/charts/caraml-store/Chart.yaml
+++ b/charts/caraml-store/Chart.yaml
@@ -20,4 +20,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: caraml-store
-version: 0.1.16
+version: 0.1.17

--- a/charts/caraml-store/README.md
+++ b/charts/caraml-store/README.md
@@ -1,6 +1,6 @@
 # caraml-store
 
-![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
+![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
 
 CaraML store registry: Feature registry for CaraML store.
 

--- a/charts/caraml-store/templates/serving/deployment.yaml
+++ b/charts/caraml-store/templates/serving/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     {{- include "caraml-store.serving.labels" . | nindent 4 }}
 spec:
+{{- if not .Values.serving.autoscaling.enabled }}
   replicas: {{ .Values.serving.replicaCount }}
+{{- end }}
 {{- if .Values.serving.strategy }}
   strategy:
 {{ toYaml .Values.serving.strategy | indent 4 }}


### PR DESCRIPTION
# Motivation
Replica shouldnt be set if HPA is enabled.

# Modification

# Checklist
- [x] Chart version bumped
- [x] README.md updated
