### PR TITLE
fix(mlflow): Remove redundant Mlflow extra envs mapping

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.22
+version: 0.13.23

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.13.22](https://img.shields.io/badge/Version-0.13.22-informational?style=flat-square)
+![Version: 0.13.23](https://img.shields.io/badge/Version-0.13.23-informational?style=flat-square)
 ![AppVersion: v0.42.0](https://img.shields.io/badge/AppVersion-v0.42.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.

--- a/charts/merlin/templates/mlflow-deployment.yaml
+++ b/charts/merlin/templates/mlflow-deployment.yaml
@@ -73,10 +73,6 @@ spec:
         - name: MLFLOW_S3_ENDPOINT_URL
           value: http://minio.minio.svc.cluster.local:9000
         {{- end}}
-        {{- range $key, $val := .Values.mlflow.extraEnvs }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end}}
         {{- if .Values.gcpServiceAccount }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/gcp_service_account/service-account.json


### PR DESCRIPTION
# Motivation
In PR #426, modifications were made to the Mlflow deployment template in order to allow it to be configured with additional environment variables specified under the `extraEnvs` field. 

However that was problematic as there was already an existing template block that already parses the values of `extraEnvs` as environment values in the deployment template.

See the following lines:
- https://github.com/caraml-dev/helm-charts/blob/main/charts/merlin/templates/mlflow-deployment.yaml#L76
- https://github.com/caraml-dev/helm-charts/blob/main/charts/merlin/templates/mlflow-deployment.yaml#L84

This PR cleans up the previous template block for the `extraEnvs` field in favour of the new one, which is simpler.

# Modification
- `charts/merlin/templates/mlflow-deployment.yaml` - removal of a redundant block to parse environment variables

# Checklist
- [x] Chart version bumped
- [x] README.md updated
