### PR TITLE
feat(serving): adding startup and readiness probe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ override.tf.json
 
 # Ignore inner charts dir
 charts/**/charts/*.tgz
+
+.idea/

--- a/charts/caraml-store/Chart.yaml
+++ b/charts/caraml-store/Chart.yaml
@@ -20,4 +20,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: caraml-store
-version: 0.1.17
+version: 0.1.18

--- a/charts/caraml-store/README.md
+++ b/charts/caraml-store/README.md
@@ -85,7 +85,6 @@ CaraML store registry: Feature registry for CaraML store.
 | serving.image.tag | string | `""` |  |
 | serving.imagePullSecrets | list | `[]` |  |
 | serving.javaOpts | string | `nil` |  |
-| serving.livenessProbe.enabled | bool | `true` | Flag to enable the liveness probe |
 | serving.livenessProbe.failureThreshold | int | `5` | Min consecutive failures for the liveness probe to be considered failed |
 | serving.livenessProbe.initialDelaySeconds | int | `0` | Delay before the liveness probe is initiated |
 | serving.livenessProbe.periodSeconds | int | `10` | How often to perform the liveness probe |
@@ -98,7 +97,6 @@ CaraML store registry: Feature registry for CaraML store.
 | serving.podDisruptionBudget | object | `{}` | This value is used to configure a Kubernetes PodDisruptionBudget for Serving deployment |
 | serving.podLabels | object | `{}` |  |
 | serving.prometheus.monitor.enabled | bool | `false` | Create a ServiceMonitor resource to expose Prometheus metrics |
-| serving.readinessProbe.enabled | bool | `true` | Flag to enable the readiness probe |
 | serving.readinessProbe.failureThreshold | int | `2` | Min consecutive failures for the readiness probe to be considered failed |
 | serving.readinessProbe.initialDelaySeconds | int | `0` | Delay before the readiness probe is initiated |
 | serving.readinessProbe.periodSeconds | int | `5` | How often to perform the readiness probe |
@@ -111,7 +109,6 @@ CaraML store registry: Feature registry for CaraML store.
 | serving.service.grpc.port | int | `6566` | Service port for GRPC requests |
 | serving.service.grpc.targetPort | int | `6566` | Container port serving GRPC requests |
 | serving.service.type | string | `"ClusterIP"` | Kubernetes service type |
-| serving.startupProbe.enabled | bool | `true` | Flag to enable the startup probe |
 | serving.startupProbe.failureThreshold | int | `10` | Min consecutive failures for the startup probe to be considered failed |
 | serving.startupProbe.periodSeconds | int | `5` | How often to perform the startup probe |
 | serving.startupProbe.timeoutSeconds | int | `1` | When the startup probe times out |

--- a/charts/caraml-store/README.md
+++ b/charts/caraml-store/README.md
@@ -1,6 +1,6 @@
 # caraml-store
 
-![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
+![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
 
 CaraML store registry: Feature registry for CaraML store.
 
@@ -85,6 +85,11 @@ CaraML store registry: Feature registry for CaraML store.
 | serving.image.tag | string | `""` |  |
 | serving.imagePullSecrets | list | `[]` |  |
 | serving.javaOpts | string | `nil` |  |
+| serving.livenessProbe.enabled | bool | `true` | Flag to enable the liveness probe |
+| serving.livenessProbe.failureThreshold | int | `5` | Min consecutive failures for the liveness probe to be considered failed |
+| serving.livenessProbe.initialDelaySeconds | int | `0` | Delay before the liveness probe is initiated |
+| serving.livenessProbe.periodSeconds | int | `10` | How often to perform the liveness probe |
+| serving.livenessProbe.timeoutSeconds | int | `2` | When the liveness probe times out |
 | serving.minReadySeconds | int | `0` | The minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. |
 | serving.name | string | `"serving"` |  |
 | serving.nameOverride | string | `""` |  |
@@ -93,12 +98,12 @@ CaraML store registry: Feature registry for CaraML store.
 | serving.podDisruptionBudget | object | `{}` | This value is used to configure a Kubernetes PodDisruptionBudget for Serving deployment |
 | serving.podLabels | object | `{}` |  |
 | serving.prometheus.monitor.enabled | bool | `false` | Create a ServiceMonitor resource to expose Prometheus metrics |
-| serving.readinessProbe.enabled | bool | `true` | Flag to enable the probe |
-| serving.readinessProbe.failureThreshold | int | `5` | Min consecutive failures for the probe to be considered failed |
-| serving.readinessProbe.initialDelaySeconds | int | `20` | Delay before the probe is initiated |
-| serving.readinessProbe.periodSeconds | int | `10` | How often to perform the probe |
-| serving.readinessProbe.successThreshold | int | `1` | Min consecutive success for the probe to be considered successful |
-| serving.readinessProbe.timeoutSeconds | int | `10` | When the probe times out |
+| serving.readinessProbe.enabled | bool | `true` | Flag to enable the readiness probe |
+| serving.readinessProbe.failureThreshold | int | `2` | Min consecutive failures for the readiness probe to be considered failed |
+| serving.readinessProbe.initialDelaySeconds | int | `0` | Delay before the readiness probe is initiated |
+| serving.readinessProbe.periodSeconds | int | `5` | How often to perform the readiness probe |
+| serving.readinessProbe.successThreshold | int | `2` | Min consecutive success for the readiness probe to be considered successful |
+| serving.readinessProbe.timeoutSeconds | int | `2` | When the readiness probe times out |
 | serving.replicaCount | int | `1` |  |
 | serving.resources | object | `{}` |  |
 | serving.secrets | list | `[]` |  |
@@ -106,6 +111,10 @@ CaraML store registry: Feature registry for CaraML store.
 | serving.service.grpc.port | int | `6566` | Service port for GRPC requests |
 | serving.service.grpc.targetPort | int | `6566` | Container port serving GRPC requests |
 | serving.service.type | string | `"ClusterIP"` | Kubernetes service type |
+| serving.startupProbe.enabled | bool | `true` | Flag to enable the startup probe |
+| serving.startupProbe.failureThreshold | int | `10` | Min consecutive failures for the startup probe to be considered failed |
+| serving.startupProbe.periodSeconds | int | `5` | How often to perform the startup probe |
+| serving.startupProbe.timeoutSeconds | int | `1` | When the startup probe times out |
 | serving.strategy | object | `{}` | Strategy used to replace old Pods by new ones. .spec.strategy.type can be "Recreate" or "RollingUpdate". "RollingUpdate" is the default value. |
 | serving.tolerations | list | `[]` |  |
 

--- a/charts/caraml-store/templates/serving/deployment.yaml
+++ b/charts/caraml-store/templates/serving/deployment.yaml
@@ -106,7 +106,6 @@ spec:
             - name: http
               containerPort: {{ .Values.serving.actuator.port }}
               protocol: TCP
-          {{- if .Values.serving.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /actuator/health
@@ -114,8 +113,6 @@ spec:
             periodSeconds: {{ .Values.serving.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.serving.startupProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.serving.startupProbe.failureThreshold }}
-          {{- end }}
-          {{- if .Values.serving.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -125,8 +122,6 @@ spec:
             successThreshold: {{ .Values.serving.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.serving.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.serving.readinessProbe.failureThreshold }}
-          {{- end }}
-          {{- if .Values.serving.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /actuator/health
@@ -135,7 +130,6 @@ spec:
             periodSeconds: {{ .Values.serving.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.serving.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.serving.livenessProbe.failureThreshold }}
-          {{- end }}
           resources:
             {{- toYaml .Values.serving.resources | nindent 12 }}
       {{- with .Values.serving.nodeSelector }}

--- a/charts/caraml-store/templates/serving/deployment.yaml
+++ b/charts/caraml-store/templates/serving/deployment.yaml
@@ -106,6 +106,15 @@ spec:
             - name: http
               containerPort: {{ .Values.serving.actuator.port }}
               protocol: TCP
+          {{- if .Values.serving.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: {{ .Values.serving.actuator.port }}
+            periodSeconds: {{ .Values.serving.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.serving.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.serving.startupProbe.failureThreshold }}
+          {{- end }}
           {{- if .Values.serving.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
@@ -116,6 +125,16 @@ spec:
             successThreshold: {{ .Values.serving.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.serving.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.serving.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.serving.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: {{ .Values.serving.actuator.port }}
+            initialDelaySeconds: {{ .Values.serving.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.serving.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.serving.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.serving.livenessProbe.failureThreshold }}
           {{- end }}
           resources:
             {{- toYaml .Values.serving.resources | nindent 12 }}

--- a/charts/caraml-store/values.yaml
+++ b/charts/caraml-store/values.yaml
@@ -160,18 +160,40 @@ serving:
 
   javaOpts:
 
-  readinessProbe:
-    # serving.readinessProbe.enabled -- Flag to enable the probe
+  startupProbe:
+    # serving.startupProbe.enabled -- Flag to enable the startup probe
     enabled: true
-    # serving.readinessProbe.initialDelaySeconds -- Delay before the probe is initiated
-    initialDelaySeconds: 20
-    # serving.readinessProbe.periodSeconds -- How often to perform the probe
+    # serving.startupProbe.periodSeconds -- How often to perform the startup probe
+    periodSeconds: 5
+    # serving.startupProbe.timeoutSeconds -- When the startup probe times out
+    timeoutSeconds: 1
+    # serving.startupProbe.failureThreshold -- Min consecutive failures for the startup probe to be considered failed
+    failureThreshold: 10
+
+  readinessProbe:
+    # serving.readinessProbe.enabled -- Flag to enable the readiness probe
+    enabled: true
+    # serving.readinessProbe.initialDelaySeconds -- Delay before the readiness probe is initiated
+    initialDelaySeconds: 0
+    # serving.readinessProbe.periodSeconds -- How often to perform the readiness probe
+    periodSeconds: 5
+    # serving.readinessProbe.timeoutSeconds -- When the readiness probe times out
+    timeoutSeconds: 2
+    # serving.readinessProbe.successThreshold -- Min consecutive success for the readiness probe to be considered successful
+    successThreshold: 2
+    # serving.readinessProbe.failureThreshold -- Min consecutive failures for the readiness probe to be considered failed
+    failureThreshold: 2
+
+  livenessProbe:
+    # serving.livenessProbe.enabled -- Flag to enable the liveness probe
+    enabled: true
+    # serving.livenessProbe.initialDelaySeconds -- Delay before the liveness probe is initiated
+    initialDelaySeconds: 0
+    # serving.livenessProbe.periodSeconds -- How often to perform the liveness probe
     periodSeconds: 10
-    # serving.readinessProbe.timeoutSeconds -- When the probe times out
-    timeoutSeconds: 10
-    # serving.readinessProbe.successThreshold -- Min consecutive success for the probe to be considered successful
-    successThreshold: 1
-    # serving.readinessProbe.failureThreshold -- Min consecutive failures for the probe to be considered failed
+    # serving.livenessProbe.timeoutSeconds -- When the liveness probe times out
+    timeoutSeconds: 2
+    # serving.livenessProbe.failureThreshold -- Min consecutive failures for the liveness probe to be considered failed
     failureThreshold: 5
 
   resources: {}

--- a/charts/caraml-store/values.yaml
+++ b/charts/caraml-store/values.yaml
@@ -161,8 +161,6 @@ serving:
   javaOpts:
 
   startupProbe:
-    # serving.startupProbe.enabled -- Flag to enable the startup probe
-    enabled: true
     # serving.startupProbe.periodSeconds -- How often to perform the startup probe
     periodSeconds: 5
     # serving.startupProbe.timeoutSeconds -- When the startup probe times out
@@ -171,8 +169,6 @@ serving:
     failureThreshold: 10
 
   readinessProbe:
-    # serving.readinessProbe.enabled -- Flag to enable the readiness probe
-    enabled: true
     # serving.readinessProbe.initialDelaySeconds -- Delay before the readiness probe is initiated
     initialDelaySeconds: 0
     # serving.readinessProbe.periodSeconds -- How often to perform the readiness probe
@@ -185,8 +181,6 @@ serving:
     failureThreshold: 2
 
   livenessProbe:
-    # serving.livenessProbe.enabled -- Flag to enable the liveness probe
-    enabled: true
     # serving.livenessProbe.initialDelaySeconds -- Delay before the liveness probe is initiated
     initialDelaySeconds: 0
     # serving.livenessProbe.periodSeconds -- How often to perform the liveness probe


### PR DESCRIPTION
# Motivation
The Caraml Store Serving service needs to maintain high availability due to the large volume of requests it handles. Therefore, it's crucial to ensure the application has completed its startup process using a startup probe. Additionally, if the service becomes unresponsive for an extended period, the pod should be restarted using a liveness probe.

# Modification
Adding startup and liveness probe for caraml store serving deployments with default value
```yaml
startupProbe:
  httpGet:
    path: /actuator/health
    port: 8080
  periodSeconds: 5
  timeoutSeconds: 1
  failureThreshold: 10
livenessProbe:
  httpGet:
    path: /actuator/health
    port: 8080
  initialDelaySeconds: 0
  periodSeconds: 10
  timeoutSeconds: 2
  failureThreshold: 5

```

# Checklist
- [x] Chart version bumped
- [x] README.md updated
