### PR TITLE
chore(merlin): Update merlin and mlflow versions

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.18
+version: 0.13.19

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -111,6 +111,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.ObservabilityPublisher.DefaultResources.Limits.Memory | string | `"1Gi"` |  |
 | config.ObservabilityPublisher.DefaultResources.Requests.CPU | string | `"1"` |  |
 | config.ObservabilityPublisher.DefaultResources.Requests.Memory | string | `"1Gi"` |  |
+| config.ObservabilityPublisher.EnvironmentName | string | `"id-dev"` |  |
 | config.ObservabilityPublisher.KafkaConsumer.Brokers | string | `"kafka-brokers"` |  |
 | config.Port | int | `8080` |  |
 | config.PyFuncPublisherConfig.Kafka.Acks | int | `0` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -214,9 +214,9 @@ The following table lists the configurable parameters of the Merlin chart and th
 | global.protocol | string | `"http"` |  |
 | imageBuilder.builderConfig.ArtifactServiceType | string | `"nop"` |  |
 | imageBuilder.builderConfig.BaseImage.BuildContextSubPath | string | `"python"` |  |
-| imageBuilder.builderConfig.BaseImage.BuildContextURI | string | `"git://github.com/caraml-dev/merlin.git#refs/tags/v0.38.0-rc1"` |  |
+| imageBuilder.builderConfig.BaseImage.BuildContextURI | string | `"git://github.com/caraml-dev/merlin.git#refs/tags/v0.45.3"` |  |
 | imageBuilder.builderConfig.BaseImage.DockerfilePath | string | `"pyfunc-server/docker/Dockerfile"` |  |
-| imageBuilder.builderConfig.BaseImage.ImageName | string | `"ghcr.io/caraml-dev/merlin/merlin-pyfunc-base:0.38.0-rc1"` |  |
+| imageBuilder.builderConfig.BaseImage.ImageName | string | `"ghcr.io/caraml-dev/merlin/merlin-pyfunc-base:0.45.3"` |  |
 | imageBuilder.builderConfig.BuildNamespace | string | `"mlp"` |  |
 | imageBuilder.builderConfig.BuildTimeout | string | `"30m"` |  |
 | imageBuilder.builderConfig.DefaultResources.Limits.CPU | string | `"1"` |  |
@@ -234,9 +234,9 @@ The following table lists the configurable parameters of the Merlin chart and th
 | imageBuilder.builderConfig.MaximumRetry | int | `3` |  |
 | imageBuilder.builderConfig.NodeSelectors | object | `{}` |  |
 | imageBuilder.builderConfig.PredictionJobBaseImage.BuildContextSubPath | string | `"python"` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImage.BuildContextURI | string | `"git://github.com/caraml-dev/merlin.git#refs/tags/v0.38.0-rc1"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImage.BuildContextURI | string | `"git://github.com/caraml-dev/merlin.git#refs/tags/v0.45.3"` |  |
 | imageBuilder.builderConfig.PredictionJobBaseImage.DockerfilePath | string | `"batch-predictor/docker/app.Dockerfile"` |  |
-| imageBuilder.builderConfig.PredictionJobBaseImage.ImageName | string | `"ghcr.io/caraml-dev/merlin/merlin-pyspark-base:0.38.0-rc1"` |  |
+| imageBuilder.builderConfig.PredictionJobBaseImage.ImageName | string | `"ghcr.io/caraml-dev/merlin/merlin-pyspark-base:0.45.3"` |  |
 | imageBuilder.builderConfig.PredictionJobBaseImage.MainAppPath | string | `"/home/spark/merlin-spark-app/main.py"` |  |
 | imageBuilder.builderConfig.Retention | string | `"48h"` |  |
 | imageBuilder.builderConfig.SafeToEvict | bool | `false` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -230,6 +230,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | imageBuilder.builderConfig.KanikoAdditionalArgs[3] | string | `"--use-new-run"` |  |
 | imageBuilder.builderConfig.KanikoAdditionalArgs[4] | string | `"--log-timestamp"` |  |
 | imageBuilder.builderConfig.KanikoImage | string | `"gcr.io/kaniko-project/executor:v1.18.0"` |  |
+| imageBuilder.builderConfig.KanikoPushRegistryType | string | `"gcr"` |  |
 | imageBuilder.builderConfig.MaximumRetry | int | `3` |  |
 | imageBuilder.builderConfig.NodeSelectors | object | `{}` |  |
 | imageBuilder.builderConfig.PredictionJobBaseImage.BuildContextSubPath | string | `"python"` |  |
@@ -313,8 +314,8 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlflow.host | string | `"0.0.0.0"` |  |
 | mlflow.image.pullPolicy | string | `"Always"` |  |
 | mlflow.image.registry | string | `"ghcr.io"` |  |
-| mlflow.image.repository | string | `"gojek/mlflow"` |  |
-| mlflow.image.tag | string | `"1.3.0"` |  |
+| mlflow.image.repository | string | `"caraml-dev/mlflow"` |  |
+| mlflow.image.tag | string | `"1.26.1"` |  |
 | mlflow.ingress.class | string | `"nginx"` |  |
 | mlflow.ingress.enabled | bool | `false` |  |
 | mlflow.livenessProbe.initialDelaySeconds | int | `30` |  |
@@ -361,7 +362,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlp.keto.enabled | bool | `true` |  |
 | mlp.keto.fullnameOverride | string | `"mlp-keto"` |  |
 | rendered.overrides | object | `{}` |  |
-| rendered.releasedVersion | string | `"v0.38.0-rc1"` |  |
+| rendered.releasedVersion | string | `"v0.45.3"` |  |
 | service.externalPort | int | `8080` |  |
 | service.internalPort | int | `8080` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -107,6 +107,11 @@ The following table lists the configurable parameters of the Merlin chart and th
 | config.NewRelic.IgnoreStatusCodes[5] | int | `412` |  |
 | config.NewRelic.License | string | `"newrelic-license-secret"` |  |
 | config.NumOfQueueWorkers | int | `2` |  |
+| config.ObservabilityPublisher.DefaultResources.Limits.CPU | string | `"2"` |  |
+| config.ObservabilityPublisher.DefaultResources.Limits.Memory | string | `"1Gi"` |  |
+| config.ObservabilityPublisher.DefaultResources.Requests.CPU | string | `"1"` |  |
+| config.ObservabilityPublisher.DefaultResources.Requests.Memory | string | `"1Gi"` |  |
+| config.ObservabilityPublisher.KafkaConsumer.Brokers | string | `"kafka-brokers"` |  |
 | config.Port | int | `8080` |  |
 | config.PyFuncPublisherConfig.Kafka.Acks | int | `0` |  |
 | config.PyFuncPublisherConfig.Kafka.AdditionalConfig | string | `"{}"` |  |

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.13.18](https://img.shields.io/badge/Version-0.13.18-informational?style=flat-square)
+![Version: 0.13.19](https://img.shields.io/badge/Version-0.13.19-informational?style=flat-square)
 ![AppVersion: v0.42.0](https://img.shields.io/badge/AppVersion-v0.42.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/tests/merlin_config_secret_test.yaml
+++ b/charts/merlin/tests/merlin_config_secret_test.yaml
@@ -195,7 +195,7 @@ tests:
           pattern: my-release-merlin-config$
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base:0.38.0-rc1"
+          pattern: "ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base:0.45.3"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "BuildContextURI: git://github.com/caraml-dev/merlin.git#refs/tags/v0.38.0-rc1"
+          pattern: "BuildContextURI: git://github.com/caraml-dev/merlin.git#refs/tags/v0.45.3"

--- a/charts/merlin/tests/merlin_deployment_test.yaml
+++ b/charts/merlin/tests/merlin_deployment_test.yaml
@@ -177,7 +177,7 @@ tests:
           pattern: my-release-merlin$
       - equal: # check image version
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/caraml-dev/merlin:0.38.0-rc1
+          value: ghcr.io/caraml-dev/merlin:0.45.3
       - equal: # check version label
           path: spec.template.metadata.labels.version
-          value: 0.38.0-rc1
+          value: 0.45.3

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -268,14 +268,14 @@ imageBuilder:
   builderConfig:
     ArtifactServiceType: nop
     BaseImage:
-      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base:0.38.0-rc1
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyfunc-base:0.45.3
       DockerfilePath: "pyfunc-server/docker/Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v0.38.0-rc1"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v0.45.3"
       BuildContextSubPath: "python"
     PredictionJobBaseImage:
-      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base:0.38.0-rc1
+      ImageName: ghcr.io/caraml-dev/merlin/merlin-pyspark-base:0.45.3
       DockerfilePath: "batch-predictor/docker/app.Dockerfile"
-      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v0.38.0-rc1"
+      BuildContextURI: "git://github.com/caraml-dev/merlin.git#refs/tags/v0.45.3"
       BuildContextSubPath: "python"
       MainAppPath: "/home/spark/merlin-spark-app/main.py"
     BuildNamespace: "mlp"

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -246,6 +246,7 @@ config:
       Limits:
         CPU: "2"
         Memory: "1Gi"
+    EnvironmentName: id-dev
 clusterConfig:
   # -- (bool) Configuration to tell Merlin API how it should authenticate with deployment k8s cluster
   # By default, Merlin API expects to use a remote k8s cluster for deployment and to do so, it requires

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -5,7 +5,7 @@ global:
 # .config when generating templates
 rendered:
   # releasedVersion refers to the git release or tag
-  releasedVersion: v0.38.0-rc1
+  releasedVersion: v0.45.3
   overrides: {}
 # set deployment.image.tag to non-nil to overwrite
 # .rendered.releasedVersion
@@ -282,6 +282,7 @@ imageBuilder:
     DockerRegistry: "dockerRegistry"
     BuildTimeout: "30m"
     KanikoImage: "gcr.io/kaniko-project/executor:v1.18.0"
+    KanikoPushRegistryType: gcr
     KanikoAdditionalArgs:
       - "--cache=true"
       - "--compressed-caching=false"
@@ -477,8 +478,8 @@ mlflow:
   podLabels: {}
   image:
     registry: ghcr.io
-    repository: gojek/mlflow
-    tag: 1.3.0
+    repository: caraml-dev/mlflow
+    tag: 1.26.1
     pullPolicy: Always
   replicaCount: 1
   rollingUpdate:

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -236,6 +236,16 @@ config:
       Acks: 0
       LingerMS: 100
       AdditionalConfig: "{}"
+  ObservabilityPublisher:
+    KafkaConsumer:
+      Brokers: "kafka-brokers"
+    DefaultResources:
+      Requests:
+        CPU: "1"
+        Memory: "1Gi"
+      Limits:
+        CPU: "2"
+        Memory: "1Gi"
 clusterConfig:
   # -- (bool) Configuration to tell Merlin API how it should authenticate with deployment k8s cluster
   # By default, Merlin API expects to use a remote k8s cluster for deployment and to do so, it requires


### PR DESCRIPTION
# Motivation
With the recent changes in the Merlin repo to update both the Merlin API server and Mlflow server, this PR updates the versions of these components in the Merlin Helm chart to ensure that the latest versions get deployed by default.

# Main Modifications
- Update of the `ghcr.io/gojek/mlflow:1.3.0` image for Mlflow to `ghcr.io/caraml-dev/mlflow:1.26.1` 
- Update of the Merlin API server image tag from `v0.38.0-rc1` to `v0.45.3`
- Addition of the `KanikoPushRegistryType` field to the default values file as it is now required in the newer version of the Merlin API server

# Checklist
- [x] Chart version bumped
- [x] README.md updated
