### PR TITLE
fix(mlflow): Change default extra envs field type in Mlflow config values to list

### DIFF
--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: merlin
-version: 0.13.23
+version: 0.13.24

--- a/charts/merlin/README.md
+++ b/charts/merlin/README.md
@@ -1,7 +1,7 @@
 # merlin
 
 ---
-![Version: 0.13.23](https://img.shields.io/badge/Version-0.13.23-informational?style=flat-square)
+![Version: 0.13.24](https://img.shields.io/badge/Version-0.13.24-informational?style=flat-square)
 ![AppVersion: v0.42.0](https://img.shields.io/badge/AppVersion-v0.42.0-informational?style=flat-square)
 
 Kubernetes-friendly ML model management, deployment, and serving.
@@ -316,7 +316,7 @@ The following table lists the configurable parameters of the Merlin chart and th
 | mlflow.artifactRoot | string | `"/data/artifacts"` |  |
 | mlflow.artifactServiceType | string | `"nop"` |  |
 | mlflow.deploymentLabels | object | `{}` |  |
-| mlflow.extraEnvs | object | `{}` |  |
+| mlflow.extraEnvs | list | `[]` |  |
 | mlflow.host | string | `"0.0.0.0"` |  |
 | mlflow.image.pullPolicy | string | `"Always"` |  |
 | mlflow.image.registry | string | `"ghcr.io"` |  |

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -577,7 +577,7 @@ mlflow:
   #   orchestrator: unknown
 
   # Add the following configs when you wish to point to an actual S3 for mlflow to store its artifacts
-  extraEnvs: {}
+  extraEnvs: []
   #   AWS_ACCESS_KEY_ID: YOURACCESSKEY
   #   AWS_SECRET_ACCESS_KEY: YOURSECRETKEY
   #   AWS_DEFAULT_REGION: ap-southeast-2


### PR DESCRIPTION
# Motivation
With the removal of the old way of parsing `extraEnvs` for the Mlflow deployment, we need to update the default value of the `extraEnvs` field to be a list as opposed to a map. This PR simply fixes this by replacing the default value of that field in the Merlin Helm chart `mlflow.extraEnvs` from `{}` to `[]`.

# Modification
- `charts/merlin/values.yaml` - Modification of default `extraEnvs` file from `{}` to `[]`

# Checklist
- [x] Chart version bumped
- [x] README.md updated
