### PR TITLE
fix(xp): Add POST method to XP Oathkeeper rules

### DIFF
--- a/charts/routes/Chart.yaml
+++ b/charts/routes/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
     name: caraml-dev
 name: caraml-routes
 type: application
-version: 0.3.3
+version: 0.3.4

--- a/charts/routes/README.md
+++ b/charts/routes/README.md
@@ -1,7 +1,7 @@
 # caraml-routes
 
 ---
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square)
 ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying CaraML networking resources

--- a/charts/routes/templates/xp-oathkeeper-rules.yaml
+++ b/charts/routes/templates/xp-oathkeeper-rules.yaml
@@ -11,6 +11,7 @@ spec:
     url: {{ printf "<%s>/<(treatment-service-config|validate|projects)>" (include "caraml-routes.oathkeeper.xp.regexPrefix" .) }}
     methods:
       - "GET"
+      - "POST"
   authenticators:
     - handler: jwt
   authorizer:

--- a/scripts/install_metallib.sh
+++ b/scripts/install_metallib.sh
@@ -8,7 +8,7 @@ set -ex
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.5/config/manifests/metallb-native.yaml
 kubectl wait pods --all -n metallb-system --for=condition=Ready --timeout 500s
 
-KIND_SUBNET=$(docker network inspect kind | jq '.[0].IPAM.Config[0].Subnet' | sed 's/"//g')
+KIND_SUBNET=$(docker network inspect kind | jq '.[0].IPAM.Config[1].Subnet' | sed 's/"//g')
 if [[ -z $KIND_SUBNET ]]; then
   echo "Could not find kind subnet. Please ensure a kind cluster named kind is present"
   exit 1


### PR DESCRIPTION
# Motivation
XP's `/validate` endpoint only [allows](https://github.com/caraml-dev/xp/blob/main/management-service/api/api.go#L2254) POST methods but these aren't allowed under the existing Oathkeeper rules (probably it got forgotten when the authentication mechanism of CaraML was changed). This PR adds POST methods to the existing methods (only GET exists currently) allowed for the non-project specific endpoints (i.e. `/treatment-service-config` and `/projects`). 

# Modification
- Add POST method to existing XP Oathkeeper rule

# Checklist
- [x] Chart version bumped
- [x] README.md updated
