### PR TITLE
fix(turing): Update turing images

### DIFF
--- a/charts/turing/Chart.yaml
+++ b/charts/turing/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 - email: caraml-dev@caraml.dev
   name: caraml-dev
 name: turing
-version: 0.3.30
+version: 0.3.31

--- a/charts/turing/README.md
+++ b/charts/turing/README.md
@@ -1,7 +1,7 @@
 # turing
 
 ---
-![Version: 0.3.30](https://img.shields.io/badge/Version-0.3.30-informational?style=flat-square)
+![Version: 0.3.31](https://img.shields.io/badge/Version-0.3.31-informational?style=flat-square)
 ![AppVersion: v1.17.2](https://img.shields.io/badge/AppVersion-v1.17.2-informational?style=flat-square)
 
 Kubernetes-friendly multi-model orchestration and experimentation system.

--- a/charts/turing/templates/_config.tpl
+++ b/charts/turing/templates/_config.tpl
@@ -5,8 +5,8 @@
 {{- $tag := $rendered.releasedVersion}}
 {{- $ensemblerTag := default $tag $rendered.ensemblerTag }}
 {{- $ensemblerServiceTag := default $ensemblerTag $rendered.ensemblerServiceTag }}
-{{- $ensemblerJobPrefix := printf "%s/caraml-dev/turing/pyfunc-ensembler-job" $.Values.deployment.image.registry -}}
-{{- $servicePrefix := printf "%s/caraml-dev/turing/pyfunc-ensembler-service" $.Values.deployment.image.registry -}}
+{{- $ensemblerJobPrefix := printf "%s/caraml-dev/turing/turing-pyfunc-ensembler-job" $.Values.deployment.image.registry -}}
+{{- $servicePrefix := printf "%s/caraml-dev/turing/turing-pyfunc-ensembler-service" $.Values.deployment.image.registry -}}
 # Now we have access to the "real" root and current contexts
 # just as if we were outside of include/define:
 {{ with index . 1 }}

--- a/charts/turing/tests/turing_config_secret_test.yaml
+++ b/charts/turing/tests/turing_config_secret_test.yaml
@@ -115,7 +115,7 @@ tests:
           pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "BaseImage: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service:some-ensembler-tag"
+          pattern: "BaseImage: ghcr.io/caraml-dev/turing/turing-pyfunc-ensembler-service:some-ensembler-tag"
   - it: should use rendered version when BatchEnsemblingConfig is enabled
     set:
       rendered:
@@ -138,11 +138,11 @@ tests:
           pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "BaseImage: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service:some-ensembler-tag"
+          pattern: "BaseImage: ghcr.io/caraml-dev/turing/turing-pyfunc-ensembler-service:some-ensembler-tag"
       #
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "BaseImage: ghcr.io/caraml-dev/turing/pyfunc-ensembler-job:some-ensembler-tag"
+          pattern: "BaseImage: ghcr.io/caraml-dev/turing/turing-pyfunc-ensembler-job:some-ensembler-tag"
   - it: should use rendered version, but allow config to override value
     set:
       rendered:
@@ -151,7 +151,7 @@ tests:
         overrides:
           BatchEnsemblingConfig:
             ImageBuilderConfig:
-              BaseImage: docker.io/caraml-dev/turing/pyfunc-ensembler-job:test-tag-123
+              BaseImage: docker.io/caraml-dev/turing/turing-pyfunc-ensembler-job:test-tag-123
       config:
         BatchEnsemblingConfig:
           Enabled: true
@@ -169,8 +169,8 @@ tests:
           pattern: "Image: ghcr.io/caraml-dev/turing/turing-router:v1.0.0-test-release"
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "BaseImage: ghcr.io/caraml-dev/turing/pyfunc-ensembler-service:some-ensembler-tag"
+          pattern: "BaseImage: ghcr.io/caraml-dev/turing/turing-pyfunc-ensembler-service:some-ensembler-tag"
       #
       - matchRegex:
           path: stringData.[config.yaml]
-          pattern: "BaseImage: docker.io/caraml-dev/turing/pyfunc-ensembler-job:test-tag-123"
+          pattern: "BaseImage: docker.io/caraml-dev/turing/turing-pyfunc-ensembler-job:test-tag-123"


### PR DESCRIPTION
# Motivation
This PR updates all the Turing ensembler image names to keep them consistent with the changes made on the Turing repo.

# Modification
- `charts/turing/templates/_config.tpl` - Update Turing ensembler image names
- `charts/turing/tests/turing_config_secret_test.yaml` - Update Turing ensembler image names

# Checklist
- [x] Chart version bumped
- [x] README.md updated
